### PR TITLE
RSDK-2322 - implement support for component dependencies in config

### DIFF
--- a/src/common/adxl345.rs
+++ b/src/common/adxl345.rs
@@ -3,11 +3,11 @@ use crate::common::i2c::I2cHandleType;
 use crate::common::math_utils::Vector3;
 use crate::common::movement_sensor::{MovementSensor, MovementSensorSupportedMethods};
 
-use super::board::{Board, BoardType};
+use super::board::Board;
 use super::config::ConfigType;
 use super::i2c::I2CHandle;
 use super::movement_sensor::MovementSensorType;
-use super::registry::ComponentRegistry;
+use super::registry::{get_board_from_dependencies, ComponentRegistry, Dependency};
 use super::status::Status;
 
 use std::collections::BTreeMap;
@@ -47,8 +47,9 @@ impl ADXL345 {
     #[allow(dead_code)]
     pub(crate) fn from_config(
         cfg: ConfigType,
-        board: Option<BoardType>,
+        dependencies: Vec<Dependency>,
     ) -> anyhow::Result<MovementSensorType> {
+        let board = get_board_from_dependencies(dependencies);
         if board.is_none() {
             return Err(anyhow::anyhow!(
                 "actual board is required to be passed to configure ADXL-345"

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -19,6 +19,8 @@ use super::i2c::I2CHandle;
 use super::i2c::I2cHandleType;
 use super::registry::ComponentRegistry;
 
+pub static COMPONENT_NAME: &str = "board";
+
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
         .register_board("fake", &FakeBoard::from_config)

--- a/src/common/camera.rs
+++ b/src/common/camera.rs
@@ -5,6 +5,8 @@ use crate::proto::component::camera;
 use bytes::{Bytes, BytesMut};
 use prost::Message;
 
+pub static COMPONENT_NAME: &str = "camera";
+
 pub trait Camera {
     fn get_frame(&mut self, buffer: BytesMut) -> anyhow::Result<BytesMut>;
 }

--- a/src/common/encoder.rs
+++ b/src/common/encoder.rs
@@ -6,10 +6,11 @@ use crate::proto::component::encoder::v1::GetPositionResponse;
 use crate::proto::component::encoder::v1::GetPropertiesResponse;
 use crate::proto::component::encoder::v1::PositionType;
 
-use super::board::BoardType;
 use super::config::ConfigType;
-use super::registry::ComponentRegistry;
+use super::registry::{ComponentRegistry, Dependency};
 use super::status::Status;
+
+pub static COMPONENT_NAME: &str = "encoder";
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
@@ -134,10 +135,7 @@ impl FakeIncrementalEncoder {
     pub fn new() -> Self {
         Self { ticks: 0.0 }
     }
-    pub(crate) fn from_config(
-        cfg: ConfigType,
-        _: Option<BoardType>,
-    ) -> anyhow::Result<EncoderType> {
+    pub(crate) fn from_config(cfg: ConfigType, _: Vec<Dependency>) -> anyhow::Result<EncoderType> {
         let mut enc: FakeIncrementalEncoder = Default::default();
         if let Ok(fake_ticks) = cfg.get_attribute::<f32>("fake_ticks") {
             enc.ticks = fake_ticks;
@@ -196,10 +194,7 @@ impl FakeEncoder {
         }
     }
 
-    pub(crate) fn from_config(
-        cfg: ConfigType,
-        _: Option<BoardType>,
-    ) -> anyhow::Result<EncoderType> {
+    pub(crate) fn from_config(cfg: ConfigType, _: Vec<Dependency>) -> anyhow::Result<EncoderType> {
         let mut enc: FakeEncoder = Default::default();
         if let Ok(ticks_per_rotation) = cfg.get_attribute::<u32>("ticks_per_rotation") {
             enc.ticks_per_rotation = ticks_per_rotation;

--- a/src/common/movement_sensor.rs
+++ b/src/common/movement_sensor.rs
@@ -1,14 +1,15 @@
 #![allow(dead_code)]
-use super::board::BoardType;
 use super::config::ConfigType;
 use super::math_utils::Vector3;
-use super::registry::ComponentRegistry;
+use super::registry::{ComponentRegistry, Dependency};
 use super::status::Status;
 use crate::proto::common::v1::GeoPoint;
 use crate::proto::component::movement_sensor;
 
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
+
+pub static COMPONENT_NAME: &str = "movement_sensor";
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
@@ -105,7 +106,7 @@ impl FakeMovementSensor {
     }
     pub(crate) fn from_config(
         cfg: ConfigType,
-        _: Option<BoardType>,
+        _: Vec<Dependency>,
     ) -> anyhow::Result<MovementSensorType> {
         let mut fake_pos: GeoPosition = Default::default();
         if let Ok(fake_lat) = cfg.get_attribute::<f64>("fake_lat") {

--- a/src/common/mpu6050.rs
+++ b/src/common/mpu6050.rs
@@ -3,11 +3,11 @@ use crate::common::i2c::I2cHandleType;
 use crate::common::math_utils::Vector3;
 use crate::common::movement_sensor::{MovementSensor, MovementSensorSupportedMethods};
 
-use super::board::{Board, BoardType};
+use super::board::Board;
 use super::config::ConfigType;
 use super::i2c::I2CHandle;
 use super::movement_sensor::MovementSensorType;
-use super::registry::ComponentRegistry;
+use super::registry::{get_board_from_dependencies, ComponentRegistry, Dependency};
 use super::status::Status;
 
 use std::collections::BTreeMap;
@@ -47,8 +47,9 @@ impl MPU6050 {
     #[allow(dead_code)]
     pub(crate) fn from_config(
         cfg: ConfigType,
-        board: Option<BoardType>,
+        dependencies: Vec<Dependency>,
     ) -> anyhow::Result<MovementSensorType> {
+        let board = get_board_from_dependencies(dependencies);
         if board.is_none() {
             return Err(anyhow::anyhow!(
                 "actual board is required to be passed to configure MPU6050"

--- a/src/common/sensor.rs
+++ b/src/common/sensor.rs
@@ -5,9 +5,10 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use super::board::BoardType;
 use super::config::ConfigType;
-use super::registry::ComponentRegistry;
+use super::registry::{ComponentRegistry, Dependency};
+
+pub static COMPONENT_NAME: &str = "sensor";
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
@@ -56,7 +57,7 @@ impl FakeSensor {
             fake_reading: 42.42,
         }
     }
-    pub(crate) fn from_config(cfg: ConfigType, _: Option<BoardType>) -> anyhow::Result<SensorType> {
+    pub(crate) fn from_config(cfg: ConfigType, _: Vec<Dependency>) -> anyhow::Result<SensorType> {
         if let Ok(val) = cfg.get_attribute::<f64>("fake_value") {
             return Ok(Arc::new(Mutex::new(FakeSensor { fake_reading: val })));
         }

--- a/src/esp32/encoder.rs
+++ b/src/esp32/encoder.rs
@@ -19,12 +19,11 @@ use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::common::board::BoardType;
 use crate::common::config::ConfigType;
 use crate::common::encoder::{
     Encoder, EncoderPosition, EncoderPositionType, EncoderSupportedRepresentations, EncoderType,
 };
-use crate::common::registry::ComponentRegistry;
+use crate::common::registry::{ComponentRegistry, Dependency};
 use crate::common::status::Status;
 
 use embedded_hal::digital::v2::InputPin;
@@ -89,10 +88,7 @@ where
         Ok(enc)
     }
 
-    pub(crate) fn from_config(
-        cfg: ConfigType,
-        _: Option<BoardType>,
-    ) -> anyhow::Result<EncoderType> {
+    pub(crate) fn from_config(cfg: ConfigType, _: Vec<Dependency>) -> anyhow::Result<EncoderType> {
         let pin_a_num = match cfg.get_attribute::<i32>("a") {
             Ok(num) => num,
             Err(_) => return Err(anyhow::anyhow!("cannot build encoder, need 'a' pin")),


### PR DESCRIPTION
This supports _implicit_ dependencies only; it does not make use of the 'depends_on' field (although this could be implemented in a later PR). I made this choice because it seems that we were headed in the direction of implicit rather than explicit dependencies in RDK anyway. The board is still always passed as a dependency to every component constructor.

Follow-up PRs (still under RSDK-2322) will implement dependency functions for the rest of the components for which such a thing is relevant.