### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -25,7 +25,14 @@ jobs:
       - name: Install toolchain deps
         run: sudo apt-get install -y git curl gcc clang ninja-build cmake libudev-dev unzip xz-utils python3 python3-pip python3-venv libusb-1.0-0 libssl-dev pkg-config libpython2.7
 
+      - name: "Check if esp toolchain installed"
+        id: esp_toolchain
+        uses: andstor/file-existence-action@v2
+        with:
+          files: "/github/home/.rustup/toolchains/esp/"
+
       - name: Install esp32 toolchain
+        if: steps.esp_toolchain.outputs.files_exists == 'false'
         run: curl -LO https://github.com/esp-rs/rust-build/releases/download/v1.66.0.0/install-rust-toolchain.sh && chmod a+x install-rust-toolchain.sh && ./install-rust-toolchain.sh && . ./export-esp.sh
 
       - name: Install latest rust toolchain


### PR DESCRIPTION
can't reinstall esp toolchain twice. we should probably make a dedicated docker for mini-rdk