### PR TITLE
[RSDK-760] [RSDK-761] [RSDK-763] [RSDK-764] More grpc stubs

### DIFF
--- a/src/grpc.rs
+++ b/src/grpc.rs
@@ -104,25 +104,43 @@ impl GrpcServer {
             "/viam.component.base.v1.BaseService/MoveStraight" => self.base_move_straight(payload),
             "/viam.component.base.v1.BaseService/Spin" => self.base_spin(payload),
             "/viam.component.base.v1.BaseService/SetVelocity" => self.base_set_velocity(payload),
-            "/viam.component.board.v1.BoardService/GetDigitalinterruptValue" => self.board_get_digital_interrupt_value(payload),
+            "/viam.component.board.v1.BoardService/GetDigitalinterruptValue" => {
+                self.board_get_digital_interrupt_value(payload)
+            }
             "/viam.component.board.v1.BoardService/GetGPIO" => self.board_get_pin(payload),
             "/viam.component.board.v1.BoardService/PWM" => self.board_pwm(payload),
-            "/viam.component.board.v1.BoardService/PWMFrequency" => self.board_pwm_frequency(payload),
-            "/viam.component.board.v1.BoardService/ReadAnalogReader" => self.board_read_analog_reader(payload),
+            "/viam.component.board.v1.BoardService/PWMFrequency" => {
+                self.board_pwm_frequency(payload)
+            }
+            "/viam.component.board.v1.BoardService/ReadAnalogReader" => {
+                self.board_read_analog_reader(payload)
+            }
             "/viam.component.board.v1.BoardService/SetGPIO" => self.board_set_pin(payload),
             "/viam.component.board.v1.BoardService/SetPWM" => self.board_set_pwm(payload),
-            "/viam.component.board.v1.BoardService/SetPWMFrequency" => self.board_set_pwm_frequency(payload),
+            "/viam.component.board.v1.BoardService/SetPWMFrequency" => {
+                self.board_set_pwm_frequency(payload)
+            }
             "/viam.component.board.v1.BoardService/Status" => self.board_status(payload),
             "/viam.component.camera.v1.CameraService/GetImage" => self.camera_get_frame(payload),
-            "/viam.component.camera.v1.CameraService/GetPointCloud" => self.camera_get_point_cloud(payload),
-            "/viam.component.camera.v1.CameraService/GetProperties" => self.camera_get_properties(payload),
-            "/viam.component.camera.v1.CameraService/RenderFrame" => self.camera_render_frame(payload),
+            "/viam.component.camera.v1.CameraService/GetPointCloud" => {
+                self.camera_get_point_cloud(payload)
+            }
+            "/viam.component.camera.v1.CameraService/GetProperties" => {
+                self.camera_get_properties(payload)
+            }
+            "/viam.component.camera.v1.CameraService/RenderFrame" => {
+                self.camera_render_frame(payload)
+            }
             "/viam.component.motor.v1.MotorService/GetPosition" => self.motor_get_position(payload),
-            "/viam.component.motor.v1.MotorService/GetProperties" => self.motor_get_properties(payload),
+            "/viam.component.motor.v1.MotorService/GetProperties" => {
+                self.motor_get_properties(payload)
+            }
             "/viam.component.motor.v1.MotorService/GoFor" => self.motor_go_for(payload),
             "/viam.component.motor.v1.MotorService/GoTo" => self.motor_go_to(payload),
             "/viam.component.motor.v1.MotorService/IsPowered" => self.motor_is_powered(payload),
-            "/viam.component.motor.v1.MotorService/ResetZeroPosition" => self.motor_reset_zero_position(payload),
+            "/viam.component.motor.v1.MotorService/ResetZeroPosition" => {
+                self.motor_reset_zero_position(payload)
+            }
             "/viam.component.motor.v1.MotorService/SetPower" => self.motor_set_power(payload),
             "/viam.component.motor.v1.MotorService/Stop" => self.motor_stop(payload),
             "/viam.robot.v1.RobotService/ResourceNames" => self.resource_names(payload),


### PR DESCRIPTION
This is similar to https://github.com/viamrobotics/mini-rdk/pull/5.

I also renamed `get_frame` to `camera_get_frame` to match the naming convention for the other functions.

I wonder if some of the motor-related functions will be permanently unimplemented for GPIO motors, and should be removed again. but I wasn't sure how to check on that in the Go code. Any thoughts? Relatedly, do we need to support GPIO motors with encoders, or just encoder-less ones?

I dislike the way `cargo fmt` restructured the long lines in the match into a different silhouette than the short lines, but I also dislike long lines. I spent some time trying to abstract out the `"/viam.component."` at the beginning of the paths, and eventually decided that was impossible because there doesn't seem to be a compile-time way to build up string literals from smaller pieces, and match patterns require string literals and cannot construct the patterns at runtime.

Everything compiles, but I haven't tried it out further than that.