### PR TITLE
RSDK-3169 - fix lack of support for non-static config structs in component generators

### DIFF
--- a/src/common/analog.rs
+++ b/src/common/analog.rs
@@ -44,40 +44,30 @@ pub(crate) struct AnalogReaderConfig {
 impl TryFrom<Kind> for AnalogReaderConfig {
     type Error = AttributeError;
     fn try_from(value: Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                if !v.contains_key("pin") {
-                    return Err(AttributeError::KeyNotFound("pin".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                let pin: i32 = v.get("pin").unwrap().try_into()?;
-                Ok(Self { name, pin })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        if !value.contains_key("pin")? {
+            return Err(AttributeError::KeyNotFound("pin".to_string()));
+        }
+        let name = value.get("name")?.unwrap().try_into()?;
+        let pin: i32 = value.get("pin")?.unwrap().try_into()?;
+        Ok(Self { name, pin })
     }
 }
 
 impl TryFrom<&Kind> for AnalogReaderConfig {
     type Error = AttributeError;
     fn try_from(value: &Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                if !v.contains_key("pin") {
-                    return Err(AttributeError::KeyNotFound("pin".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                let pin: i32 = v.get("pin").unwrap().try_into()?;
-                Ok(Self { name, pin })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        if !value.contains_key("pin")? {
+            return Err(AttributeError::KeyNotFound("pin".to_string()));
+        }
+        let name = value.get("name")?.unwrap().try_into()?;
+        let pin: i32 = value.get("pin")?.unwrap().try_into()?;
+        Ok(Self { name, pin })
     }
 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -254,7 +254,7 @@ impl Kind {
         match self {
             Self::StructValueStatic(v) => Ok(v.get(key)),
             Self::StructValue(v) => Ok(v.get(key)),
-            _ => Err(AttributeError::ConversionImpossibleError),
+            _ => Err(AttributeError::KeyNotFound(key.to_string())),
         }
     }
 
@@ -262,7 +262,7 @@ impl Kind {
         match self {
             Self::StructValueStatic(v) => Ok(v.contains_key(key)),
             Self::StructValue(v) => Ok(v.contains_key(key)),
-            _ => Err(AttributeError::ConversionImpossibleError),
+            _ => Err(AttributeError::KeyNotFound(key.to_string())),
         }
     }
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -249,6 +249,24 @@ pub enum Kind {
     StructValue(BTreeMap<String, Kind>),
 }
 
+impl Kind {
+    pub fn get(&self, key: &str) -> Result<Option<&Kind>, AttributeError> {
+        match self {
+            Self::StructValueStatic(v) => Ok(v.get(key)),
+            Self::StructValue(v) => Ok(v.get(key)),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+
+    pub fn contains_key(&self, key: &str) -> Result<bool, AttributeError> {
+        match self {
+            Self::StructValueStatic(v) => Ok(v.contains_key(key)),
+            Self::StructValue(v) => Ok(v.contains_key(key)),
+            _ => Err(AttributeError::ConversionImpossibleError),
+        }
+    }
+}
+
 impl TryFrom<prost_types::value::Kind> for Kind {
     type Error = AttributeError;
     fn try_from(value: prost_types::value::Kind) -> Result<Self, Self::Error> {

--- a/src/common/i2c.rs
+++ b/src/common/i2c.rs
@@ -40,66 +40,56 @@ pub(crate) struct FakeI2cConfig<'a> {
 impl<'a> TryFrom<Kind> for FakeI2cConfig<'a> {
     type Error = AttributeError;
     fn try_from(value: Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                let value_1 = match v.get("value_1") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                let value_2 = match v.get("value_2") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                let value_3 = match v.get("value_3") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                Ok(FakeI2cConfig {
-                    name,
-                    value_1,
-                    value_2,
-                    value_3,
-                })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        let name = value.get("name")?.unwrap().try_into()?;
+        let value_1 = match value.get("value_1")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        let value_2 = match value.get("value_2")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        let value_3 = match value.get("value_3")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        Ok(FakeI2cConfig {
+            name,
+            value_1,
+            value_2,
+            value_3,
+        })
     }
 }
 
 impl<'a> TryFrom<&Kind> for FakeI2cConfig<'a> {
     type Error = AttributeError;
     fn try_from(value: &Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                let value_1 = match v.get("value_1") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                let value_2 = match v.get("value_2") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                let value_3 = match v.get("value_3") {
-                    Some(val) => val.try_into()?,
-                    None => 0,
-                };
-                Ok(FakeI2cConfig {
-                    name,
-                    value_1,
-                    value_2,
-                    value_3,
-                })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        let name = value.get("name")?.unwrap().try_into()?;
+        let value_1 = match value.get("value_1")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        let value_2 = match value.get("value_2")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        let value_3 = match value.get("value_3")? {
+            Some(val) => val.try_into()?,
+            None => 0,
+        };
+        Ok(FakeI2cConfig {
+            name,
+            value_1,
+            value_2,
+            value_3,
+        })
     }
 }
 

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -54,54 +54,48 @@ pub struct FakeMotor {
 impl TryFrom<Kind> for MotorPinsConfig {
     type Error = AttributeError;
     fn try_from(value: Kind) -> Result<Self, Self::Error> {
-        let mut motor = MotorPinsConfig::default();
-        match value {
-            Kind::StructValueStatic(v) => {
-                motor.pwm = v
-                    .get("pwm")
-                    .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
-                    .try_into()?;
-                if let Some(a) = v.get("a") {
-                    motor.a = Some(a.try_into()?);
-                } else {
-                    motor.a = None;
-                }
-                if let Some(b) = v.get("b") {
-                    motor.b = Some(b.try_into()?);
-                } else {
-                    motor.b = None;
-                }
-            }
-            _ => return Err(AttributeError::ConversionImpossibleError),
-        }
-        Ok(motor)
+        Ok(MotorPinsConfig {
+            a: Some(
+                value
+                    .get("a")?
+                    .ok_or_else(|| AttributeError::KeyNotFound("a".to_string()))?
+                    .try_into()?,
+            ),
+            b: Some(
+                value
+                    .get("b")?
+                    .ok_or_else(|| AttributeError::KeyNotFound("b".to_string()))?
+                    .try_into()?,
+            ),
+            pwm: value
+                .get("pwm")?
+                .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
+                .try_into()?,
+        })
     }
 }
 
 impl TryFrom<&Kind> for MotorPinsConfig {
     type Error = AttributeError;
     fn try_from(value: &Kind) -> Result<Self, Self::Error> {
-        let mut motor = MotorPinsConfig::default();
-        match value {
-            Kind::StructValueStatic(v) => {
-                motor.pwm = v
-                    .get("pwm")
-                    .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
-                    .try_into()?;
-                motor.a = Some(
-                    v.get("a")
-                        .ok_or_else(|| AttributeError::KeyNotFound("a".to_string()))?
-                        .try_into()?,
-                );
-                motor.b = Some(
-                    v.get("b")
-                        .ok_or_else(|| AttributeError::KeyNotFound("b".to_string()))?
-                        .try_into()?,
-                );
-            }
-            _ => return Err(AttributeError::ConversionImpossibleError),
-        }
-        Ok(motor)
+        Ok(MotorPinsConfig {
+            a: Some(
+                value
+                    .get("a")?
+                    .ok_or_else(|| AttributeError::KeyNotFound("a".to_string()))?
+                    .try_into()?,
+            ),
+            b: Some(
+                value
+                    .get("b")?
+                    .ok_or_else(|| AttributeError::KeyNotFound("b".to_string()))?
+                    .try_into()?,
+            ),
+            pwm: value
+                .get("pwm")?
+                .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
+                .try_into()?,
+        })
     }
 }
 

--- a/src/esp32/i2c.rs
+++ b/src/esp32/i2c.rs
@@ -33,86 +33,76 @@ impl From<Esp32I2cConfig> for I2cConfig {
 impl TryFrom<Kind> for Esp32I2cConfig {
     type Error = AttributeError;
     fn try_from(value: Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                if !v.contains_key("bus") {
-                    return Err(AttributeError::KeyNotFound("bus".to_string()));
-                }
-                let bus = v.get("bus").unwrap().try_into()?;
-                let mut data_pin = 11;
-                if v.contains_key("data_pin") {
-                    data_pin = v.get("data_pin").unwrap().try_into()?;
-                }
-                let mut clock_pin = 6;
-                if v.contains_key("clock_pin") {
-                    clock_pin = v.get("clock_pin").unwrap().try_into()?;
-                }
-                let mut baudrate_hz: u32 = 1000000;
-                if v.contains_key("baudrate_hz") {
-                    baudrate_hz = v.get("baudrate").unwrap().try_into()?;
-                }
-                let mut timeout_ns: u32 = 0;
-                if v.contains_key("timeout_ns") {
-                    timeout_ns = v.get("timeout_ns").unwrap().try_into()?;
-                }
-                Ok(Self {
-                    name,
-                    bus,
-                    baudrate_hz,
-                    timeout_ns,
-                    data_pin,
-                    clock_pin,
-                })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        let name = value.get("name")?.unwrap().try_into()?;
+        if !value.contains_key("bus")? {
+            return Err(AttributeError::KeyNotFound("bus".to_string()));
+        }
+        let bus = value.get("bus")?.unwrap().try_into()?;
+        let mut data_pin = 11;
+        if value.contains_key("data_pin")? {
+            data_pin = value.get("data_pin")?.unwrap().try_into()?;
+        }
+        let mut clock_pin = 6;
+        if value.contains_key("clock_pin")? {
+            clock_pin = value.get("clock_pin")?.unwrap().try_into()?;
+        }
+        let mut baudrate_hz: u32 = 1000000;
+        if value.contains_key("baudrate_hz")? {
+            baudrate_hz = value.get("baudrate")?.unwrap().try_into()?;
+        }
+        let mut timeout_ns: u32 = 0;
+        if value.contains_key("timeout_ns")? {
+            timeout_ns = value.get("timeout_ns")?.unwrap().try_into()?;
+        }
+        Ok(Self {
+            name,
+            bus,
+            baudrate_hz,
+            timeout_ns,
+            data_pin,
+            clock_pin,
+        })
     }
 }
 
 impl TryFrom<&Kind> for Esp32I2cConfig {
     type Error = AttributeError;
     fn try_from(value: &Kind) -> Result<Self, Self::Error> {
-        match value {
-            Kind::StructValueStatic(v) => {
-                if !v.contains_key("name") {
-                    return Err(AttributeError::KeyNotFound("name".to_string()));
-                }
-                let name = v.get("name").unwrap().try_into()?;
-                if !v.contains_key("bus") {
-                    return Err(AttributeError::KeyNotFound("bus".to_string()));
-                }
-                let bus = v.get("bus").unwrap().try_into()?;
-                let mut data_pin = 11;
-                if v.contains_key("data_pin") {
-                    data_pin = v.get("data_pin").unwrap().try_into()?;
-                }
-                let mut clock_pin = 6;
-                if v.contains_key("clock_pin") {
-                    clock_pin = v.get("clock_pin").unwrap().try_into()?;
-                }
-                let mut baudrate_hz: u32 = 1000000;
-                if v.contains_key("baudrate_hz") {
-                    baudrate_hz = v.get("baudrate").unwrap().try_into()?;
-                }
-                let mut timeout_ns: u32 = 0;
-                if v.contains_key("timeout_ns") {
-                    timeout_ns = v.get("timeout_ns").unwrap().try_into()?;
-                }
-                Ok(Self {
-                    name,
-                    bus,
-                    baudrate_hz,
-                    timeout_ns,
-                    data_pin,
-                    clock_pin,
-                })
-            }
-            _ => Err(AttributeError::ConversionImpossibleError),
+        if !value.contains_key("name")? {
+            return Err(AttributeError::KeyNotFound("name".to_string()));
         }
+        let name = value.get("name")?.unwrap().try_into()?;
+        if !value.contains_key("bus")? {
+            return Err(AttributeError::KeyNotFound("bus".to_string()));
+        }
+        let bus = value.get("bus")?.unwrap().try_into()?;
+        let mut data_pin = 11;
+        if value.contains_key("data_pin")? {
+            data_pin = value.get("data_pin")?.unwrap().try_into()?;
+        }
+        let mut clock_pin = 6;
+        if value.contains_key("clock_pin")? {
+            clock_pin = value.get("clock_pin")?.unwrap().try_into()?;
+        }
+        let mut baudrate_hz: u32 = 1000000;
+        if value.contains_key("baudrate_hz")? {
+            baudrate_hz = value.get("baudrate")?.unwrap().try_into()?;
+        }
+        let mut timeout_ns: u32 = 0;
+        if value.contains_key("timeout_ns")? {
+            timeout_ns = value.get("timeout_ns")?.unwrap().try_into()?;
+        }
+        Ok(Self {
+            name,
+            bus,
+            baudrate_hz,
+            timeout_ns,
+            data_pin,
+            clock_pin,
+        })
     }
 }
 


### PR DESCRIPTION
This was a change that I forgot to make in the [previous commit](https://github.com/viamrobotics/micro-rdk/commit/fbc7fc8f6bb2c7ef01f631fcef1987f612b61dcf). Without this, certain components that implemented from_config still could not be generated from dynamically acquired configs.