### PR TITLE
RSDK-3171 - remove special prefix requirement and fix string parsing bug

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -39,6 +39,7 @@ macro_rules! primitives
                       Kind::NumberValue(v) => Ok(v as $t),
                       Kind::BoolValue(v) => Ok(v as $t),
                       Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      Kind::StringValue(v) => Ok(v.parse::<$t>()?),
                       _ => Err(AttributeError::ConversionImpossibleError),
                   }
               }
@@ -52,6 +53,7 @@ macro_rules! primitives
                       Kind::NumberValue(v) => Ok(*v as $t),
                       Kind::BoolValue(v) => Ok(*v as $t),
                       Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      Kind::StringValue(v) => Ok(v.parse::<$t>()?),
                       _ => Err(AttributeError::ConversionImpossibleError),
                   }
               }
@@ -73,6 +75,7 @@ macro_rules! floats
                       Kind::NullValue(v) => Ok(v as $t),
                       Kind::NumberValue(v) => Ok(v as $t),
                       Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      Kind::StringValue(v) => Ok(v.parse::<$t>()?),
                       _ => Err(AttributeError::ConversionImpossibleError),
                   }
               }
@@ -85,6 +88,7 @@ macro_rules! floats
                       Kind::NullValue(v) => Ok(*v as $t),
                       Kind::NumberValue(v) => Ok(*v as $t),
                       Kind::StringValueStatic(v) => Ok(v.parse::<$t>()?),
+                      Kind::StringValue(v) => Ok(v.parse::<$t>()?),
                       _ => Err(AttributeError::ConversionImpossibleError),
                   }
               }

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -104,7 +104,6 @@ impl TryFrom<Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let b = match value.get("b") {
             Ok(opt) => match opt {
                 Some(val) => Some(val.try_into()?),
@@ -117,7 +116,6 @@ impl TryFrom<Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let dir = match value.get("dir") {
             Ok(opt) => match opt {
                 Some(val) => Some(val.try_into()?),
@@ -130,12 +128,10 @@ impl TryFrom<Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let pwm = value
             .get("pwm")?
             .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
             .try_into()?;
-
         Ok(Self { a, b, dir, pwm })
     }
 }
@@ -155,7 +151,6 @@ impl TryFrom<&Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let b = match value.get("b") {
             Ok(opt) => match opt {
                 Some(val) => Some(val.try_into()?),
@@ -168,7 +163,6 @@ impl TryFrom<&Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let dir = match value.get("dir") {
             Ok(opt) => match opt {
                 Some(val) => Some(val.try_into()?),
@@ -181,12 +175,10 @@ impl TryFrom<&Kind> for MotorPinsConfig {
                 }
             },
         };
-
         let pwm = value
             .get("pwm")?
             .ok_or_else(|| AttributeError::KeyNotFound("pwm".to_string()))?
             .try_into()?;
-
         Ok(Self { a, b, dir, pwm })
     }
 }


### PR DESCRIPTION
This commit results in the following UX changes:

- prefixing the model name with "micro-rdk:builtin:" is no longer required when configuring a component
- the config cards for `gpio` motor, as well as for `accel-adxl345` and `gyro-mpu6050`, in the app UI can also now be used