### PR TITLE
RSDK-4499 - add digital interrupt support to board

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ crate-type = ["lib"]
 
 [patch.crates-io]
 esp-idf-sys = {git = "https://github.com/npmenard/esp-idf-sys.git"}
-polling = { git = "https://github.com/esp-rs-compat/polling" }
 smol = { git = "https://github.com/esp-rs-compat/smol" }
 socket2 = { git = "https://github.com/npmenard/socket2.git" }
 async-io = {git = "https://github.com/npmenard/async-io.git"}
@@ -73,6 +72,7 @@ async-std-openssl = {version = "0.6.3", optional = true }
 thiserror = "1.0.40"
 pin-project-lite = "0.2.9"
 url = "2.4.0"
+once_cell = "1.18.0"
 
 [build-dependencies]
 anyhow = "1"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2921,6 +2921,7 @@ dependencies = [
  "local-ip-address",
  "log 0.4.19",
  "mdns-sd",
+ "once_cell",
  "openssl",
  "phf",
  "pin-project-lite 0.2.11",

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -48,6 +48,11 @@ pub trait Board: Status {
         duration: Option<Duration>,
     ) -> anyhow::Result<()>;
     fn get_i2c_by_name(&self, name: String) -> anyhow::Result<I2cHandleType>;
+    /// Return the amount of detected interrupt events on a pin. Should error if the
+    /// pin has not been configured as an interrupt
+    fn get_digital_interrupt_value(&self, _pin: i32) -> anyhow::Result<u32> {
+        anyhow::bail!("this board does not support digital interrupts")
+    }
 }
 
 pub type BoardType = Arc<Mutex<dyn Board>>;
@@ -219,5 +224,9 @@ where
 
     fn get_i2c_by_name(&self, name: String) -> anyhow::Result<I2cHandleType> {
         self.lock().unwrap().get_i2c_by_name(name)
+    }
+
+    fn get_digital_interrupt_value(&self, pin: i32) -> anyhow::Result<u32> {
+        self.lock().unwrap().get_digital_interrupt_value(pin)
     }
 }

--- a/src/common/digital_interrupt.rs
+++ b/src/common/digital_interrupt.rs
@@ -1,0 +1,28 @@
+use super::config::{AttributeError, Kind};
+
+#[derive(Copy, Clone, Debug)]
+pub struct DigitalInterruptConfig {
+    pub pin: i32,
+}
+
+impl TryFrom<Kind> for DigitalInterruptConfig {
+    type Error = AttributeError;
+    fn try_from(value: Kind) -> Result<Self, Self::Error> {
+        if !value.contains_key("pin")? {
+            return Err(AttributeError::KeyNotFound("pin".to_string()));
+        }
+        let pin = value.get("pin")?.unwrap().try_into()?;
+        Ok(DigitalInterruptConfig { pin })
+    }
+}
+
+impl TryFrom<&Kind> for DigitalInterruptConfig {
+    type Error = AttributeError;
+    fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+        if !value.contains_key("pin")? {
+            return Err(AttributeError::KeyNotFound("pin".to_string()));
+        }
+        let pin = value.get("pin")?.unwrap().try_into()?;
+        Ok(DigitalInterruptConfig { pin })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod common {
     pub mod board;
     pub mod camera;
     pub mod config;
+    pub mod digital_interrupt;
     pub mod encoder;
     pub mod entry;
     pub mod grpc;


### PR DESCRIPTION
Also contains a small refactor on board that goes part of the way to improving management of pin resources on the ESP32 across components (see `GPIOPin` struct)

Hardware Test Cases Conducted
- getting/setting level for a pin not configured as an interrupt
- getting level for a pin configured as an interrupt
- calling `GetDigitalInterruptValue` on the board from a Python SDK for a pin configured as an interrupt (touched the pin to a 3v3 connection repeatedly to increase the event count)

I'm willing to remove the pins subscription support for other drivers if we don't like that I used channels. I felt it might be ok because our cargo dependencies implied that we were already implicitly using them