### PR TITLE
[RSDK-1722] ConsumeStatic config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ camera = []
 esp32 = ["dep:esp-idf-hal", "dep:esp-idf-svc","dep:esp-idf-sys","dep:embedded-svc","dep:embedded-hal"]
 native = ["dep:rustls","dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address"]
 
+[dev-dependencies]
+test-log = "0.2.11"
+env_logger = "0.10.0"
+
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 bytes = "1.2.1"
@@ -28,9 +32,11 @@ esp-idf-sys = { version = "0.31.11", features = ["binstart"],  optional = true }
 futures-lite = "1.12.0"
 h2 = "0.3.14"
 hyper = { version="0.14.20", default-features = false, features = ["server","stream","http2"] }
+lazy_static = "1.4.0"
 local-ip-address = { version = "0.4.9", optional = true }
 log = "0.4"
 mdns-sd = { version = "0.5.10", optional = true, default-features = false, features = ["async"] }
+phf = { version = "0.11", features = ["macros"] }
 prost = "0.11.0"
 prost-types = "0.11.1"
 rustls = { version = "0.20.7", features = ["logging","tls12"], optional = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -41,12 +41,17 @@ log = "0.4"
 [target.'cfg(target_os="espidf")'.dependencies]
 esp-idf-sys = { version = "0.31.11", features = ["binstart"] }
 
+[dependencies]
+phf = { version = "0.11", features = ["macros"] }
+
+
 [build-dependencies]
 anyhow = "1"
 const-gen = "1.3.0"
 embuild = "0.29"
 gethostname = "0.4.1"
 local-ip-address = "0.4.9"
+prost-types = "0.10"
 serde = { version="1.0.145",features=["derive"] }
 serde_json = "1.0.86"
 tokio = { version = "1", features = ["full"] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -66,4 +66,8 @@ path = "native/native.rs"
 name = "esp32"
 path = "esp32/esp32.rs"
 
+[[example]]
+name = "esp32_static"
+path = "esp32/esp32_static.rs"
+
 

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -5,10 +5,107 @@ use serde::{Deserialize, Serialize};
 use std::{env, fs, path::Path};
 use tokio::runtime::Runtime;
 use viam::gen::proto::app::v1::{
-    robot_service_client::RobotServiceClient, AgentInfo, CertificateRequest, CloudConfig,
-    ConfigRequest,
+    robot_service_client::RobotServiceClient, AgentInfo, CertificateRequest, ConfigRequest,
+    RobotConfig,
 };
 use viam_rust_utils::rpc::dial::{DialOptions, RPCCredentials};
+
+struct ComponentConfig(viam::gen::proto::app::v1::ComponentConfig);
+struct Attributes(prost_types::Struct);
+struct Kind(prost_types::value::Kind);
+struct StaticRobotConfig {
+    components: Vec<ComponentConfig>,
+}
+
+impl const_gen::CompileConst for StaticRobotConfig {
+    fn const_type() -> String {
+        String::from("RobotConfigStatic")
+    }
+    fn const_val(&self) -> String {
+        let mut obj = String::new();
+        if self.components.len() > 0 {
+            obj.push_str(&format!("Some({})", self.components.const_val()));
+        } else {
+            obj.push_str("None");
+        }
+        format!("RobotConfigStatic {{components: {}}}", obj)
+    }
+}
+
+impl const_gen::CompileConst for Kind {
+    fn const_type() -> String {
+        String::from("Kind")
+    }
+    fn const_val(&self) -> String {
+        let mut obj = String::new();
+        match self.0.clone() {
+            prost_types::value::Kind::NumberValue(v) => {
+                obj.push_str(&format!("NumberValue({})", v.const_val()));
+            }
+            prost_types::value::Kind::NullValue(v) => {
+                obj.push_str(&format!("NullValue({})", v.const_val()));
+            }
+            prost_types::value::Kind::StringValue(v) => {
+                obj.push_str(&format!("StringValueStatic({})", v.const_val()));
+            }
+            prost_types::value::Kind::ListValue(v) => {
+                obj.push_str(&format!(
+                    "ListValueStatic({})",
+                    v.values
+                        .into_iter()
+                        .filter(|a| a.kind.is_some())
+                        .map(|a| Kind(a.kind.unwrap()))
+                        .collect::<Vec<Kind>>()
+                        .const_val()
+                ));
+            }
+            prost_types::value::Kind::StructValue(v) => {
+                obj.push_str(&format!("StructValueStatic({})", Attributes(v).const_val()));
+            }
+            prost_types::value::Kind::BoolValue(v) => {
+                obj.push_str(&format!("BoolValue({})", v.const_val()));
+            }
+        }
+        format!("Kind::{}", obj)
+    }
+}
+
+impl const_gen::CompileConst for ComponentConfig {
+    fn const_type() -> String {
+        String::from("StaticComponentConfig")
+    }
+    fn const_val(&self) -> String {
+        let mut obj = String::new();
+        obj.push_str(&format!("name: {},", &self.0.name.const_val()));
+        obj.push_str(&format!("namespace: {},", self.0.namespace.const_val()));
+        obj.push_str(&format!("r#type: {},", self.0.r#type.const_val()));
+        obj.push_str(&format!("model: {},", self.0.model.const_val()));
+        match self.0.attributes.clone() {
+            Some(attrs) => obj.push_str(&format!(
+                "attributes: Some({}),",
+                Attributes(attrs).const_val()
+            )),
+            None => obj.push_str("None"),
+        };
+        format!("StaticComponentConfig {{{}}}", obj)
+    }
+}
+
+impl const_gen::CompileConst for Attributes {
+    fn const_type() -> String {
+        format!("phf::Map<{}, {}>", "&'static str", "Kind")
+    }
+    fn const_val(&self) -> String {
+        self.0
+            .fields
+            .clone()
+            .into_iter()
+            .filter(|(_, v)| v.kind.is_some())
+            .map(|(k, v)| (k, Kind(v.kind.unwrap())))
+            .collect::<std::collections::HashMap<_, _>>()
+            .const_val()
+    }
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
@@ -72,7 +169,8 @@ fn main() -> anyhow::Result<()> {
     let mut cfg: Config = serde_json::from_str(content.as_str()).map_err(anyhow::Error::msg)?;
 
     let rt = Runtime::new()?;
-    let cloud_cfg = rt.block_on(read_cloud_config(&mut cfg))?;
+    let robot_cfg = rt.block_on(read_cloud_config(&mut cfg))?;
+    let cloud_cfg = robot_cfg.cloud.unwrap();
     let robot_name = cloud_cfg.local_fqdn.split('.').next().unwrap_or("");
     let local_fqdn = cloud_cfg.local_fqdn.replace('.', "-");
     let fqdn = cloud_cfg.fqdn.replace('.', "-");
@@ -111,6 +209,30 @@ fn main() -> anyhow::Result<()> {
     ]
     .join("\n");
     fs::write(&dest_path, robot_decl).unwrap();
+
+    let components_config = robot_cfg
+        .components
+        .into_iter()
+        .map(ComponentConfig)
+        .collect::<Vec<ComponentConfig>>();
+    let robot_config = StaticRobotConfig {
+        components: components_config,
+    };
+    let dest_path = Path::new(&out_dir).join("robot_config.rs");
+    let conf_decl = if robot_config.components.len() > 0 {
+        vec![const_declaration!(
+            #[allow(clippy::redundant_static_lifetimes, dead_code)]
+            STATIC_ROBOT_CONFIG = Some(robot_config)
+        )]
+    } else {
+        vec![const_declaration!(
+            #[allow(clippy::redundant_static_lifetimes, dead_code)]
+            STATIC_ROBOT_CONFIG = None::<StaticRobotConfig>
+        )]
+    }
+    .join("\n");
+    fs::write(&dest_path, conf_decl).unwrap();
+
     Ok(())
 }
 
@@ -136,7 +258,7 @@ async fn read_certificates(config: &mut Config) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn read_cloud_config(config: &mut Config) -> anyhow::Result<CloudConfig> {
+async fn read_cloud_config(config: &mut Config) -> anyhow::Result<RobotConfig> {
     let creds = RPCCredentials::new(
         Some(config.cloud.id.clone()),
         "robot-secret".to_string(),
@@ -162,10 +284,7 @@ async fn read_cloud_config(config: &mut Config) -> anyhow::Result<CloudConfig> {
     let mut app_service = RobotServiceClient::new(dial);
     let cfg = app_service.config(cfg_req).await?.into_inner();
     match cfg.config {
-        Some(cfg) => match cfg.cloud {
-            Some(cfg) => Ok(cfg),
-            None => anyhow::bail!("no cloud config for robot"),
-        },
+        Some(cfg) => Ok(cfg),
         None => anyhow::bail!("no config for robot"),
     }
 }

--- a/examples/esp32/esp32_static.rs
+++ b/examples/esp32/esp32_static.rs
@@ -1,0 +1,180 @@
+#[allow(dead_code)]
+#[cfg(not(feature = "qemu"))]
+const SSID: &str = env!("MICRO_RDK_WIFI_SSID");
+#[allow(dead_code)]
+#[cfg(not(feature = "qemu"))]
+const PASS: &str = env!("MICRO_RDK_WIFI_PASSWORD");
+
+// Generated robot config during build process
+include!(concat!(env!("OUT_DIR"), "/robot_secret.rs"));
+include!(concat!(env!("OUT_DIR"), "/robot_config.rs"));
+
+#[cfg(all(not(feature = "qemu"), feature = "camera"))]
+use crate::camera::Esp32Camera;
+
+use anyhow::bail;
+use esp_idf_hal::prelude::Peripherals;
+#[cfg(feature = "qemu")]
+use esp_idf_svc::eth::*;
+#[cfg(feature = "qemu")]
+use esp_idf_svc::eth::{EspEth, EthWait};
+use esp_idf_svc::eventloop::EspSystemEventLoop;
+use esp_idf_svc::netif::{EspNetif, EspNetifWait};
+#[cfg(not(feature = "qemu"))]
+use esp_idf_svc::wifi::EspWifi;
+use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+#[cfg(not(feature = "qemu"))]
+use esp_idf_sys::esp_wifi_set_ps;
+use log::*;
+use micro_rdk::common::config::{Kind, RobotConfigStatic, StaticComponentConfig};
+use micro_rdk::common::robot::LocalRobot;
+use micro_rdk::common::robot::ResourceType;
+use micro_rdk::esp32::server::{CloudConfig, Esp32Server};
+use micro_rdk::esp32::tls::Esp32TlsServerConfig;
+use micro_rdk::proto::common::v1::ResourceName;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+fn main() -> anyhow::Result<()> {
+    esp_idf_sys::link_patches();
+
+    esp_idf_svc::log::EspLogger::initialize_default();
+    let sys_loop_stack = EspSystemEventLoop::take().unwrap();
+    let periph = Peripherals::take().unwrap();
+
+    let robot = LocalRobot::new_from_static(&STATIC_ROBOT_CONFIG.unwrap()).unwrap();
+
+    #[cfg(feature = "qemu")]
+    let (ip, _eth) = {
+        use std::net::Ipv4Addr;
+        info!("creating eth object");
+        let eth = eth_configure(
+            &sys_loop_stack,
+            Box::new(esp_idf_svc::eth::EspEth::wrap(EthDriver::new_openeth(
+                periph.mac,
+                sys_loop_stack.clone(),
+            )?)?),
+        )?;
+        (Ipv4Addr::new(0, 0, 0, 0), eth)
+    };
+    {
+        esp_idf_sys::esp!(unsafe {
+            esp_idf_sys::esp_vfs_eventfd_register(&esp_idf_sys::esp_vfs_eventfd_config_t {
+                max_fds: 5,
+            })
+        })?;
+    }
+
+    #[allow(clippy::redundant_clone)]
+    #[cfg(not(feature = "qemu"))]
+    let (ip, _wifi) = {
+        let wifi = start_wifi(periph.modem, sys_loop_stack)?;
+        (wifi.sta_netif().get_ip_info()?.ip, wifi)
+    };
+
+    let cfg = {
+        let cert = include_bytes!(concat!(env!("OUT_DIR"), "/ca.crt"));
+        let key = include_bytes!(concat!(env!("OUT_DIR"), "/key.key"));
+        Esp32TlsServerConfig::new(
+            cert.as_ptr(),
+            cert.len() as u32,
+            key.as_ptr(),
+            key.len() as u32,
+        )
+    };
+
+    let mut cloud_cfg = CloudConfig::new(ROBOT_NAME, LOCAL_FQDN, FQDN, ROBOT_ID, ROBOT_SECRET);
+    cloud_cfg.set_tls_config(cfg);
+    let esp32_srv = Esp32Server::new(robot, cloud_cfg);
+    esp32_srv.start(ip)?;
+    Ok(())
+}
+
+#[cfg(feature = "qemu")]
+fn eth_configure(
+    sl_stack: &EspSystemEventLoop,
+    mut eth: Box<EspEth<'static>>,
+) -> anyhow::Result<Box<EspEth<'static>>> {
+    use std::net::Ipv4Addr;
+
+    eth.start()?;
+
+    if !EthWait::new(eth.driver(), sl_stack)?
+        .wait_with_timeout(Duration::from_secs(30), || eth.is_started().unwrap())
+    {
+        bail!("couldn't start eth driver")
+    }
+
+    if !EspNetifWait::new::<EspNetif>(eth.netif(), sl_stack)?
+        .wait_with_timeout(Duration::from_secs(20), || {
+            eth.netif().get_ip_info().unwrap().ip != Ipv4Addr::new(0, 0, 0, 0)
+        })
+    {
+        bail!("didn't get an ip")
+    }
+    let ip_info = eth.netif().get_ip_info()?;
+    info!("ETH IP {:?}", ip_info);
+    Ok(eth)
+}
+
+#[cfg(not(feature = "qemu"))]
+fn start_wifi(
+    modem: impl esp_idf_hal::peripheral::Peripheral<P = esp_idf_hal::modem::Modem> + 'static,
+    sl_stack: EspSystemEventLoop,
+) -> anyhow::Result<Box<EspWifi<'static>>> {
+    use embedded_svc::wifi::{ClientConfiguration, Wifi};
+    use esp_idf_svc::wifi::WifiWait;
+    use std::net::Ipv4Addr;
+
+    let mut wifi = Box::new(EspWifi::new(modem, sl_stack.clone(), None)?);
+
+    info!("scanning");
+    let aps = wifi.scan()?;
+    let foundap = aps.into_iter().find(|x| x.ssid == SSID);
+
+    let channel = if let Some(foundap) = foundap {
+        info!("{} channel is {}", "Viam", foundap.channel);
+        Some(foundap.channel)
+    } else {
+        None
+    };
+    let client_config = ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASS.into(),
+        channel,
+        ..Default::default()
+    };
+    wifi.set_configuration(&embedded_svc::wifi::Configuration::Client(client_config))?; //&Configuration::Client(client_config)
+
+    wifi.start()?;
+
+    if !WifiWait::new(&sl_stack)?
+        .wait_with_timeout(Duration::from_secs(20), || wifi.is_started().unwrap())
+    {
+        bail!("couldn't start wifi")
+    }
+
+    wifi.connect()?;
+
+    if !EspNetifWait::new::<EspNetif>(wifi.sta_netif(), &sl_stack)?.wait_with_timeout(
+        Duration::from_secs(20),
+        || {
+            wifi.is_connected().unwrap()
+                && wifi.sta_netif().get_ip_info().unwrap().ip != Ipv4Addr::new(0, 0, 0, 0)
+        },
+    ) {
+        bail!("wifi couldn't connect")
+    }
+
+    let ip_info = wifi.sta_netif().get_ip_info()?;
+
+    info!("Wifi DHCP info: {:?}", ip_info);
+
+    esp_idf_sys::esp!(unsafe { esp_wifi_set_ps(esp_idf_sys::wifi_ps_type_t_WIFI_PS_NONE) })?;
+
+    Ok(wifi)
+}

--- a/examples/native/native.rs
+++ b/examples/native/native.rs
@@ -21,7 +21,7 @@ fn main() -> anyhow::Result<()> {
         .init()
         .unwrap();
     // tracing_subscriber::fmt()
-    //     // enabble everything
+    //     // enable everything
     //     .with_max_level(tracing::Level::TRACE)
     //     // sets this to be the default, global collector for this application.
     //     .init();

--- a/examples/native/native.rs
+++ b/examples/native/native.rs
@@ -1,7 +1,9 @@
 // Generated robot config during build process
 include!(concat!(env!("OUT_DIR"), "/robot_secret.rs"));
+include!(concat!(env!("OUT_DIR"), "/robot_config.rs"));
 
 use log::*;
+use micro_rdk::common::config::{Kind, RobotConfigStatic, StaticComponentConfig};
 use micro_rdk::common::robot::LocalRobot;
 use micro_rdk::common::robot::ResourceType;
 use micro_rdk::native::server::{CloudConfig, NativeServer};
@@ -19,7 +21,7 @@ fn main() -> anyhow::Result<()> {
         .init()
         .unwrap();
     // tracing_subscriber::fmt()
-    //     // enable everything
+    //     // enabble everything
     //     .with_max_level(tracing::Level::TRACE)
     //     // sets this to be the default, global collector for this application.
     //     .init();

--- a/src/common/base.rs
+++ b/src/common/base.rs
@@ -3,12 +3,14 @@ use crate::common::status::Status;
 use crate::proto::common::v1::Vector3;
 use log::*;
 use std::collections::BTreeMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 pub trait Base: Status {
     fn set_power(&mut self, lin: &Vector3, ang: &Vector3) -> anyhow::Result<()>;
     fn stop(&mut self) -> anyhow::Result<()>;
 }
+
+pub(crate) type BaseType = Arc<Mutex<dyn Base>>;
 
 pub struct FakeBase {}
 

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -9,6 +9,18 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use super::config::StaticComponentConfig;
+use super::registry::ComponentRegistry;
+
+pub(crate) fn register_models(registry: &mut ComponentRegistry) {
+    if registry
+        .register_board("fake", &FakeBoard::from_static_config)
+        .is_err()
+    {
+        log::error!("model fake is already registered")
+    }
+}
+
 pub struct FakeBoard {
     analogs: Vec<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>,
 }
@@ -22,9 +34,14 @@ pub trait Board: Status {
     ) -> anyhow::Result<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>;
 }
 
+pub(crate) type BoardType = Arc<Mutex<dyn Board>>;
+
 impl FakeBoard {
     pub fn new(analogs: Vec<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>) -> Self {
         FakeBoard { analogs }
+    }
+    pub(crate) fn from_static_config(_: &StaticComponentConfig) -> anyhow::Result<BoardType> {
+        Ok(Arc::new(Mutex::new(FakeBoard::new(Vec::new()))))
     }
 }
 

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -9,12 +9,12 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use super::config::StaticComponentConfig;
+use super::config::ConfigType;
 use super::registry::ComponentRegistry;
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
-        .register_board("fake", &FakeBoard::from_static_config)
+        .register_board("fake", &FakeBoard::from_config)
         .is_err()
     {
         log::error!("model fake is already registered")
@@ -40,7 +40,7 @@ impl FakeBoard {
     pub fn new(analogs: Vec<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>) -> Self {
         FakeBoard { analogs }
     }
-    pub(crate) fn from_static_config(_: &StaticComponentConfig) -> anyhow::Result<BoardType> {
+    pub(crate) fn from_config(_: ConfigType) -> anyhow::Result<BoardType> {
         Ok(Arc::new(Mutex::new(FakeBoard::new(Vec::new()))))
     }
 }

--- a/src/common/camera.rs
+++ b/src/common/camera.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use crate::proto::component::camera;
 use bytes::{Bytes, BytesMut};
@@ -8,6 +8,8 @@ use prost::Message;
 pub trait Camera {
     fn get_frame(&mut self, buffer: BytesMut) -> anyhow::Result<BytesMut>;
 }
+
+pub(crate) type CameraType = Arc<Mutex<dyn Camera>>;
 
 pub struct FakeCamera {}
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -115,7 +115,6 @@ where
 {
     type Error = AttributeError;
     fn try_from(value: &Kind) -> Result<Self, Self::Error> {
-        println!("Obj {:?}", value);
         match value {
             Kind::StructValueStatic(v) => v
                 .into_iter()

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -1,0 +1,366 @@
+#![allow(dead_code)]
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum AttributeError {
+    ParseNumError,
+    ConversionImpossibleError,
+    KeyNotFound,
+}
+
+use std::{
+    collections::BTreeMap,
+    num::{ParseFloatError, ParseIntError},
+};
+
+use crate::proto::common::v1::ResourceName;
+
+impl From<ParseIntError> for AttributeError {
+    fn from(_: ParseIntError) -> AttributeError {
+        AttributeError::ParseNumError
+    }
+}
+impl From<ParseFloatError> for AttributeError {
+    fn from(_: ParseFloatError) -> AttributeError {
+        AttributeError::ParseNumError
+    }
+}
+
+macro_rules! primitives
+{
+    ( $($t:ty),* ) =>
+    {
+        $(impl TryFrom<Kind> for $t
+          {
+              type Error = AttributeError;
+              fn try_from(value: Kind) -> Result<Self, Self::Error> {
+                  match value {
+                      Kind::NullValue(v) => Ok(v as $t),
+                      Kind::NumberValue(v) => Ok(v as $t),
+                      Kind::BoolValue(v) => Ok(v as $t),
+                      Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      _ => Err(AttributeError::ConversionImpossibleError),
+                  }
+              }
+          }
+          impl TryFrom<&Kind> for $t
+          {
+              type Error = AttributeError;
+              fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+                  match value {
+                      Kind::NullValue(v) => Ok(*v as $t),
+                      Kind::NumberValue(v) => Ok(*v as $t),
+                      Kind::BoolValue(v) => Ok(*v as $t),
+                      Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      _ => Err(AttributeError::ConversionImpossibleError),
+                  }
+              }
+          }
+        )*
+    }
+}
+primitives!(u32, i32, u8, u16, i16, i8);
+
+macro_rules! floats
+{
+    ( $($t:ty),* ) =>
+    {
+        $(impl TryFrom<Kind> for $t
+          {
+              type Error = AttributeError;
+              fn try_from(value: Kind) -> Result<Self, Self::Error> {
+                  match value {
+                      Kind::NullValue(v) => Ok(v as $t),
+                      Kind::NumberValue(v) => Ok(v as $t),
+                      Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      _ => Err(AttributeError::ConversionImpossibleError),
+                  }
+              }
+          }
+          impl TryFrom<&Kind> for $t
+          {
+              type Error = AttributeError;
+              fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+                  match value {
+                      Kind::NullValue(v) => Ok(*v as $t),
+                      Kind::NumberValue(v) => Ok(*v as $t),
+                      Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      _ => Err(AttributeError::ConversionImpossibleError),
+                  }
+              }
+          }
+        )*
+    }
+}
+
+floats!(f64, f32);
+
+impl<V> TryFrom<Kind> for BTreeMap<&'static str, V>
+where
+    V: for<'a> std::convert::TryFrom<&'a Kind, Error = AttributeError>,
+{
+    type Error = AttributeError;
+    fn try_from(value: Kind) -> Result<Self, Self::Error> {
+        match value {
+            Kind::StructValueStatic(v) => v
+                .into_iter()
+                .map(|(k, v)| Ok((*k, v.try_into()?)))
+                .collect(),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+impl<V> TryFrom<&Kind> for BTreeMap<&'static str, V>
+where
+    V: for<'a> std::convert::TryFrom<&'a Kind, Error = AttributeError>,
+{
+    type Error = AttributeError;
+    fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+        println!("Obj {:?}", value);
+        match value {
+            Kind::StructValueStatic(v) => v
+                .into_iter()
+                .map(|(k, v)| Ok((*k, v.try_into()?)))
+                .collect(),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+
+impl<T> TryFrom<&Kind> for Vec<T>
+where
+    T: for<'a> std::convert::TryFrom<&'a Kind, Error = AttributeError>,
+{
+    type Error = AttributeError;
+    fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+        match value {
+            Kind::ListValueStatic(v) => v.iter().map(|v| v.try_into()).collect(),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+
+impl<T> TryFrom<Kind> for Vec<T>
+where
+    T: for<'a> std::convert::TryFrom<&'a Kind, Error = AttributeError>,
+{
+    type Error = AttributeError;
+    fn try_from(value: Kind) -> Result<Self, Self::Error> {
+        match value {
+            Kind::ListValueStatic(v) => v.iter().map(|v| v.try_into()).collect(),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+
+impl TryFrom<&Kind> for Kind {
+    type Error = AttributeError;
+    fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+        match value {
+            Kind::BoolValue(v) => Ok(Kind::BoolValue(*v)),
+            Kind::NullValue(v) => Ok(Kind::NullValue(*v)),
+            Kind::StringValueStatic(v) => Ok(Kind::StringValueStatic(v)),
+            Kind::NumberValue(v) => Ok(Kind::NumberValue(*v)),
+            Kind::ListValueStatic(v) => Ok(Kind::ListValueStatic(v)),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum Kind {
+    NullValue(i32),
+    NumberValue(f64),
+    StringValueStatic(&'static str),
+    BoolValue(bool),
+    StructValueStatic(phf::map::Map<&'static str, Kind>),
+    ListValueStatic(&'static [Kind]),
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct StaticComponentConfig {
+    pub name: &'static str,
+    pub namespace: &'static str,
+    pub r#type: &'static str,
+    pub model: &'static str,
+    pub attributes: Option<phf::map::Map<&'static str, Kind>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct RobotConfigStatic {
+    pub components: Option<&'static [StaticComponentConfig]>,
+}
+
+pub trait Component {
+    fn get_name(&self) -> &str;
+    fn get_model(&self) -> &str;
+    fn get_type(&self) -> &str;
+    fn get_namespace(&self) -> &str;
+    fn get_resource_name(&self) -> ResourceName {
+        ResourceName {
+            namespace: self.get_namespace().to_string(),
+            r#type: "component".to_string(),
+            subtype: self.get_type().to_string(),
+            name: self.get_name().to_string(),
+        }
+    }
+    fn get_attribute<'a, T>(&'a self, key: &str) -> Result<T, AttributeError>
+    where
+        T: std::convert::TryFrom<Kind, Error = AttributeError>
+            + std::convert::TryFrom<&'a Kind, Error = AttributeError>;
+}
+
+impl Component for StaticComponentConfig {
+    fn get_name(&self) -> &str {
+        self.name
+    }
+    fn get_model(&self) -> &str {
+        self.model
+    }
+    fn get_type(&self) -> &str {
+        self.r#type
+    }
+    fn get_namespace(&self) -> &str {
+        self.namespace
+    }
+    fn get_attribute<'a, T>(&'a self, key: &str) -> Result<T, AttributeError>
+    where
+        T: std::convert::TryFrom<Kind, Error = AttributeError>
+            + std::convert::TryFrom<&'a Kind, Error = AttributeError>,
+    {
+        if let Some(v) = self.attributes.as_ref() {
+            if let Some(v) = v.get(key) {
+                return v.try_into();
+            }
+        }
+        Err(AttributeError::KeyNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::common::config::{
+        AttributeError, Component, Kind, RobotConfigStatic, StaticComponentConfig,
+    };
+    #[test_log::test]
+    fn test_config_component() -> anyhow::Result<()> {
+        #[allow(clippy::redundant_static_lifetimes, dead_code)]
+        const PMR: &'static RobotConfigStatic = &RobotConfigStatic {
+            components: Some(&[
+                StaticComponentConfig {
+                    name: "board",
+                    namespace: "rdk",
+                    r#type: "board",
+                    model: "pi",
+                    attributes: Some(
+                        phf::phf_map! {"pins" => Kind::ListValueStatic(&[Kind::StringValueStatic("11"),Kind::StringValueStatic("12"),Kind::StringValueStatic("13")])},
+                    ),
+                },
+                StaticComponentConfig {
+                    name: "motor",
+                    namespace: "rdk",
+                    r#type: "motor",
+                    model: "gpio",
+                    attributes: Some(
+                        phf::phf_map! {"pins" => Kind::StructValueStatic(phf::phf_map!{"a" => Kind::StringValueStatic("29"),"pwm" => Kind::StringValueStatic("12"),"b" => Kind::StringValueStatic("5")}),"board" => Kind::StringValueStatic("board")},
+                    ),
+                },
+                StaticComponentConfig {
+                    name: "motor",
+                    namespace: "rdk",
+                    r#type: "motor",
+                    model: "gpio",
+                    attributes: Some(
+                        phf::phf_map! {"float" => Kind::NumberValue(10.556), "float2" => Kind::StringValueStatic("10.564"), "float3" => Kind::StringValueStatic("-1.18e+11"),
+                        "pins" => Kind::ListValueStatic(&[Kind::StringValueStatic("11000"),Kind::StringValueStatic("12"),Kind::StringValueStatic("13")]),
+                        "pins2" => Kind::StructValueStatic(phf::phf_map!{"a" => Kind::StringValueStatic("29000")})},
+                    ),
+                },
+            ]),
+        };
+
+        let val = PMR.components.unwrap()[0].get_name();
+        assert_eq!(val, "board");
+
+        let val = PMR.components.unwrap()[0].get_model();
+        assert_eq!(val, "pi");
+
+        let val = PMR.components.unwrap()[0].get_type();
+        assert_eq!(val, "board");
+
+        let val = PMR.components.unwrap()[1].get_name();
+        assert_eq!(val, "motor");
+
+        let val = PMR.components.unwrap()[1].get_model();
+        assert_eq!(val, "gpio");
+
+        let val = PMR.components.unwrap()[1].get_type();
+        assert_eq!(val, "motor");
+
+        let val = PMR.components.unwrap()[1].get_attribute::<u32>("board");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(val.err().unwrap(), AttributeError::ParseNumError);
+
+        let val = PMR.components.unwrap()[1].get_attribute::<u32>("nope");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(val.err().unwrap(), AttributeError::KeyNotFound);
+
+        let val = PMR.components.unwrap()[0].get_attribute::<u32>("pins");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(
+            val.err().unwrap(),
+            AttributeError::ConversionImpossibleError
+        );
+
+        let val = PMR.components.unwrap()[2].get_attribute::<f32>("float");
+
+        assert_eq!(val.as_ref().err(), None);
+        assert_eq!(val.ok().unwrap(), 10.556);
+
+        let val = PMR.components.unwrap()[2].get_attribute::<f32>("float2");
+
+        assert_eq!(val.as_ref().err(), None);
+        assert_eq!(val.ok().unwrap(), 10.564);
+
+        let val = PMR.components.unwrap()[2].get_attribute::<f64>("float3");
+
+        assert_eq!(val.as_ref().err(), None);
+        assert_eq!(val.ok().unwrap(), -1.18e+11);
+
+        let val = PMR.components.unwrap()[0].get_attribute::<u32>("pins");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(
+            val.err().unwrap(),
+            AttributeError::ConversionImpossibleError
+        );
+
+        let val = PMR.components.unwrap()[0].get_attribute::<Vec<i8>>("pins");
+
+        assert_eq!(val.ok().unwrap(), vec![11, 12, 13]);
+
+        let val = PMR.components.unwrap()[2].get_attribute::<Vec<i8>>("pins");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(val.err().unwrap(), AttributeError::ParseNumError);
+
+        let val = PMR.components.unwrap()[1].get_attribute::<BTreeMap<&'static str, u32>>("pins");
+
+        assert_eq!(val.as_ref().err(), None);
+        let val = val.unwrap();
+
+        assert_eq!(val["pwm"], 12);
+        assert_eq!(val["a"], 29);
+        assert_eq!(val["b"], 5);
+
+        let val = PMR.components.unwrap()[2].get_attribute::<BTreeMap<&'static str, u8>>("pins2");
+
+        assert_eq!(val.as_ref().ok(), None);
+        assert_eq!(val.err().unwrap(), AttributeError::ParseNumError);
+        Ok(())
+    }
+}

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -185,6 +185,11 @@ pub struct StaticComponentConfig {
 }
 
 #[derive(Debug)]
+pub enum ConfigType<'a> {
+    Static(&'a StaticComponentConfig),
+}
+
+#[derive(Debug)]
 pub struct RobotConfigStatic {
     pub components: Option<&'static [StaticComponentConfig]>,
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -177,7 +177,7 @@ pub enum Kind {
 }
 
 #[derive(Debug, Default)]
-pub(crate) struct StaticComponentConfig {
+pub struct StaticComponentConfig {
     pub name: &'static str,
     pub namespace: &'static str,
     pub r#type: &'static str,
@@ -186,7 +186,7 @@ pub(crate) struct StaticComponentConfig {
 }
 
 #[derive(Debug)]
-pub(crate) struct RobotConfigStatic {
+pub struct RobotConfigStatic {
     pub components: Option<&'static [StaticComponentConfig]>,
 }
 

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -13,7 +13,7 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
         .register_motor("fake", &FakeMotor::from_static_config)
         .is_err()
     {
-        log::error!("fake type is already resgitered");
+        log::error!("fake type is already registered");
     }
 }
 

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -5,12 +5,12 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use super::board::BoardType;
-use super::config::{Component, StaticComponentConfig};
+use super::config::{Component, ConfigType};
 use super::registry::ComponentRegistry;
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
-        .register_motor("fake", &FakeMotor::from_static_config)
+        .register_motor("fake", &FakeMotor::from_config)
         .is_err()
     {
         log::error!("fake type is already registered");
@@ -42,13 +42,15 @@ impl FakeMotor {
             power: 0.0,
         }
     }
-    pub(crate) fn from_static_config(
-        cfg: &StaticComponentConfig,
-        _: Option<BoardType>,
-    ) -> anyhow::Result<MotorType> {
-        if let Ok(pos) = cfg.get_attribute::<f64>("fake_positon") {
-            return Ok(Arc::new(Mutex::new(FakeMotor { pos, power: 0.0 })));
-        }
+    pub(crate) fn from_config(cfg: ConfigType, _: Option<BoardType>) -> anyhow::Result<MotorType> {
+        match cfg {
+            ConfigType::Static(cfg) => {
+                if let Ok(pos) = cfg.get_attribute::<f64>("fake_position") {
+                    return Ok(Arc::new(Mutex::new(FakeMotor { pos, power: 0.0 })));
+                }
+            }
+        };
+
         Ok(Arc::new(Mutex::new(FakeMotor::new())))
     }
 }

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -98,7 +98,7 @@ impl Status for FakeMotor {
         bt.insert(
             "position".to_string(),
             prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(15.0)),
+                kind: Some(prost_types::value::Kind::NumberValue(self.pos as f64)),
             },
         );
         bt.insert(

--- a/src/common/registry.rs
+++ b/src/common/registry.rs
@@ -1,0 +1,174 @@
+#![allow(dead_code)]
+
+lazy_static::lazy_static! {
+    pub(crate) static ref COMPONENT_REGISTRY: ComponentRegistry = {
+        let mut r = ComponentRegistry::new();
+        crate::common::board::register_models(&mut r);
+        crate::common::motor::register_models(&mut r);
+        r
+    };
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum RegistryError {
+    ModelNotFound,
+    ModelAlreadyRegistered(&'static str),
+}
+
+impl fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegistryError::ModelNotFound => {
+                write!(f, "RegistryError : Model not found")
+            }
+            RegistryError::ModelAlreadyRegistered(model) => {
+                write!(f, "RegistryError : model {} already exists", model)
+            }
+        }
+    }
+}
+impl Error for RegistryError {}
+
+use core::fmt;
+use std::{collections::BTreeMap as Map, error::Error};
+
+use super::{board::BoardType, config::StaticComponentConfig, motor::MotorType};
+
+type MotorConstructor =
+    dyn Fn(&StaticComponentConfig, Option<BoardType>) -> anyhow::Result<MotorType>;
+
+type BoardConstructor = dyn Fn(&StaticComponentConfig) -> anyhow::Result<BoardType>;
+
+pub(crate) struct ComponentRegistry {
+    motors: Map<&'static str, &'static MotorConstructor>,
+    board: Map<&'static str, &'static BoardConstructor>,
+}
+
+unsafe impl Sync for ComponentRegistry {}
+
+impl ComponentRegistry {
+    pub(crate) fn new() -> Self {
+        Self {
+            motors: Map::new(),
+            board: Map::new(),
+        }
+    }
+    pub(crate) fn register_motor(
+        &mut self,
+        model: &'static str,
+        constructor: &'static MotorConstructor,
+    ) -> Result<(), RegistryError> {
+        if self.motors.contains_key(model) {
+            return Err(RegistryError::ModelAlreadyRegistered(model));
+        }
+        let _ = self.motors.insert(model, constructor);
+        Ok(())
+    }
+
+    pub(crate) fn register_board(
+        &mut self,
+        model: &'static str,
+        constructor: &'static BoardConstructor,
+    ) -> Result<(), RegistryError> {
+        if self.board.contains_key(model) {
+            return Err(RegistryError::ModelAlreadyRegistered(model));
+        }
+        let _ = self.board.insert(model, constructor);
+        Ok(())
+    }
+    pub(crate) fn get_motor_constructor(
+        &self,
+        model: &'static str,
+    ) -> Result<&'static MotorConstructor, RegistryError> {
+        if let Some(ctor) = self.motors.get(model) {
+            return Ok(*ctor);
+        }
+        Err(RegistryError::ModelNotFound)
+    }
+
+    pub(crate) fn get_board_constructor(
+        &self,
+        model: &'static str,
+    ) -> Result<&'static BoardConstructor, RegistryError> {
+        if let Some(ctor) = self.board.get(model) {
+            return Ok(*ctor);
+        }
+        Err(RegistryError::ModelNotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::common;
+    use crate::common::config::StaticComponentConfig;
+    use crate::common::registry::{ComponentRegistry, RegistryError, COMPONENT_REGISTRY};
+    #[test_log::test]
+    fn test_registry() -> anyhow::Result<()> {
+        let mut registry = ComponentRegistry::new();
+
+        let ctor = registry.get_motor_constructor("fake");
+        assert!(ctor.is_err());
+        assert_eq!(ctor.err().unwrap(), RegistryError::ModelNotFound);
+        common::motor::register_models(&mut registry);
+
+        let ctor = registry.get_motor_constructor("fake");
+        assert!(ctor.is_ok());
+
+        let ret = registry.register_motor("fake", &|_, _| Err(anyhow::anyhow!("not implemented")));
+        assert!(ret.is_err());
+        assert_eq!(
+            ret.err().unwrap(),
+            RegistryError::ModelAlreadyRegistered("fake")
+        );
+
+        let ret = registry.register_motor("fake2", &|_, _| Err(anyhow::anyhow!("not implemented")));
+        assert!(ret.is_ok());
+
+        let ctor = registry.get_board_constructor("fake");
+        assert!(ctor.is_err());
+        assert_eq!(ctor.err().unwrap(), RegistryError::ModelNotFound);
+        common::board::register_models(&mut registry);
+
+        let ctor = registry.get_board_constructor("fake");
+        assert!(ctor.is_ok());
+
+        let ret = registry.register_board("fake", &|_| Err(anyhow::anyhow!("not implemented")));
+        assert!(ret.is_err());
+        assert_eq!(
+            ret.err().unwrap(),
+            RegistryError::ModelAlreadyRegistered("fake")
+        );
+
+        let ret = registry.register_board("fake2", &|_| Err(anyhow::anyhow!("not implemented")));
+        assert!(ret.is_ok());
+
+        let cfg = StaticComponentConfig::default();
+
+        let ctor = registry.get_motor_constructor("fake2");
+        assert!(ctor.is_ok());
+
+        let ret = ctor.unwrap()(&cfg, None);
+
+        assert!(ret.is_err());
+        assert_eq!(format!("{}", ret.err().unwrap()), "not implemented");
+
+        let ctor = registry.get_board_constructor("fake2");
+        assert!(ctor.is_ok());
+
+        let ret = ctor.unwrap()(&cfg);
+
+        assert!(ret.is_err());
+        assert_eq!(format!("{}", ret.err().unwrap()), "not implemented");
+
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn test_lazy_init() {
+        let ctor = COMPONENT_REGISTRY.get_motor_constructor("fake");
+        assert!(ctor.is_ok());
+
+        let ctor = COMPONENT_REGISTRY.get_board_constructor("fake");
+        assert!(ctor.is_ok());
+    }
+}

--- a/src/common/robot.rs
+++ b/src/common/robot.rs
@@ -262,6 +262,7 @@ impl LocalRobot {
 
 #[cfg(test)]
 mod tests {
+    use crate::common::board::Board;
     use crate::common::config::{Kind, RobotConfigStatic, StaticComponentConfig};
     use crate::common::motor::Motor;
     use crate::common::robot::LocalRobot;
@@ -277,7 +278,8 @@ mod tests {
                     r#type: "board",
                     model: "fake",
                     attributes: Some(
-                        phf::phf_map! {"pins" => Kind::ListValueStatic(&[Kind::StringValueStatic("11"),Kind::StringValueStatic("12"),Kind::StringValueStatic("13")])},
+                        phf::phf_map! {"pins" => Kind::ListValueStatic(&[Kind::StringValueStatic("11"),Kind::StringValueStatic("12"),Kind::StringValueStatic("13")]),
+                        "analogs" => Kind::StructValueStatic(phf::phf_map!{"1" => Kind::StringValueStatic("11.12")})},
                     ),
                 },
                 StaticComponentConfig {
@@ -318,6 +320,25 @@ mod tests {
         let board = robot.get_board_by_name("board".to_string());
 
         assert!(board.is_some());
+
+        assert!(board
+            .as_ref()
+            .unwrap()
+            .get_analog_reader_by_name("1".to_string())
+            .is_ok());
+
+        let value = board
+            .as_ref()
+            .unwrap()
+            .get_analog_reader_by_name("1".to_string())
+            .unwrap()
+            .clone()
+            .borrow_mut()
+            .read();
+
+        assert!(value.is_ok());
+
+        assert_eq!(value.unwrap(), 11);
 
         let sensor = robot.get_sensor_by_name("sensor".to_string());
 

--- a/src/common/robot.rs
+++ b/src/common/robot.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(feature = "camera")]
-use crate::camera::Camera;
+use crate::camera::{Camera, CameraType};
 
 use crate::{
     common::base::Base,
@@ -22,17 +22,21 @@ use crate::{
 use log::*;
 
 use super::{
+    base::BaseType,
+    board::BoardType,
     config::{Component, RobotConfigStatic},
+    motor::MotorType,
     registry::COMPONENT_REGISTRY,
+    sensor::SensorType,
 };
 
 pub enum ResourceType {
-    Motor(Arc<Mutex<dyn Motor>>),
-    Board(Arc<Mutex<dyn Board>>),
-    Base(Arc<Mutex<dyn Base>>),
-    Sensor(Arc<Mutex<dyn Sensor>>),
+    Motor(MotorType),
+    Board(BoardType),
+    Base(BaseType),
+    Sensor(SensorType),
     #[cfg(feature = "camera")]
-    Camera(Arc<Mutex<dyn Camera>>),
+    Camera(CameraType),
 }
 pub type Resource = ResourceType;
 pub type ResourceMap = HashMap<ResourceName, Resource>;

--- a/src/common/sensor.rs
+++ b/src/common/sensor.rs
@@ -5,6 +5,20 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use super::board::BoardType;
+use super::config::Component;
+use super::config::ConfigType;
+use super::registry::ComponentRegistry;
+
+pub(crate) fn register_models(registry: &mut ComponentRegistry) {
+    if registry
+        .register_sensor("fake", &FakeSensor::from_config)
+        .is_err()
+    {
+        log::error!("fake sensor type is already registered");
+    }
+}
+
 pub type GenericReadingsResult =
     ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>;
 
@@ -43,6 +57,16 @@ impl FakeSensor {
             fake_reading: 42.42,
         }
     }
+    pub(crate) fn from_config(cfg: ConfigType, _: Option<BoardType>) -> anyhow::Result<SensorType> {
+        match cfg {
+            ConfigType::Static(cfg) => {
+                if let Ok(val) = cfg.get_attribute::<f64>("fake_value") {
+                    return Ok(Arc::new(Mutex::new(FakeSensor { fake_reading: val })));
+                }
+            }
+        }
+        Ok(Arc::new(Mutex::new(FakeSensor::new())))
+    }
 }
 
 impl Default for FakeSensor {
@@ -66,6 +90,14 @@ impl SensorT<f64> for FakeSensor {
         let mut x = HashMap::new();
         x.insert("fake_sensor".to_string(), self.fake_reading);
         Ok(x)
+    }
+}
+impl<A> Sensor for Mutex<A>
+where
+    A: ?Sized + Sensor,
+{
+    fn get_generic_readings(&self) -> anyhow::Result<GenericReadingsResult> {
+        self.lock().unwrap().get_generic_readings()
     }
 }
 

--- a/src/common/sensor.rs
+++ b/src/common/sensor.rs
@@ -3,6 +3,7 @@
 use crate::common::status::Status;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 pub type GenericReadingsResult =
     ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>;
@@ -12,6 +13,8 @@ pub type TypedReadingsResult<T> = ::std::collections::HashMap<String, T>;
 pub trait Sensor: Status {
     fn get_generic_readings(&self) -> anyhow::Result<GenericReadingsResult>;
 }
+
+pub(crate) type SensorType = Arc<Mutex<dyn Sensor>>;
 
 pub trait SensorT<T>: Sensor {
     fn get_readings(&self) -> anyhow::Result<TypedReadingsResult<T>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,11 @@ pub mod common {
     pub mod base;
     pub mod board;
     pub mod camera;
+    pub mod config;
     pub mod grpc;
     pub mod moisture_sensor;
     pub mod motor;
+    pub mod registry;
     pub mod robot;
     pub mod sensor;
     pub mod status;


### PR DESCRIPTION
This PR sets the basic framework to process config during build time and have the ability to use it when running micro-rdk as to avoid hardcoding it.

During the build step we generate a rust representation of the config that can be used without much more processing by micro-rdk at runtime. Similarly to go a component's config gets consumed by the matching model constructor (see registry) the constructor can use helper functions to convert attributes to usable values. It can also extend the conversion support by implementing the TryFrom trait. 

For now only two fake models (board, motor) are supported, with planned support for sensors and analog reader before the close of the PR. Anything relevant to ESP32 will be in a separate PR given the need to refactor many of the current interfaces to allow config at runtime.

The registry API & config processing by local robot are not (yet) in a good state and will change down the road but for now will work nicely as a starting point