### PR TITLE
[RSDK-4961] Remove BTreeMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ log = "0.4"
 mdns-sd = { version = "0.5.10", optional = true, default-features = false, features = ["async"] }
 phf = { version = "0.11", features = ["macros"] }
 prost = "0.11.0"
-prost-types = "0.11.1"
 rustls = { version = "0.20.7", features = ["logging","tls12"], optional = true }
 rustls-pemfile = { version = "1.0.2", optional = true }
 sctp-proto = "0.1.4"

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ buf: buf-clean
 	buf generate buf.build/viamrobotics/goutils --template buf.gen.yaml
 	buf generate buf.build/googleapis/googleapis --template buf.gen.yaml --path google/rpc --path google/api
 	buf generate buf.build/viamrobotics/api --template buf.gen.yaml
+	buf generate buf.build/protocolbuffers/wellknowntypes --template buf.gen.yaml 
 
 license-finder:
 	license_finder

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,3 +6,4 @@ plugins:
       - bytes=.viam.component.camera.v1
       - bytes=.proto.rpc.webrtc.v1
       - type_attribute=.viam.common.v1.ResourceName=#[derive(Eq\, Hash)]
+      - compile_well_known_types

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2926,7 +2926,6 @@ dependencies = [
  "phf",
  "pin-project-lite 0.2.11",
  "prost 0.11.9",
- "prost-types 0.11.9",
  "rand",
  "rcgen",
  "rustls 0.20.8",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -579,17 +579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,17 +999,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "colored"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
-dependencies = [
- "is-terminal",
- "lazy_static 1.4.0",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -1756,6 +1734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log 0.4.19",
+ "regex 1.9.3",
+ "termcolor",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1869,7 @@ dependencies = [
  "embedded-hal 0.2.7",
  "embedded-svc",
  "embuild 0.29.3",
+ "env_logger",
  "esp-idf-hal",
  "esp-idf-svc",
  "esp-idf-sys",
@@ -1893,7 +1885,6 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "simple_logger",
  "smol",
  "thiserror",
  "tokio",
@@ -2356,15 +2347,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -2648,7 +2630,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -2665,7 +2647,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix 0.38.7",
  "windows-sys 0.48.0",
 ]
@@ -3190,7 +3172,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3213,15 +3195,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -4430,19 +4403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_logger"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48047e77b528151aaf841a10a9025f9459da80ba820e425ff7eb005708a76dc7"
-dependencies = [
- "atty",
- "colored",
- "log 0.4.19",
- "time 0.3.25",
- "winapi",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4687,6 +4647,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4755,8 +4724,6 @@ checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
- "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,7 +26,7 @@ async-io = {git = "https://github.com/npmenard/async-io.git"}
 
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
 micro-rdk = { path = "../", features = ["native"], default-features = false }
-simple_logger = "2.3.0"
+env_logger = "0.10.0"
 local-ip-address = { version = "0.4.9" }
 log = "0.4"
 anyhow = { version = "1", features = ["backtrace"] }

--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -136,7 +136,7 @@ fn main() -> Result<(), ServerError> {
         RobotRepresentation::WithRobot(LocalRobot::new(res))
     };
     #[cfg(not(feature = "qemu"))]
-    let repr = RobotRepresentation::WithRegistry(ComponentRegistry::default());
+    let repr = RobotRepresentation::WithRegistry(Box::new(ComponentRegistry::default()));
 
     esp_idf_sys::esp!(unsafe {
         esp_idf_sys::esp_vfs_eventfd_register(&esp_idf_sys::esp_vfs_eventfd_config_t { max_fds: 5 })

--- a/examples/esp32/esp32-server.rs
+++ b/examples/esp32/esp32-server.rs
@@ -69,7 +69,7 @@ fn main() -> anyhow::Result<()> {
         RobotRepresentation::WithRobot(LocalRobot::new(res))
     };
     #[cfg(not(feature = "qemu"))]
-    let repr = RobotRepresentation::WithRegistry(ComponentRegistry::default());
+    let repr = RobotRepresentation::WithRegistry(Box::new(ComponentRegistry::default()));
 
     {
         esp_idf_sys::esp!(unsafe {

--- a/examples/native/native-server.rs
+++ b/examples/native/native-server.rs
@@ -19,10 +19,7 @@ use std::{
 };
 
 fn main() -> anyhow::Result<()> {
-    simple_logger::SimpleLogger::new()
-        .with_level(LevelFilter::Info)
-        .init()
-        .unwrap();
+    env_logger::init();
 
     let repr = {
         use micro_rdk::common::analog::FakeAnalogReader;

--- a/src/common/adxl345.rs
+++ b/src/common/adxl345.rs
@@ -2,6 +2,7 @@
 use crate::common::i2c::I2cHandleType;
 use crate::common::math_utils::Vector3;
 use crate::common::movement_sensor::{MovementSensor, MovementSensorSupportedMethods};
+use crate::google;
 
 use super::board::Board;
 use super::config::ConfigType;
@@ -10,7 +11,7 @@ use super::movement_sensor::MovementSensorType;
 use super::registry::{get_board_from_dependencies, ComponentRegistry, Dependency};
 use super::status::Status;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
@@ -145,9 +146,9 @@ impl MovementSensor for ADXL345 {
 }
 
 impl Status for ADXL345 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/base.rs
+++ b/src/common/base.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)]
 use crate::common::status::Status;
 use crate::common::stop::Stoppable;
+use crate::google;
 use crate::proto::common::v1::Vector3;
 use log::*;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub static COMPONENT_NAME: &str = "base";
@@ -54,14 +55,14 @@ impl Stoppable for FakeBase {
 }
 
 impl Status for FakeBase {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
-        bt.insert(
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
+        hm.insert(
             "is_moving".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::BoolValue(false)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::BoolValue(false)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }

--- a/src/common/encoder.rs
+++ b/src/common/encoder.rs
@@ -1,7 +1,8 @@
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use crate::google;
 use crate::proto::component::encoder::v1::GetPositionResponse;
 use crate::proto::component::encoder::v1::GetPropertiesResponse;
 use crate::proto::component::encoder::v1::PositionType;
@@ -168,9 +169,9 @@ impl Encoder for FakeIncrementalEncoder {
 }
 
 impl Status for FakeIncrementalEncoder {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }
@@ -228,9 +229,9 @@ impl Encoder for FakeEncoder {
 }
 
 impl Status for FakeEncoder {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/entry.rs
+++ b/src/common/entry.rs
@@ -3,5 +3,5 @@ use super::robot::LocalRobot;
 
 pub enum RobotRepresentation {
     WithRobot(LocalRobot),
-    WithRegistry(ComponentRegistry),
+    WithRegistry(Box<ComponentRegistry>),
 }

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -883,16 +883,20 @@ where
     R: GrpcResponse + 'static,
 {
     fn unary_rpc(&mut self, method: &str, data: &Bytes) -> Result<Bytes, GrpcError> {
-        {
-            let cap = RefCell::borrow(&self.buffer).capacity();
-            let len = RefCell::borrow(&self.buffer).len();
-            log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
-        }
-        debug!("webRTC");
+        // {
+        //     let cap = RefCell::borrow(&self.buffer).capacity();
+        //     let len = RefCell::borrow(&self.buffer).len();
+        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
+        // }
         {
             RefCell::borrow_mut(&self.buffer).reserve(GRPC_BUFFER_SIZE);
         }
-        log::debug!("req is {:?}, ", method);
+        // {
+        //     let cap = RefCell::borrow(&self.buffer).capacity();
+        //     let len = RefCell::borrow(&self.buffer).len();
+        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
+        // }
+        log::debug!("unary req is {:?}, ", method);
         self.handle_request(method, data)
             .map(|_| self.response.get_data().split_off(5))
     }
@@ -901,15 +905,15 @@ where
         method: &str,
         data: &Bytes,
     ) -> Result<(Bytes, Instant), GrpcError> {
-        {
-            let cap = RefCell::borrow(&self.buffer).capacity();
-            let len = RefCell::borrow(&self.buffer).len();
-            log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
-        }
-        debug!("webRTC");
+        // {
+        //     let cap = RefCell::borrow(&self.buffer).capacity();
+        //     let len = RefCell::borrow(&self.buffer).len();
+        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
+        // }
         {
             RefCell::borrow_mut(&self.buffer).reserve(GRPC_BUFFER_SIZE);
         }
+        log::debug!("stream req is {:?}, ", method);
         self.handle_rpc_stream(method, data)
             .map(|dur| (self.response.get_data().split_off(5), dur))
     }

--- a/src/common/grpc.rs
+++ b/src/common/grpc.rs
@@ -883,20 +883,9 @@ where
     R: GrpcResponse + 'static,
 {
     fn unary_rpc(&mut self, method: &str, data: &Bytes) -> Result<Bytes, GrpcError> {
-        // {
-        //     let cap = RefCell::borrow(&self.buffer).capacity();
-        //     let len = RefCell::borrow(&self.buffer).len();
-        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
-        // }
         {
             RefCell::borrow_mut(&self.buffer).reserve(GRPC_BUFFER_SIZE);
         }
-        // {
-        //     let cap = RefCell::borrow(&self.buffer).capacity();
-        //     let len = RefCell::borrow(&self.buffer).len();
-        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
-        // }
-        log::debug!("unary req is {:?}, ", method);
         self.handle_request(method, data)
             .map(|_| self.response.get_data().split_off(5))
     }
@@ -905,11 +894,6 @@ where
         method: &str,
         data: &Bytes,
     ) -> Result<(Bytes, Instant), GrpcError> {
-        // {
-        //     let cap = RefCell::borrow(&self.buffer).capacity();
-        //     let len = RefCell::borrow(&self.buffer).len();
-        //     log::debug!("current status of buffer is cap: {:?} len: {:?}", cap, len);
-        // }
         {
             RefCell::borrow_mut(&self.buffer).reserve(GRPC_BUFFER_SIZE);
         }

--- a/src/common/moisture_sensor.rs
+++ b/src/common/moisture_sensor.rs
@@ -5,8 +5,8 @@ use crate::common::sensor::SensorResult;
 use crate::common::sensor::SensorT;
 use crate::common::sensor::TypedReadingsResult;
 use crate::common::status::Status;
+use crate::google;
 use std::cell::RefCell;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -40,9 +40,9 @@ impl SensorT<f64> for MoistureSensor {
 }
 
 impl Status for MoistureSensor {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/motor.rs
+++ b/src/common/motor.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 use crate::common::status::Status;
+use crate::google;
 use log::*;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -255,22 +256,22 @@ impl Motor for FakeMotor {
     }
 }
 impl Status for FakeMotor {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
-        bt.insert(
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
+        hm.insert(
             "position".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(self.pos)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(self.pos)),
             },
         );
-        bt.insert(
+        hm.insert(
             "position_reporting".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::BoolValue(true)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::BoolValue(true)),
             },
         );
 
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 
@@ -336,9 +337,9 @@ impl Motor for FakeMotorWithDependency {
 }
 
 impl Status for FakeMotorWithDependency {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let bt = BTreeMap::new();
-        Ok(Some(prost_types::Struct { fields: bt }))
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let hm = HashMap::new();
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 

--- a/src/common/movement_sensor.rs
+++ b/src/common/movement_sensor.rs
@@ -3,10 +3,11 @@ use super::config::ConfigType;
 use super::math_utils::Vector3;
 use super::registry::{ComponentRegistry, Dependency};
 use super::status::Status;
+use crate::google;
 use crate::proto::common::v1::GeoPoint;
 use crate::proto::component::movement_sensor;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub static COMPONENT_NAME: &str = "movement_sensor";
@@ -170,9 +171,9 @@ impl MovementSensor for FakeMovementSensor {
 }
 
 impl Status for FakeMovementSensor {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/mpu6050.rs
+++ b/src/common/mpu6050.rs
@@ -2,6 +2,7 @@
 use crate::common::i2c::I2cHandleType;
 use crate::common::math_utils::Vector3;
 use crate::common::movement_sensor::{MovementSensor, MovementSensorSupportedMethods};
+use crate::google;
 
 use super::board::Board;
 use super::config::ConfigType;
@@ -10,7 +11,7 @@ use super::movement_sensor::MovementSensorType;
 use super::registry::{get_board_from_dependencies, ComponentRegistry, Dependency};
 use super::status::Status;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::mem::size_of;
 use std::sync::{Arc, Mutex};
 
@@ -167,9 +168,9 @@ impl MovementSensor for MPU6050 {
 }
 
 impl Status for MPU6050 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/registry.rs
+++ b/src/common/registry.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use std::collections::BTreeMap as Map;
+use std::collections::HashMap as Map;
 use thiserror::Error;
 
 use super::{
@@ -327,7 +327,7 @@ impl ComponentRegistry {
 
 #[cfg(test)]
 mod tests {
-    use prost_types::value::Kind;
+    use crate::google;
 
     use crate::common::{
         self,
@@ -339,7 +339,7 @@ mod tests {
         },
         status::Status,
     };
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
 
     lazy_static::lazy_static! {
@@ -381,9 +381,9 @@ mod tests {
     }
 
     impl Status for TestSensor {
-        fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-            Ok(Some(prost_types::Struct {
-                fields: BTreeMap::new(),
+        fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+            Ok(Some(google::protobuf::Struct {
+                fields: HashMap::new(),
             }))
         }
     }
@@ -456,8 +456,8 @@ mod tests {
             .clone();
         assert_eq!(
             r,
-            prost_types::Value {
-                kind: Some(Kind::NumberValue(42.0))
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(42.0))
             }
         );
 

--- a/src/common/registry.rs
+++ b/src/common/registry.rs
@@ -440,7 +440,7 @@ mod tests {
         assert!(ctor.is_ok());
 
         // make robot
-        let robot = LocalRobot::new_from_config_response(&cfg_resp, registry)?;
+        let robot = LocalRobot::new_from_config_response(&cfg_resp, Box::new(registry))?;
 
         // get test value from sensor
         let test_sensor = robot

--- a/src/common/robot.rs
+++ b/src/common/robot.rs
@@ -143,7 +143,7 @@ impl LocalRobot {
     // and added to the created robot.
     pub fn new_from_config_response(
         config_resp: &ConfigResponse,
-        registry: ComponentRegistry,
+        registry: Box<ComponentRegistry>,
     ) -> anyhow::Result<Self> {
         let mut robot = LocalRobot {
             resources: ResourceMap::new(),
@@ -195,7 +195,7 @@ impl LocalRobot {
         components: &mut Vec<&ComponentConfig>,
         board: Option<BoardType>,
         board_resource_key: Option<ResourceKey>,
-        registry: ComponentRegistry,
+        registry: Box<ComponentRegistry>,
     ) -> anyhow::Result<()> {
         let mut registry = registry;
         let mut inserted_resources = HashSet::<ResourceKey>::new();
@@ -594,7 +594,7 @@ impl LocalRobot {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::HashMap;
 
     use crate::common::board::Board;
     use crate::common::config::{Kind, RobotConfigStatic, StaticComponentConfig};
@@ -605,8 +605,9 @@ mod tests {
     use crate::common::registry::ComponentRegistry;
     use crate::common::robot::{LocalRobot, ResourceMap};
     use crate::common::sensor::Sensor;
+    use crate::google;
+    use crate::google::protobuf::Struct;
     use crate::proto::app::v1::ComponentConfig;
-    use prost_types::Struct;
 
     #[test_log::test]
     fn test_robot_from_static() {
@@ -771,7 +772,7 @@ mod tests {
         assert!(value.is_some());
 
         let value = match value {
-            Some(prost_types::value::Kind::NumberValue(a)) => Some(a),
+            Some(google::protobuf::value::Kind::NumberValue(a)) => Some(a),
             _ => None,
         };
 
@@ -874,10 +875,10 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "fake_deg".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::NumberValue(90.0)),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::NumberValue(90.0)),
                     },
                 )]),
             }),
@@ -894,10 +895,12 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "encoder".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("enc1".to_string())),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::StringValue(
+                            "enc1".to_string(),
+                        )),
                     },
                 )]),
             }),
@@ -914,10 +917,12 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "encoder".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("enc2".to_string())),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::StringValue(
+                            "enc2".to_string(),
+                        )),
                     },
                 )]),
             }),
@@ -934,10 +939,10 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "fake_deg".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::NumberValue(180.0)),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::NumberValue(180.0)),
                     },
                 )]),
             }),
@@ -992,10 +997,12 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "encoder".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("enc1".to_string())),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::StringValue(
+                            "enc1".to_string(),
+                        )),
                     },
                 )]),
             }),
@@ -1012,10 +1019,12 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "encoder".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::StringValue("enc2".to_string())),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::StringValue(
+                            "enc2".to_string(),
+                        )),
                     },
                 )]),
             }),
@@ -1032,10 +1041,10 @@ mod tests {
             service_configs: Vec::new(),
             api: "blah".to_string(),
             attributes: Some(Struct {
-                fields: BTreeMap::from([(
+                fields: HashMap::from([(
                     "fake_deg".to_string(),
-                    prost_types::Value {
-                        kind: Some(prost_types::value::Kind::NumberValue(180.0)),
+                    google::protobuf::Value {
+                        kind: Some(google::protobuf::value::Kind::NumberValue(180.0)),
                     },
                 )]),
             }),

--- a/src/common/robot.rs
+++ b/src/common/robot.rs
@@ -958,7 +958,7 @@ mod tests {
                 &mut component_cfgs,
                 None,
                 None,
-                ComponentRegistry::default()
+                Box::new(ComponentRegistry::default())
             )
             .is_ok());
 
@@ -1060,7 +1060,7 @@ mod tests {
                 &mut component_cfgs,
                 None,
                 None,
-                ComponentRegistry::default()
+                Box::new(ComponentRegistry::default())
             )
             .is_ok());
 

--- a/src/common/sensor.rs
+++ b/src/common/sensor.rs
@@ -1,7 +1,8 @@
 #![allow(dead_code)]
 
 use crate::common::status::Status;
-use std::collections::BTreeMap;
+use crate::google;
+
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -20,7 +21,7 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
 }
 
 pub type GenericReadingsResult =
-    ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>;
+    ::std::collections::HashMap<::prost::alloc::string::String, google::protobuf::Value>;
 
 pub type TypedReadingsResult<T> = ::std::collections::HashMap<String, T>;
 
@@ -34,15 +35,15 @@ pub trait SensorT<T>: Sensor {
     fn get_readings(&self) -> anyhow::Result<TypedReadingsResult<T>>;
 }
 
-// A local wrapper type we can use to specialize `From` for `prost_types::Value``
+// A local wrapper type we can use to specialize `From` for `google::protobuf::Value``
 pub struct SensorResult<T> {
     pub value: T,
 }
 
-impl From<SensorResult<f64>> for ::prost_types::Value {
-    fn from(value: SensorResult<f64>) -> ::prost_types::Value {
-        prost_types::Value {
-            kind: Some(::prost_types::value::Kind::NumberValue(value.value)),
+impl From<SensorResult<f64>> for google::protobuf::Value {
+    fn from(value: SensorResult<f64>) -> google::protobuf::Value {
+        google::protobuf::Value {
+            kind: Some(google::protobuf::value::Kind::NumberValue(value.value)),
         }
     }
 }
@@ -98,9 +99,9 @@ where
 }
 
 impl Status for FakeSensor {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/common/status.rs
+++ b/src/common/status.rs
@@ -1,14 +1,16 @@
 use std::sync::{Arc, Mutex};
 
+use crate::google;
+
 pub trait Status {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>>;
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>>;
 }
 
 impl<L> Status for Mutex<L>
 where
     L: ?Sized + Status,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
         self.lock().unwrap().get_status()
     }
 }
@@ -17,7 +19,7 @@ impl<A> Status for Arc<A>
 where
     A: ?Sized + Status,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
         (**self).get_status()
     }
 }

--- a/src/esp32/base.rs
+++ b/src/esp32/base.rs
@@ -6,8 +6,9 @@ use crate::common::registry::{ComponentRegistry, Dependency, ResourceKey};
 use crate::common::robot::Resource;
 use crate::common::status::Status;
 use crate::common::stop::Stoppable;
+use crate::google;
 use crate::proto::common::v1::Vector3;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
@@ -115,15 +116,15 @@ where
     ML: Motor,
     MR: Motor,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
-        bt.insert(
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
+        hm.insert(
             "is_moving".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::BoolValue(false)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::BoolValue(false)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 

--- a/src/esp32/encoder.rs
+++ b/src/esp32/encoder.rs
@@ -15,7 +15,7 @@ use espsys::pcnt_evt_type_t_PCNT_EVT_H_LIM as pcnt_evt_h_lim;
 use espsys::pcnt_evt_type_t_PCNT_EVT_L_LIM as pcnt_evt_l_lim;
 use espsys::{esp, EspError, ESP_OK};
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -25,6 +25,7 @@ use crate::common::encoder::{
 };
 use crate::common::registry::{ComponentRegistry, Dependency};
 use crate::common::status::Status;
+use crate::google;
 
 use embedded_hal::digital::v2::InputPin;
 
@@ -261,9 +262,9 @@ where
     A: InputPin + PinExt,
     B: InputPin + PinExt,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/esp32/motor.rs
+++ b/src/esp32/motor.rs
@@ -56,8 +56,10 @@ use crate::common::registry::{ComponentRegistry, Dependency, ResourceKey};
 use crate::common::robot::Resource;
 use crate::common::status::Status;
 use crate::common::stop::Stoppable;
+use crate::google;
+
 use log::*;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -178,19 +180,19 @@ where
     M: Motor,
     Enc: Encoder,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
         let pos = self
             .enc
             .get_position(EncoderPositionType::UNSPECIFIED)?
             .value as f64;
-        bt.insert(
+        hm.insert(
             "position".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(pos)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(pos)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 
@@ -309,16 +311,16 @@ where
     B: OutputPin + PinExt,
     PWM: PwmPin<Duty = u32>,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
         let pos = 0.0;
-        bt.insert(
+        hm.insert(
             "position".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(pos)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(pos)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 
@@ -426,16 +428,16 @@ where
     DIR: OutputPin + PinExt,
     PWM: PwmPin<Duty = u32>,
 {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
         let pos = 0.0;
-        bt.insert(
+        hm.insert(
             "position".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(pos)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(pos)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }
 

--- a/src/esp32/single_encoded_motor.rs
+++ b/src/esp32/single_encoded_motor.rs
@@ -3,11 +3,11 @@ use crate::common::encoder::{
     Direction, Encoder, EncoderPositionType, EncoderSupportedRepresentations, SingleEncoder,
 };
 use crate::common::motor::{Motor, MotorType};
-
 use crate::common::status::Status;
 use crate::common::stop::Stoppable;
+use crate::google;
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::time::Duration;
 
 pub struct SingleEncodedMotor {
@@ -74,18 +74,18 @@ impl Stoppable for SingleEncodedMotor {
 }
 
 impl Status for SingleEncodedMotor {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        let mut bt = BTreeMap::new();
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        let mut hm = HashMap::new();
         let pos = self
             .encoder
             .get_position(EncoderPositionType::UNSPECIFIED)?
             .value as f64;
-        bt.insert(
+        hm.insert(
             "position".to_string(),
-            prost_types::Value {
-                kind: Some(prost_types::value::Kind::NumberValue(pos)),
+            google::protobuf::Value {
+                kind: Some(google::protobuf::value::Kind::NumberValue(pos)),
             },
         );
-        Ok(Some(prost_types::Struct { fields: bt }))
+        Ok(Some(google::protobuf::Struct { fields: hm }))
     }
 }

--- a/src/esp32/single_encoder.rs
+++ b/src/esp32/single_encoder.rs
@@ -9,6 +9,7 @@ use crate::common::encoder::{
     EncoderType, SingleEncoder,
 };
 use crate::common::registry::{ComponentRegistry, Dependency};
+use crate::google;
 
 use core::ffi::{c_short, c_ulong};
 use esp_idf_hal::gpio::{AnyInputPin, PinDriver};
@@ -22,7 +23,7 @@ use espsys::pcnt_evt_type_t_PCNT_EVT_H_LIM as pcnt_evt_h_lim;
 use espsys::pcnt_evt_type_t_PCNT_EVT_L_LIM as pcnt_evt_l_lim;
 use espsys::{esp, EspError, ESP_OK};
 
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -331,9 +332,9 @@ impl SingleEncoder for Esp32SingleEncoder {
 }
 
 impl Status for Esp32SingleEncoder {
-    fn get_status(&self) -> anyhow::Result<Option<prost_types::Struct>> {
-        Ok(Some(prost_types::Struct {
-            fields: BTreeMap::new(),
+    fn get_status(&self) -> anyhow::Result<Option<google::protobuf::Struct>> {
+        Ok(Some(google::protobuf::Struct {
+            fields: HashMap::new(),
         }))
     }
 }

--- a/src/gen/google.api.expr.v1alpha1.rs
+++ b/src/gen/google.api.expr.v1alpha1.rs
@@ -278,7 +278,7 @@ pub mod constant {
 #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum ConstantKind {
         /// null value.
-        #[prost(enumeration="::prost_types::NullValue", tag="1")]
+        #[prost(enumeration="super::super::super::super::protobuf::NullValue", tag="1")]
         NullValue(i32),
         /// boolean value.
         #[prost(bool, tag="2")]
@@ -302,12 +302,12 @@ pub mod constant {
         ///
         /// Deprecated: duration is no longer considered a builtin cel type.
         #[prost(message, tag="8")]
-        DurationValue(::prost_types::Duration),
+        DurationValue(super::super::super::super::protobuf::Duration),
         /// protobuf.Timestamp value.
         ///
         /// Deprecated: timestamp is no longer considered a builtin cel type.
         #[prost(message, tag="9")]
-        TimestampValue(::prost_types::Timestamp),
+        TimestampValue(super::super::super::super::protobuf::Timestamp),
     }
 }
 /// Source information collected at parse time.
@@ -567,9 +567,9 @@ pub mod r#type {
     pub enum TypeKind {
         /// Dynamic type.
         #[prost(message, tag="1")]
-        Dyn(()),
+        Dyn(super::super::super::super::protobuf::Empty),
         /// Null value.
-        #[prost(enumeration="::prost_types::NullValue", tag="2")]
+        #[prost(enumeration="super::super::super::super::protobuf::NullValue", tag="2")]
         Null(i32),
         /// Primitive types: `true`, `1u`, `-2.0`, `'string'`, `b'bytes'`.
         #[prost(enumeration="PrimitiveType", tag="3")]
@@ -614,7 +614,7 @@ pub mod r#type {
         /// as the `ERROR` type. This permits the type-checker to discover other
         /// errors present in the expression.
         #[prost(message, tag="12")]
-        Error(()),
+        Error(super::super::super::super::protobuf::Empty),
         /// Abstract, application defined type.
         #[prost(message, tag="14")]
         AbstractType(AbstractType),
@@ -790,7 +790,7 @@ pub mod value {
 #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         /// Null value.
-        #[prost(enumeration="::prost_types::NullValue", tag="1")]
+        #[prost(enumeration="super::super::super::super::protobuf::NullValue", tag="1")]
         NullValue(i32),
         /// Boolean value.
         #[prost(bool, tag="2")]
@@ -815,7 +815,7 @@ pub mod value {
         EnumValue(super::EnumValue),
         /// The proto message backing an object value.
         #[prost(message, tag="10")]
-        ObjectValue(::prost_types::Any),
+        ObjectValue(super::super::super::super::protobuf::Any),
         /// Map value.
         #[prost(message, tag="11")]
         MapValue(super::MapValue),

--- a/src/gen/google.api.expr.v1beta1.rs
+++ b/src/gen/google.api.expr.v1beta1.rs
@@ -304,7 +304,7 @@ pub mod literal {
 #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum ConstantKind {
         /// null value.
-        #[prost(enumeration="::prost_types::NullValue", tag="1")]
+        #[prost(enumeration="super::super::super::super::protobuf::NullValue", tag="1")]
         NullValue(i32),
         /// boolean value.
         #[prost(bool, tag="2")]
@@ -418,7 +418,7 @@ pub mod value {
 #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         /// Null value.
-        #[prost(enumeration="::prost_types::NullValue", tag="1")]
+        #[prost(enumeration="super::super::super::super::protobuf::NullValue", tag="1")]
         NullValue(i32),
         /// Boolean value.
         #[prost(bool, tag="2")]
@@ -443,7 +443,7 @@ pub mod value {
         EnumValue(super::EnumValue),
         /// The proto message backing an object value.
         #[prost(message, tag="10")]
-        ObjectValue(::prost_types::Any),
+        ObjectValue(super::super::super::super::protobuf::Any),
         /// Map value.
         #[prost(message, tag="11")]
         MapValue(super::MapValue),

--- a/src/gen/google.api.rs
+++ b/src/gen/google.api.rs
@@ -710,7 +710,7 @@ pub mod method_settings {
         /// Initial delay after which the first poll request will be made.
         /// Default value: 5 seconds.
         #[prost(message, optional, tag="1")]
-        pub initial_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        pub initial_poll_delay: ::core::option::Option<super::super::protobuf::Duration>,
         /// Multiplier to gradually increase delay between subsequent polls until it
         /// reaches max_poll_delay.
         /// Default value: 1.5.
@@ -719,11 +719,11 @@ pub mod method_settings {
         /// Maximum time between two subsequent poll requests.
         /// Default value: 45 seconds.
         #[prost(message, optional, tag="3")]
-        pub max_poll_delay: ::core::option::Option<::prost_types::Duration>,
+        pub max_poll_delay: ::core::option::Option<super::super::protobuf::Duration>,
         /// Total polling timeout.
         /// Default value: 5 minutes.
         #[prost(message, optional, tag="4")]
-        pub total_poll_timeout: ::core::option::Option<::prost_types::Duration>,
+        pub total_poll_timeout: ::core::option::Option<super::super::protobuf::Duration>,
     }
 }
 /// The organization for which the client libraries are being published.
@@ -857,6 +857,19 @@ pub enum FieldBehavior {
     /// a non-empty value will be returned. The user will not be aware of what
     /// non-empty value to expect.
     NonEmptyDefault = 7,
+    /// Denotes that the field in a resource (a message annotated with
+    /// google.api.resource) is used in the resource name to uniquely identify the
+    /// resource. For AIP-compliant APIs, this should only be applied to the
+    /// `name` field on the resource.
+    ///
+    /// This behavior should not be applied to references to other resources within
+    /// the message.
+    ///
+    /// The identifier field of resources often have different field behavior
+    /// depending on the request it is embedded in (e.g. for Create methods name
+    /// is optional and unused, while for Update methods it is required). Instead
+    /// of method-specific annotations, only `IDENTIFIER` is required.
+    Identifier = 8,
 }
 impl FieldBehavior {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -873,6 +886,7 @@ impl FieldBehavior {
             FieldBehavior::Immutable => "IMMUTABLE",
             FieldBehavior::UnorderedList => "UNORDERED_LIST",
             FieldBehavior::NonEmptyDefault => "NON_EMPTY_DEFAULT",
+            FieldBehavior::Identifier => "IDENTIFIER",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -886,6 +900,7 @@ impl FieldBehavior {
             "IMMUTABLE" => Some(Self::Immutable),
             "UNORDERED_LIST" => Some(Self::UnorderedList),
             "NON_EMPTY_DEFAULT" => Some(Self::NonEmptyDefault),
+            "IDENTIFIER" => Some(Self::Identifier),
             _ => None,
         }
     }
@@ -945,7 +960,7 @@ pub struct HttpBody {
     /// Application specific response metadata. Must be set in the first response
     /// for streaming APIs.
     #[prost(message, repeated, tag="3")]
-    pub extensions: ::prost::alloc::vec::Vec<::prost_types::Any>,
+    pub extensions: ::prost::alloc::vec::Vec<super::protobuf::Any>,
 }
 /// A simple descriptor of a resource type.
 ///

--- a/src/gen/google.protobuf.compiler.rs
+++ b/src/gen/google.protobuf.compiler.rs
@@ -1,0 +1,178 @@
+// @generated
+/// The version number of protocol compiler.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Version {
+    #[prost(int32, optional, tag="1")]
+    pub major: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag="2")]
+    pub minor: ::core::option::Option<i32>,
+    #[prost(int32, optional, tag="3")]
+    pub patch: ::core::option::Option<i32>,
+    /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
+    /// be empty for mainline stable releases.
+    #[prost(string, optional, tag="4")]
+    pub suffix: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// An encoded CodeGeneratorRequest is written to the plugin's stdin.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CodeGeneratorRequest {
+    /// The .proto files that were explicitly listed on the command-line.  The
+    /// code generator should generate code only for these files.  Each file's
+    /// descriptor will be included in proto_file, below.
+    #[prost(string, repeated, tag="1")]
+    pub file_to_generate: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The generator parameter passed on the command-line.
+    #[prost(string, optional, tag="2")]
+    pub parameter: ::core::option::Option<::prost::alloc::string::String>,
+    /// FileDescriptorProtos for all files in files_to_generate and everything
+    /// they import.  The files will appear in topological order, so each file
+    /// appears before any file that imports it.
+    ///
+    /// Note: the files listed in files_to_generate will include runtime-retention
+    /// options only, but all other files will include source-retention options.
+    /// The source_file_descriptors field below is available in case you need
+    /// source-retention options for files_to_generate.
+    ///
+    /// protoc guarantees that all proto_files will be written after
+    /// the fields above, even though this is not technically guaranteed by the
+    /// protobuf wire format.  This theoretically could allow a plugin to stream
+    /// in the FileDescriptorProtos and handle them one by one rather than read
+    /// the entire set into memory at once.  However, as of this writing, this
+    /// is not similarly optimized on protoc's end -- it will store all fields in
+    /// memory at once before sending them to the plugin.
+    ///
+    /// Type names of fields and extensions in the FileDescriptorProto are always
+    /// fully qualified.
+    #[prost(message, repeated, tag="15")]
+    pub proto_file: ::prost::alloc::vec::Vec<super::FileDescriptorProto>,
+    /// File descriptors with all options, including source-retention options.
+    /// These descriptors are only provided for the files listed in
+    /// files_to_generate.
+    #[prost(message, repeated, tag="17")]
+    pub source_file_descriptors: ::prost::alloc::vec::Vec<super::FileDescriptorProto>,
+    /// The version number of protocol compiler.
+    #[prost(message, optional, tag="3")]
+    pub compiler_version: ::core::option::Option<Version>,
+}
+/// The plugin writes an encoded CodeGeneratorResponse to stdout.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CodeGeneratorResponse {
+    /// Error message.  If non-empty, code generation failed.  The plugin process
+    /// should exit with status code zero even if it reports an error in this way.
+    ///
+    /// This should be used to indicate errors in .proto files which prevent the
+    /// code generator from generating correct code.  Errors which indicate a
+    /// problem in protoc itself -- such as the input CodeGeneratorRequest being
+    /// unparseable -- should be reported by writing a message to stderr and
+    /// exiting with a non-zero status code.
+    #[prost(string, optional, tag="1")]
+    pub error: ::core::option::Option<::prost::alloc::string::String>,
+    /// A bitmask of supported features that the code generator supports.
+    /// This is a bitwise "or" of values from the Feature enum.
+    #[prost(uint64, optional, tag="2")]
+    pub supported_features: ::core::option::Option<u64>,
+    #[prost(message, repeated, tag="15")]
+    pub file: ::prost::alloc::vec::Vec<code_generator_response::File>,
+}
+/// Nested message and enum types in `CodeGeneratorResponse`.
+pub mod code_generator_response {
+    /// Represents a single generated file.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct File {
+        /// The file name, relative to the output directory.  The name must not
+        /// contain "." or ".." components and must be relative, not be absolute (so,
+        /// the file cannot lie outside the output directory).  "/" must be used as
+        /// the path separator, not "\".
+        ///
+        /// If the name is omitted, the content will be appended to the previous
+        /// file.  This allows the generator to break large files into small chunks,
+        /// and allows the generated text to be streamed back to protoc so that large
+        /// files need not reside completely in memory at one time.  Note that as of
+        /// this writing protoc does not optimize for this -- it will read the entire
+        /// CodeGeneratorResponse before writing files to disk.
+        #[prost(string, optional, tag="1")]
+        pub name: ::core::option::Option<::prost::alloc::string::String>,
+        /// If non-empty, indicates that the named file should already exist, and the
+        /// content here is to be inserted into that file at a defined insertion
+        /// point.  This feature allows a code generator to extend the output
+        /// produced by another code generator.  The original generator may provide
+        /// insertion points by placing special annotations in the file that look
+        /// like:
+        ///    @@protoc_insertion_point(NAME)
+        /// The annotation can have arbitrary text before and after it on the line,
+        /// which allows it to be placed in a comment.  NAME should be replaced with
+        /// an identifier naming the point -- this is what other generators will use
+        /// as the insertion_point.  Code inserted at this point will be placed
+        /// immediately above the line containing the insertion point (thus multiple
+        /// insertions to the same point will come out in the order they were added).
+        /// The double-@ is intended to make it unlikely that the generated code
+        /// could contain things that look like insertion points by accident.
+        ///
+        /// For example, the C++ code generator places the following line in the
+        /// .pb.h files that it generates:
+        ///    // @@protoc_insertion_point(namespace_scope)
+        /// This line appears within the scope of the file's package namespace, but
+        /// outside of any particular class.  Another plugin can then specify the
+        /// insertion_point "namespace_scope" to generate additional classes or
+        /// other declarations that should be placed in this scope.
+        ///
+        /// Note that if the line containing the insertion point begins with
+        /// whitespace, the same whitespace will be added to every line of the
+        /// inserted text.  This is useful for languages like Python, where
+        /// indentation matters.  In these languages, the insertion point comment
+        /// should be indented the same amount as any inserted code will need to be
+        /// in order to work correctly in that context.
+        ///
+        /// The code generator that generates the initial file and the one which
+        /// inserts into it must both run as part of a single invocation of protoc.
+        /// Code generators are executed in the order in which they appear on the
+        /// command line.
+        ///
+        /// If |insertion_point| is present, |name| must also be present.
+        #[prost(string, optional, tag="2")]
+        pub insertion_point: ::core::option::Option<::prost::alloc::string::String>,
+        /// The file contents.
+        #[prost(string, optional, tag="15")]
+        pub content: ::core::option::Option<::prost::alloc::string::String>,
+        /// Information describing the file content being inserted. If an insertion
+        /// point is used, this information will be appropriately offset and inserted
+        /// into the code generation metadata for the generated files.
+        #[prost(message, optional, tag="16")]
+        pub generated_code_info: ::core::option::Option<super::super::GeneratedCodeInfo>,
+    }
+    /// Sync with code_generator.h.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Feature {
+        None = 0,
+        Proto3Optional = 1,
+        SupportsEditions = 2,
+    }
+    impl Feature {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Feature::None => "FEATURE_NONE",
+                Feature::Proto3Optional => "FEATURE_PROTO3_OPTIONAL",
+                Feature::SupportsEditions => "FEATURE_SUPPORTS_EDITIONS",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "FEATURE_NONE" => Some(Self::None),
+                "FEATURE_PROTO3_OPTIONAL" => Some(Self::Proto3Optional),
+                "FEATURE_SUPPORTS_EDITIONS" => Some(Self::SupportsEditions),
+                _ => None,
+            }
+        }
+    }
+}
+// @@protoc_insertion_point(module)

--- a/src/gen/google.protobuf.rs
+++ b/src/gen/google.protobuf.rs
@@ -1,0 +1,2772 @@
+// @generated
+/// `Any` contains an arbitrary serialized protocol buffer message along with a
+/// URL that describes the type of the serialized message.
+///
+/// Protobuf library provides support to pack/unpack Any values in the form
+/// of utility functions or additional generated methods of the Any type.
+///
+/// Example 1: Pack and unpack a message in C++.
+///
+///      Foo foo = ...;
+///      Any any;
+///      any.PackFrom(foo);
+///      ...
+///      if (any.UnpackTo(&foo)) {
+///        ...
+///      }
+///
+/// Example 2: Pack and unpack a message in Java.
+///
+///      Foo foo = ...;
+///      Any any = Any.pack(foo);
+///      ...
+///      if (any.is(Foo.class)) {
+///        foo = any.unpack(Foo.class);
+///      }
+///      // or ...
+///      if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+///        foo = any.unpack(Foo.getDefaultInstance());
+///      }
+///
+///   Example 3: Pack and unpack a message in Python.
+///
+///      foo = Foo(...)
+///      any = Any()
+///      any.Pack(foo)
+///      ...
+///      if any.Is(Foo.DESCRIPTOR):
+///        any.Unpack(foo)
+///        ...
+///
+///   Example 4: Pack and unpack a message in Go
+///
+///       foo := &pb.Foo{...}
+///       any, err := anypb.New(foo)
+///       if err != nil {
+///         ...
+///       }
+///       ...
+///       foo := &pb.Foo{}
+///       if err := any.UnmarshalTo(foo); err != nil {
+///         ...
+///       }
+///
+/// The pack methods provided by protobuf library will by default use
+/// 'type.googleapis.com/full.type.name' as the type URL and the unpack
+/// methods only use the fully qualified type name after the last '/'
+/// in the type URL, for example "foo.bar.com/x/y.z" will yield type
+/// name "y.z".
+///
+/// JSON
+/// ====
+/// The JSON representation of an `Any` value uses the regular
+/// representation of the deserialized, embedded message, with an
+/// additional field `@type` which contains the type URL. Example:
+///
+///      package google.profile;
+///      message Person {
+///        string first_name = 1;
+///        string last_name = 2;
+///      }
+///
+///      {
+///        "@type": "type.googleapis.com/google.profile.Person",
+///        "firstName": <string>,
+///        "lastName": <string>
+///      }
+///
+/// If the embedded message type is well-known and has a custom JSON
+/// representation, that representation will be embedded adding a field
+/// `value` which holds the custom JSON in addition to the `@type`
+/// field. Example (for message \[google.protobuf.Duration][\]):
+///
+///      {
+///        "@type": "type.googleapis.com/google.protobuf.Duration",
+///        "value": "1.212s"
+///      }
+///
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Any {
+    /// A URL/resource name that uniquely identifies the type of the serialized
+    /// protocol buffer message. This string must contain at least
+    /// one "/" character. The last segment of the URL's path must represent
+    /// the fully qualified name of the type (as in
+    /// `path/google.protobuf.Duration`). The name should be in a canonical form
+    /// (e.g., leading "." is not accepted).
+    ///
+    /// In practice, teams usually precompile into the binary all types that they
+    /// expect it to use in the context of Any. However, for URLs which use the
+    /// scheme `http`, `https`, or no scheme, one can optionally set up a type
+    /// server that maps type URLs to message definitions as follows:
+    ///
+    /// * If no scheme is provided, `https` is assumed.
+    /// * An HTTP GET on the URL must yield a \[google.protobuf.Type][\]
+    ///    value in binary format, or produce an error.
+    /// * Applications are allowed to cache lookup results based on the
+    ///    URL, or have them precompiled into a binary to avoid any
+    ///    lookup. Therefore, binary compatibility needs to be preserved
+    ///    on changes to types. (Use versioned type names to manage
+    ///    breaking changes.)
+    ///
+    /// Note: this functionality is not currently available in the official
+    /// protobuf release, and it is not used for type URLs beginning with
+    /// type.googleapis.com. As of May 2023, there are no widely used type server
+    /// implementations and no plans to implement one.
+    ///
+    /// Schemes other than `http`, `https` (or the empty scheme) might be
+    /// used with implementation specific semantics.
+    ///
+    #[prost(string, tag="1")]
+    pub type_url: ::prost::alloc::string::String,
+    /// Must be a valid serialized protocol buffer of the above specified type.
+    #[prost(bytes="vec", tag="2")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+/// `SourceContext` represents information about the source of a
+/// protobuf element, like the file in which it is defined.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SourceContext {
+    /// The path-qualified name of the .proto file that contained the associated
+    /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
+    #[prost(string, tag="1")]
+    pub file_name: ::prost::alloc::string::String,
+}
+/// A protocol buffer message type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Type {
+    /// The fully qualified message name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The list of fields.
+    #[prost(message, repeated, tag="2")]
+    pub fields: ::prost::alloc::vec::Vec<Field>,
+    /// The list of types appearing in `oneof` definitions in this type.
+    #[prost(string, repeated, tag="3")]
+    pub oneofs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The protocol buffer options.
+    #[prost(message, repeated, tag="4")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source context.
+    #[prost(message, optional, tag="5")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// The source syntax.
+    #[prost(enumeration="Syntax", tag="6")]
+    pub syntax: i32,
+    /// The source edition string, only valid when syntax is SYNTAX_EDITIONS.
+    #[prost(string, tag="7")]
+    pub edition: ::prost::alloc::string::String,
+}
+/// A single field of a message type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Field {
+    /// The field type.
+    #[prost(enumeration="field::Kind", tag="1")]
+    pub kind: i32,
+    /// The field cardinality.
+    #[prost(enumeration="field::Cardinality", tag="2")]
+    pub cardinality: i32,
+    /// The field number.
+    #[prost(int32, tag="3")]
+    pub number: i32,
+    /// The field name.
+    #[prost(string, tag="4")]
+    pub name: ::prost::alloc::string::String,
+    /// The field type URL, without the scheme, for message or enumeration
+    /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
+    #[prost(string, tag="6")]
+    pub type_url: ::prost::alloc::string::String,
+    /// The index of the field type in `Type.oneofs`, for message or enumeration
+    /// types. The first type has index 1; zero means the type is not in the list.
+    #[prost(int32, tag="7")]
+    pub oneof_index: i32,
+    /// Whether to use alternative packed wire representation.
+    #[prost(bool, tag="8")]
+    pub packed: bool,
+    /// The protocol buffer options.
+    #[prost(message, repeated, tag="9")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The field JSON name.
+    #[prost(string, tag="10")]
+    pub json_name: ::prost::alloc::string::String,
+    /// The string value of the default value of this field. Proto2 syntax only.
+    #[prost(string, tag="11")]
+    pub default_value: ::prost::alloc::string::String,
+}
+/// Nested message and enum types in `Field`.
+pub mod field {
+    /// Basic field types.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Kind {
+        /// Field type unknown.
+        TypeUnknown = 0,
+        /// Field type double.
+        TypeDouble = 1,
+        /// Field type float.
+        TypeFloat = 2,
+        /// Field type int64.
+        TypeInt64 = 3,
+        /// Field type uint64.
+        TypeUint64 = 4,
+        /// Field type int32.
+        TypeInt32 = 5,
+        /// Field type fixed64.
+        TypeFixed64 = 6,
+        /// Field type fixed32.
+        TypeFixed32 = 7,
+        /// Field type bool.
+        TypeBool = 8,
+        /// Field type string.
+        TypeString = 9,
+        /// Field type group. Proto2 syntax only, and deprecated.
+        TypeGroup = 10,
+        /// Field type message.
+        TypeMessage = 11,
+        /// Field type bytes.
+        TypeBytes = 12,
+        /// Field type uint32.
+        TypeUint32 = 13,
+        /// Field type enum.
+        TypeEnum = 14,
+        /// Field type sfixed32.
+        TypeSfixed32 = 15,
+        /// Field type sfixed64.
+        TypeSfixed64 = 16,
+        /// Field type sint32.
+        TypeSint32 = 17,
+        /// Field type sint64.
+        TypeSint64 = 18,
+    }
+    impl Kind {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Kind::TypeUnknown => "TYPE_UNKNOWN",
+                Kind::TypeDouble => "TYPE_DOUBLE",
+                Kind::TypeFloat => "TYPE_FLOAT",
+                Kind::TypeInt64 => "TYPE_INT64",
+                Kind::TypeUint64 => "TYPE_UINT64",
+                Kind::TypeInt32 => "TYPE_INT32",
+                Kind::TypeFixed64 => "TYPE_FIXED64",
+                Kind::TypeFixed32 => "TYPE_FIXED32",
+                Kind::TypeBool => "TYPE_BOOL",
+                Kind::TypeString => "TYPE_STRING",
+                Kind::TypeGroup => "TYPE_GROUP",
+                Kind::TypeMessage => "TYPE_MESSAGE",
+                Kind::TypeBytes => "TYPE_BYTES",
+                Kind::TypeUint32 => "TYPE_UINT32",
+                Kind::TypeEnum => "TYPE_ENUM",
+                Kind::TypeSfixed32 => "TYPE_SFIXED32",
+                Kind::TypeSfixed64 => "TYPE_SFIXED64",
+                Kind::TypeSint32 => "TYPE_SINT32",
+                Kind::TypeSint64 => "TYPE_SINT64",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TYPE_UNKNOWN" => Some(Self::TypeUnknown),
+                "TYPE_DOUBLE" => Some(Self::TypeDouble),
+                "TYPE_FLOAT" => Some(Self::TypeFloat),
+                "TYPE_INT64" => Some(Self::TypeInt64),
+                "TYPE_UINT64" => Some(Self::TypeUint64),
+                "TYPE_INT32" => Some(Self::TypeInt32),
+                "TYPE_FIXED64" => Some(Self::TypeFixed64),
+                "TYPE_FIXED32" => Some(Self::TypeFixed32),
+                "TYPE_BOOL" => Some(Self::TypeBool),
+                "TYPE_STRING" => Some(Self::TypeString),
+                "TYPE_GROUP" => Some(Self::TypeGroup),
+                "TYPE_MESSAGE" => Some(Self::TypeMessage),
+                "TYPE_BYTES" => Some(Self::TypeBytes),
+                "TYPE_UINT32" => Some(Self::TypeUint32),
+                "TYPE_ENUM" => Some(Self::TypeEnum),
+                "TYPE_SFIXED32" => Some(Self::TypeSfixed32),
+                "TYPE_SFIXED64" => Some(Self::TypeSfixed64),
+                "TYPE_SINT32" => Some(Self::TypeSint32),
+                "TYPE_SINT64" => Some(Self::TypeSint64),
+                _ => None,
+            }
+        }
+    }
+    /// Whether a field is optional, required, or repeated.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Cardinality {
+        /// For fields with unknown cardinality.
+        Unknown = 0,
+        /// For optional fields.
+        Optional = 1,
+        /// For required fields. Proto2 syntax only.
+        Required = 2,
+        /// For repeated fields.
+        Repeated = 3,
+    }
+    impl Cardinality {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Cardinality::Unknown => "CARDINALITY_UNKNOWN",
+                Cardinality::Optional => "CARDINALITY_OPTIONAL",
+                Cardinality::Required => "CARDINALITY_REQUIRED",
+                Cardinality::Repeated => "CARDINALITY_REPEATED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "CARDINALITY_UNKNOWN" => Some(Self::Unknown),
+                "CARDINALITY_OPTIONAL" => Some(Self::Optional),
+                "CARDINALITY_REQUIRED" => Some(Self::Required),
+                "CARDINALITY_REPEATED" => Some(Self::Repeated),
+                _ => None,
+            }
+        }
+    }
+}
+/// Enum type definition.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Enum {
+    /// Enum type name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Enum value definitions.
+    #[prost(message, repeated, tag="2")]
+    pub enumvalue: ::prost::alloc::vec::Vec<EnumValue>,
+    /// Protocol buffer options.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source context.
+    #[prost(message, optional, tag="4")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// The source syntax.
+    #[prost(enumeration="Syntax", tag="5")]
+    pub syntax: i32,
+    /// The source edition string, only valid when syntax is SYNTAX_EDITIONS.
+    #[prost(string, tag="6")]
+    pub edition: ::prost::alloc::string::String,
+}
+/// Enum value definition.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValue {
+    /// Enum value name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Enum value number.
+    #[prost(int32, tag="2")]
+    pub number: i32,
+    /// Protocol buffer options.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+}
+/// A protocol buffer option, which can be attached to a message, field,
+/// enumeration, etc.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Option {
+    /// The option's name. For protobuf built-in options (options defined in
+    /// descriptor.proto), this is the short name. For example, `"map_entry"`.
+    /// For custom options, it should be the fully-qualified name. For example,
+    /// `"google.api.http"`.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The option's value packed in an Any message. If the value is a primitive,
+    /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
+    /// should be used. If the value is an enum, it should be stored as an int32
+    /// value using the google.protobuf.Int32Value type.
+    #[prost(message, optional, tag="2")]
+    pub value: ::core::option::Option<Any>,
+}
+/// The syntax in which a protocol buffer element is defined.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Syntax {
+    /// Syntax `proto2`.
+    Proto2 = 0,
+    /// Syntax `proto3`.
+    Proto3 = 1,
+    /// Syntax `editions`.
+    Editions = 2,
+}
+impl Syntax {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Syntax::Proto2 => "SYNTAX_PROTO2",
+            Syntax::Proto3 => "SYNTAX_PROTO3",
+            Syntax::Editions => "SYNTAX_EDITIONS",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SYNTAX_PROTO2" => Some(Self::Proto2),
+            "SYNTAX_PROTO3" => Some(Self::Proto3),
+            "SYNTAX_EDITIONS" => Some(Self::Editions),
+            _ => None,
+        }
+    }
+}
+/// Api is a light-weight descriptor for an API Interface.
+///
+/// Interfaces are also described as "protocol buffer services" in some contexts,
+/// such as by the "service" keyword in a .proto file, but they are different
+/// from API Services, which represent a concrete implementation of an interface
+/// as opposed to simply a description of methods and bindings. They are also
+/// sometimes simply referred to as "APIs" in other contexts, such as the name of
+/// this message itself. See <https://cloud.google.com/apis/design/glossary> for
+/// detailed terminology.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Api {
+    /// The fully qualified name of this interface, including package name
+    /// followed by the interface's simple name.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// The methods of this interface, in unspecified order.
+    #[prost(message, repeated, tag="2")]
+    pub methods: ::prost::alloc::vec::Vec<Method>,
+    /// Any metadata attached to the interface.
+    #[prost(message, repeated, tag="3")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// A version string for this interface. If specified, must have the form
+    /// `major-version.minor-version`, as in `1.10`. If the minor version is
+    /// omitted, it defaults to zero. If the entire version field is empty, the
+    /// major version is derived from the package name, as outlined below. If the
+    /// field is not empty, the version in the package name will be verified to be
+    /// consistent with what is provided here.
+    ///
+    /// The versioning schema uses [semantic
+    /// versioning](<http://semver.org>) where the major version number
+    /// indicates a breaking change and the minor version an additive,
+    /// non-breaking change. Both version numbers are signals to users
+    /// what to expect from different versions, and should be carefully
+    /// chosen based on the product plan.
+    ///
+    /// The major version is also reflected in the package name of the
+    /// interface, which must end in `v<major-version>`, as in
+    /// `google.feature.v1`. For major versions 0 and 1, the suffix can
+    /// be omitted. Zero major versions must only be used for
+    /// experimental, non-GA interfaces.
+    ///
+    #[prost(string, tag="4")]
+    pub version: ::prost::alloc::string::String,
+    /// Source context for the protocol buffer service represented by this
+    /// message.
+    #[prost(message, optional, tag="5")]
+    pub source_context: ::core::option::Option<SourceContext>,
+    /// Included interfaces. See \[Mixin][\].
+    #[prost(message, repeated, tag="6")]
+    pub mixins: ::prost::alloc::vec::Vec<Mixin>,
+    /// The source syntax of the service.
+    #[prost(enumeration="Syntax", tag="7")]
+    pub syntax: i32,
+}
+/// Method represents a method of an API interface.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Method {
+    /// The simple name of this method.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// A URL of the input message type.
+    #[prost(string, tag="2")]
+    pub request_type_url: ::prost::alloc::string::String,
+    /// If true, the request is streamed.
+    #[prost(bool, tag="3")]
+    pub request_streaming: bool,
+    /// The URL of the output message type.
+    #[prost(string, tag="4")]
+    pub response_type_url: ::prost::alloc::string::String,
+    /// If true, the response is streamed.
+    #[prost(bool, tag="5")]
+    pub response_streaming: bool,
+    /// Any metadata attached to the method.
+    #[prost(message, repeated, tag="6")]
+    pub options: ::prost::alloc::vec::Vec<Option>,
+    /// The source syntax of this method.
+    #[prost(enumeration="Syntax", tag="7")]
+    pub syntax: i32,
+}
+/// Declares an API Interface to be included in this interface. The including
+/// interface must redeclare all the methods from the included interface, but
+/// documentation and options are inherited as follows:
+///
+/// - If after comment and whitespace stripping, the documentation
+///    string of the redeclared method is empty, it will be inherited
+///    from the original method.
+///
+/// - Each annotation belonging to the service config (http,
+///    visibility) which is not set in the redeclared method will be
+///    inherited.
+///
+/// - If an http annotation is inherited, the path pattern will be
+///    modified as follows. Any version prefix will be replaced by the
+///    version of the including interface plus the \[root][\] path if
+///    specified.
+///
+/// Example of a simple mixin:
+///
+///      package google.acl.v1;
+///      service AccessControl {
+///        // Get the underlying ACL object.
+///        rpc GetAcl(GetAclRequest) returns (Acl) {
+///          option (google.api.http).get = "/v1/{resource=**}:getAcl";
+///        }
+///      }
+///
+///      package google.storage.v2;
+///      service Storage {
+///        rpc GetAcl(GetAclRequest) returns (Acl);
+///
+///        // Get a data record.
+///        rpc GetData(GetDataRequest) returns (Data) {
+///          option (google.api.http).get = "/v2/{resource=**}";
+///        }
+///      }
+///
+/// Example of a mixin configuration:
+///
+///      apis:
+///      - name: google.storage.v2.Storage
+///        mixins:
+///        - name: google.acl.v1.AccessControl
+///
+/// The mixin construct implies that all methods in `AccessControl` are
+/// also declared with same name and request/response types in
+/// `Storage`. A documentation generator or annotation processor will
+/// see the effective `Storage.GetAcl` method after inherting
+/// documentation and annotations as follows:
+///
+///      service Storage {
+///        // Get the underlying ACL object.
+///        rpc GetAcl(GetAclRequest) returns (Acl) {
+///          option (google.api.http).get = "/v2/{resource=**}:getAcl";
+///        }
+///        ...
+///      }
+///
+/// Note how the version in the path pattern changed from `v1` to `v2`.
+///
+/// If the `root` field in the mixin is specified, it should be a
+/// relative path under which inherited HTTP paths are placed. Example:
+///
+///      apis:
+///      - name: google.storage.v2.Storage
+///        mixins:
+///        - name: google.acl.v1.AccessControl
+///          root: acls
+///
+/// This implies the following inherited HTTP annotation:
+///
+///      service Storage {
+///        // Get the underlying ACL object.
+///        rpc GetAcl(GetAclRequest) returns (Acl) {
+///          option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
+///        }
+///        ...
+///      }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Mixin {
+    /// The fully qualified name of the interface which is included.
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// If non-empty specifies a path under which inherited HTTP paths
+    /// are rooted.
+    #[prost(string, tag="2")]
+    pub root: ::prost::alloc::string::String,
+}
+/// The protocol compiler can output a FileDescriptorSet containing the .proto
+/// files it parses.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorSet {
+    #[prost(message, repeated, tag="1")]
+    pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
+}
+/// Describes a complete .proto file.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileDescriptorProto {
+    /// file name, relative to root of source tree
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    /// e.g. "foo", "foo.bar", etc.
+    #[prost(string, optional, tag="2")]
+    pub package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Names of files imported by this file.
+    #[prost(string, repeated, tag="3")]
+    pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Indexes of the public imported files in the dependency list above.
+    #[prost(int32, repeated, packed="false", tag="10")]
+    pub public_dependency: ::prost::alloc::vec::Vec<i32>,
+    /// Indexes of the weak imported files in the dependency list.
+    /// For Google-internal migration only. Do not use.
+    #[prost(int32, repeated, packed="false", tag="11")]
+    pub weak_dependency: ::prost::alloc::vec::Vec<i32>,
+    /// All top-level definitions in this file.
+    #[prost(message, repeated, tag="4")]
+    pub message_type: ::prost::alloc::vec::Vec<DescriptorProto>,
+    #[prost(message, repeated, tag="5")]
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
+    #[prost(message, repeated, tag="6")]
+    pub service: ::prost::alloc::vec::Vec<ServiceDescriptorProto>,
+    #[prost(message, repeated, tag="7")]
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, optional, tag="8")]
+    pub options: ::core::option::Option<FileOptions>,
+    /// This field contains optional information about the original source code.
+    /// You may safely remove this entire field without harming runtime
+    /// functionality of the descriptors -- the information is needed only by
+    /// development tools.
+    #[prost(message, optional, tag="9")]
+    pub source_code_info: ::core::option::Option<SourceCodeInfo>,
+    /// The syntax of the proto file.
+    /// The supported values are "proto2", "proto3", and "editions".
+    ///
+    /// If `edition` is present, this value must be "editions".
+    #[prost(string, optional, tag="12")]
+    pub syntax: ::core::option::Option<::prost::alloc::string::String>,
+    /// The edition of the proto file, which is an opaque string.
+    #[prost(string, optional, tag="13")]
+    pub edition: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Describes a message type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, repeated, tag="6")]
+    pub extension: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
+    #[prost(message, repeated, tag="3")]
+    pub nested_type: ::prost::alloc::vec::Vec<DescriptorProto>,
+    #[prost(message, repeated, tag="4")]
+    pub enum_type: ::prost::alloc::vec::Vec<EnumDescriptorProto>,
+    #[prost(message, repeated, tag="5")]
+    pub extension_range: ::prost::alloc::vec::Vec<descriptor_proto::ExtensionRange>,
+    #[prost(message, repeated, tag="8")]
+    pub oneof_decl: ::prost::alloc::vec::Vec<OneofDescriptorProto>,
+    #[prost(message, optional, tag="7")]
+    pub options: ::core::option::Option<MessageOptions>,
+    #[prost(message, repeated, tag="9")]
+    pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
+    /// Reserved field names, which may not be used by fields in the same message.
+    /// A given name may only be reserved once.
+    #[prost(string, repeated, tag="10")]
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `DescriptorProto`.
+pub mod descriptor_proto {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ExtensionRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Exclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+        #[prost(message, optional, tag="3")]
+        pub options: ::core::option::Option<super::ExtensionRangeOptions>,
+    }
+    /// Range of reserved tag numbers. Reserved tag numbers may not be used by
+    /// fields or extension ranges in the same message. Reserved ranges may
+    /// not overlap.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct ReservedRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Exclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExtensionRangeOptions {
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+    /// For external users: DO NOT USE. We are in the process of open sourcing
+    /// extension declaration and executing internal cleanups before it can be
+    /// used externally.
+    #[prost(message, repeated, tag="2")]
+    pub declaration: ::prost::alloc::vec::Vec<extension_range_options::Declaration>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="50")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The verification state of the range.
+    /// TODO(b/278783756): flip the default to DECLARATION once all empty ranges
+    /// are marked as UNVERIFIED.
+    #[prost(enumeration="extension_range_options::VerificationState", optional, tag="3", default="Unverified")]
+    pub verification: ::core::option::Option<i32>,
+}
+/// Nested message and enum types in `ExtensionRangeOptions`.
+pub mod extension_range_options {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Declaration {
+        /// The extension number declared within the extension range.
+        #[prost(int32, optional, tag="1")]
+        pub number: ::core::option::Option<i32>,
+        /// The fully-qualified name of the extension field. There must be a leading
+        /// dot in front of the full name.
+        #[prost(string, optional, tag="2")]
+        pub full_name: ::core::option::Option<::prost::alloc::string::String>,
+        /// The fully-qualified type name of the extension field. Unlike
+        /// Metadata.type, Declaration.type must have a leading dot for messages
+        /// and enums.
+        #[prost(string, optional, tag="3")]
+        pub r#type: ::core::option::Option<::prost::alloc::string::String>,
+        /// If true, indicates that the number is reserved in the extension range,
+        /// and any extension field with the number will fail to compile. Set this
+        /// when a declared extension field is deleted.
+        #[prost(bool, optional, tag="5")]
+        pub reserved: ::core::option::Option<bool>,
+        /// If true, indicates that the extension must be defined as repeated.
+        /// Otherwise the extension must be defined as optional.
+        #[prost(bool, optional, tag="6")]
+        pub repeated: ::core::option::Option<bool>,
+    }
+    /// The verification state of the extension range.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum VerificationState {
+        /// All the extensions of the range must be declared.
+        Declaration = 0,
+        Unverified = 1,
+    }
+    impl VerificationState {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                VerificationState::Declaration => "DECLARATION",
+                VerificationState::Unverified => "UNVERIFIED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "DECLARATION" => Some(Self::Declaration),
+                "UNVERIFIED" => Some(Self::Unverified),
+                _ => None,
+            }
+        }
+    }
+}
+/// Describes a field within a message.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int32, optional, tag="3")]
+    pub number: ::core::option::Option<i32>,
+    #[prost(enumeration="field_descriptor_proto::Label", optional, tag="4")]
+    pub label: ::core::option::Option<i32>,
+    /// If type_name is set, this need not be set.  If both this and type_name
+    /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
+    #[prost(enumeration="field_descriptor_proto::Type", optional, tag="5")]
+    pub r#type: ::core::option::Option<i32>,
+    /// For message and enum types, this is the name of the type.  If the name
+    /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
+    /// rules are used to find the type (i.e. first the nested types within this
+    /// message are searched, then within the parent, on up to the root
+    /// namespace).
+    #[prost(string, optional, tag="6")]
+    pub type_name: ::core::option::Option<::prost::alloc::string::String>,
+    /// For extensions, this is the name of the type being extended.  It is
+    /// resolved in the same manner as type_name.
+    #[prost(string, optional, tag="2")]
+    pub extendee: ::core::option::Option<::prost::alloc::string::String>,
+    /// For numeric types, contains the original text representation of the value.
+    /// For booleans, "true" or "false".
+    /// For strings, contains the default text contents (not escaped in any way).
+    /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
+    #[prost(string, optional, tag="7")]
+    pub default_value: ::core::option::Option<::prost::alloc::string::String>,
+    /// If set, gives the index of a oneof in the containing type's oneof_decl
+    /// list.  This field is a member of that oneof.
+    #[prost(int32, optional, tag="9")]
+    pub oneof_index: ::core::option::Option<i32>,
+    /// JSON name of this field. The value is set by protocol compiler. If the
+    /// user has set a "json_name" option on this field, that option's value
+    /// will be used. Otherwise, it's deduced from the field's name by converting
+    /// it to camelCase.
+    #[prost(string, optional, tag="10")]
+    pub json_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="8")]
+    pub options: ::core::option::Option<FieldOptions>,
+    /// If true, this is a proto3 "optional". When a proto3 field is optional, it
+    /// tracks presence regardless of field type.
+    ///
+    /// When proto3_optional is true, this field must be belong to a oneof to
+    /// signal to old proto3 clients that presence is tracked for this field. This
+    /// oneof is known as a "synthetic" oneof, and this field must be its sole
+    /// member (each proto3 optional field gets its own synthetic oneof). Synthetic
+    /// oneofs exist in the descriptor only, and do not generate any API. Synthetic
+    /// oneofs must be ordered after all "real" oneofs.
+    ///
+    /// For message fields, proto3_optional doesn't create any semantic change,
+    /// since non-repeated message fields always track presence. However it still
+    /// indicates the semantic detail of whether the user wrote "optional" or not.
+    /// This can be useful for round-tripping the .proto file. For consistency we
+    /// give message fields a synthetic oneof also, even though it is not required
+    /// to track presence. This is especially important because the parser can't
+    /// tell if a field is a message or an enum, so it must always create a
+    /// synthetic oneof.
+    ///
+    /// Proto2 optional fields do not set this flag, because they already indicate
+    /// optional with `LABEL_OPTIONAL`.
+    #[prost(bool, optional, tag="17")]
+    pub proto3_optional: ::core::option::Option<bool>,
+}
+/// Nested message and enum types in `FieldDescriptorProto`.
+pub mod field_descriptor_proto {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Type {
+        /// 0 is reserved for errors.
+        /// Order is weird for historical reasons.
+        Double = 1,
+        Float = 2,
+        /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT64 if
+        /// negative values are likely.
+        Int64 = 3,
+        Uint64 = 4,
+        /// Not ZigZag encoded.  Negative numbers take 10 bytes.  Use TYPE_SINT32 if
+        /// negative values are likely.
+        Int32 = 5,
+        Fixed64 = 6,
+        Fixed32 = 7,
+        Bool = 8,
+        String = 9,
+        /// Tag-delimited aggregate.
+        /// Group type is deprecated and not supported in proto3. However, Proto3
+        /// implementations should still be able to parse the group wire format and
+        /// treat group fields as unknown fields.
+        Group = 10,
+        /// Length-delimited aggregate.
+        Message = 11,
+        /// New in version 2.
+        Bytes = 12,
+        Uint32 = 13,
+        Enum = 14,
+        Sfixed32 = 15,
+        Sfixed64 = 16,
+        /// Uses ZigZag encoding.
+        Sint32 = 17,
+        /// Uses ZigZag encoding.
+        Sint64 = 18,
+    }
+    impl Type {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Type::Double => "TYPE_DOUBLE",
+                Type::Float => "TYPE_FLOAT",
+                Type::Int64 => "TYPE_INT64",
+                Type::Uint64 => "TYPE_UINT64",
+                Type::Int32 => "TYPE_INT32",
+                Type::Fixed64 => "TYPE_FIXED64",
+                Type::Fixed32 => "TYPE_FIXED32",
+                Type::Bool => "TYPE_BOOL",
+                Type::String => "TYPE_STRING",
+                Type::Group => "TYPE_GROUP",
+                Type::Message => "TYPE_MESSAGE",
+                Type::Bytes => "TYPE_BYTES",
+                Type::Uint32 => "TYPE_UINT32",
+                Type::Enum => "TYPE_ENUM",
+                Type::Sfixed32 => "TYPE_SFIXED32",
+                Type::Sfixed64 => "TYPE_SFIXED64",
+                Type::Sint32 => "TYPE_SINT32",
+                Type::Sint64 => "TYPE_SINT64",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TYPE_DOUBLE" => Some(Self::Double),
+                "TYPE_FLOAT" => Some(Self::Float),
+                "TYPE_INT64" => Some(Self::Int64),
+                "TYPE_UINT64" => Some(Self::Uint64),
+                "TYPE_INT32" => Some(Self::Int32),
+                "TYPE_FIXED64" => Some(Self::Fixed64),
+                "TYPE_FIXED32" => Some(Self::Fixed32),
+                "TYPE_BOOL" => Some(Self::Bool),
+                "TYPE_STRING" => Some(Self::String),
+                "TYPE_GROUP" => Some(Self::Group),
+                "TYPE_MESSAGE" => Some(Self::Message),
+                "TYPE_BYTES" => Some(Self::Bytes),
+                "TYPE_UINT32" => Some(Self::Uint32),
+                "TYPE_ENUM" => Some(Self::Enum),
+                "TYPE_SFIXED32" => Some(Self::Sfixed32),
+                "TYPE_SFIXED64" => Some(Self::Sfixed64),
+                "TYPE_SINT32" => Some(Self::Sint32),
+                "TYPE_SINT64" => Some(Self::Sint64),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum Label {
+        /// 0 is reserved for errors
+        Optional = 1,
+        Required = 2,
+        Repeated = 3,
+    }
+    impl Label {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                Label::Optional => "LABEL_OPTIONAL",
+                Label::Required => "LABEL_REQUIRED",
+                Label::Repeated => "LABEL_REPEATED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "LABEL_OPTIONAL" => Some(Self::Optional),
+                "LABEL_REQUIRED" => Some(Self::Required),
+                "LABEL_REPEATED" => Some(Self::Repeated),
+                _ => None,
+            }
+        }
+    }
+}
+/// Describes a oneof.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OneofDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="2")]
+    pub options: ::core::option::Option<OneofOptions>,
+}
+/// Describes an enum type.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<EnumOptions>,
+    /// Range of reserved numeric values. Reserved numeric values may not be used
+    /// by enum values in the same enum declaration. Reserved ranges may not
+    /// overlap.
+    #[prost(message, repeated, tag="4")]
+    pub reserved_range: ::prost::alloc::vec::Vec<enum_descriptor_proto::EnumReservedRange>,
+    /// Reserved enum value names, which may not be reused. A given name may only
+    /// be reserved once.
+    #[prost(string, repeated, tag="5")]
+    pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `EnumDescriptorProto`.
+pub mod enum_descriptor_proto {
+    /// Range of reserved numeric values. Reserved values may not be used by
+    /// entries in the same enum. Reserved ranges may not overlap.
+    ///
+    /// Note that this is distinct from DescriptorProto.ReservedRange in that it
+    /// is inclusive such that it can appropriately represent the entire int32
+    /// domain.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EnumReservedRange {
+        /// Inclusive.
+        #[prost(int32, optional, tag="1")]
+        pub start: ::core::option::Option<i32>,
+        /// Inclusive.
+        #[prost(int32, optional, tag="2")]
+        pub end: ::core::option::Option<i32>,
+    }
+}
+/// Describes a value within an enum.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValueDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(int32, optional, tag="2")]
+    pub number: ::core::option::Option<i32>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<EnumValueOptions>,
+}
+/// Describes a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServiceDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, repeated, tag="2")]
+    pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<ServiceOptions>,
+}
+/// Describes a method of a service.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodDescriptorProto {
+    #[prost(string, optional, tag="1")]
+    pub name: ::core::option::Option<::prost::alloc::string::String>,
+    /// Input and output type names.  These are resolved in the same way as
+    /// FieldDescriptorProto.type_name, but must refer to a message type.
+    #[prost(string, optional, tag="2")]
+    pub input_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="3")]
+    pub output_type: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="4")]
+    pub options: ::core::option::Option<MethodOptions>,
+    /// Identifies if client streams multiple client messages
+    #[prost(bool, optional, tag="5", default="false")]
+    pub client_streaming: ::core::option::Option<bool>,
+    /// Identifies if server streams multiple server messages
+    #[prost(bool, optional, tag="6", default="false")]
+    pub server_streaming: ::core::option::Option<bool>,
+}
+// ===================================================================
+// Options
+
+// Each of the definitions above may have "options" attached.  These are
+// just annotations which may cause code to be generated slightly differently
+// or may contain hints for code that manipulates protocol messages.
+//
+// Clients may define custom options as extensions of the *Options messages.
+// These extensions may not yet be known at parsing time, so the parser cannot
+// store the values in them.  Instead it stores them in a field in the *Options
+// message called uninterpreted_option. This field must have the same name
+// across all *Options messages. We then use this field to populate the
+// extensions when we build a descriptor, at which point all protos have been
+// parsed and so all extensions are known.
+//
+// Extension numbers for custom options may be chosen as follows:
+// * For options which will only be used within a single application or
+//    organization, or for experimental options, use field numbers 50000
+//    through 99999.  It is up to you to ensure that you do not use the
+//    same number for multiple options.
+// * For options which will be published and used publicly by multiple
+//    independent entities, e-mail protobuf-global-extension-registry@google.com
+//    to reserve extension numbers. Simply provide your project name (e.g.
+//    Objective-C plugin) and your project website (if available) -- there's no
+//    need to explain how you intend to use them. Usually you only need one
+//    extension number. You can declare multiple options with only one extension
+//    number by putting them in a sub-message. See the Custom Options section of
+//    the docs for examples:
+//    <https://developers.google.com/protocol-buffers/docs/proto#options>
+//    If this turns out to be popular, a web service will be set up
+//    to automatically assign option numbers.
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FileOptions {
+    /// Sets the Java package where classes generated from this .proto will be
+    /// placed.  By default, the proto package is used, but this is often
+    /// inappropriate because proto packages do not normally start with backwards
+    /// domain names.
+    #[prost(string, optional, tag="1")]
+    pub java_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Controls the name of the wrapper Java class generated for the .proto file.
+    /// That class will always contain the .proto file's getDescriptor() method as
+    /// well as any top-level extensions defined in the .proto file.
+    /// If java_multiple_files is disabled, then all the other classes from the
+    /// .proto file will be nested inside the single wrapper outer class.
+    #[prost(string, optional, tag="8")]
+    pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
+    /// If enabled, then the Java code generator will generate a separate .java
+    /// file for each top-level message, enum, and service defined in the .proto
+    /// file.  Thus, these types will *not* be nested inside the wrapper class
+    /// named by java_outer_classname.  However, the wrapper class will still be
+    /// generated to contain the file's getDescriptor() method as well as any
+    /// top-level extensions defined in the file.
+    #[prost(bool, optional, tag="10", default="false")]
+    pub java_multiple_files: ::core::option::Option<bool>,
+    /// This option does nothing.
+    #[deprecated]
+    #[prost(bool, optional, tag="20")]
+    pub java_generate_equals_and_hash: ::core::option::Option<bool>,
+    /// If set true, then the Java2 code generator will generate code that
+    /// throws an exception whenever an attempt is made to assign a non-UTF-8
+    /// byte sequence to a string field.
+    /// Message reflection will do the same.
+    /// However, an extension field still accepts non-UTF-8 byte sequences.
+    /// This option has no effect on when used with the lite runtime.
+    #[prost(bool, optional, tag="27", default="false")]
+    pub java_string_check_utf8: ::core::option::Option<bool>,
+    #[prost(enumeration="file_options::OptimizeMode", optional, tag="9", default="Speed")]
+    pub optimize_for: ::core::option::Option<i32>,
+    /// Sets the Go package where structs generated from this .proto will be
+    /// placed. If omitted, the Go package will be derived from the following:
+    ///    - The basename of the package import path, if provided.
+    ///    - Otherwise, the package statement in the .proto file, if present.
+    ///    - Otherwise, the basename of the .proto file, without extension.
+    #[prost(string, optional, tag="11")]
+    pub go_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Should generic services be generated in each language?  "Generic" services
+    /// are not specific to any particular RPC system.  They are generated by the
+    /// main code generators in each language (without additional plugins).
+    /// Generic services were the only kind of service generation supported by
+    /// early versions of google.protobuf.
+    ///
+    /// Generic services are now considered deprecated in favor of using plugins
+    /// that generate code specific to your particular RPC system.  Therefore,
+    /// these default to false.  Old code which depends on generic services should
+    /// explicitly set them to true.
+    #[prost(bool, optional, tag="16", default="false")]
+    pub cc_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="17", default="false")]
+    pub java_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="18", default="false")]
+    pub py_generic_services: ::core::option::Option<bool>,
+    #[prost(bool, optional, tag="42", default="false")]
+    pub php_generic_services: ::core::option::Option<bool>,
+    /// Is this file deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for everything in the file, or it will be completely ignored; in the very
+    /// least, this is a formalization for deprecating files.
+    #[prost(bool, optional, tag="23", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// Enables the use of arenas for the proto messages in this file. This applies
+    /// only to generated classes for C++.
+    #[prost(bool, optional, tag="31", default="true")]
+    pub cc_enable_arenas: ::core::option::Option<bool>,
+    /// Sets the objective c class prefix which is prepended to all objective c
+    /// generated classes from this .proto. There is no default.
+    #[prost(string, optional, tag="36")]
+    pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Namespace for generated classes; defaults to the package.
+    #[prost(string, optional, tag="37")]
+    pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// By default Swift generators will take the proto package and CamelCase it
+    /// replacing '.' with underscore and use that to prefix the types/symbols
+    /// defined. When this options is provided, they will use this value instead
+    /// to prefix the types/symbols defined.
+    #[prost(string, optional, tag="39")]
+    pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Sets the php class prefix which is prepended to all php generated classes
+    /// from this .proto. Default is empty.
+    #[prost(string, optional, tag="40")]
+    pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the namespace of php generated classes. Default
+    /// is empty. When this option is empty, the package name will be used for
+    /// determining the namespace.
+    #[prost(string, optional, tag="41")]
+    pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the namespace of php generated metadata classes.
+    /// Default is empty. When this option is empty, the proto file name will be
+    /// used for determining the namespace.
+    #[prost(string, optional, tag="44")]
+    pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
+    /// Use this option to change the package of ruby generated classes. Default
+    /// is empty. When this option is not set, the package name will be used for
+    /// determining the ruby package.
+    #[prost(string, optional, tag="45")]
+    pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="50")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here.
+    /// See the documentation for the "Options" section above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `FileOptions`.
+pub mod file_options {
+    /// Generated classes can be optimized for speed or code size.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum OptimizeMode {
+        /// Generate complete code for parsing, serialization,
+        Speed = 1,
+        /// etc.
+        ///
+        /// Use ReflectionOps to implement these methods.
+        CodeSize = 2,
+        /// Generate code using MessageLite and the lite runtime.
+        LiteRuntime = 3,
+    }
+    impl OptimizeMode {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                OptimizeMode::Speed => "SPEED",
+                OptimizeMode::CodeSize => "CODE_SIZE",
+                OptimizeMode::LiteRuntime => "LITE_RUNTIME",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "SPEED" => Some(Self::Speed),
+                "CODE_SIZE" => Some(Self::CodeSize),
+                "LITE_RUNTIME" => Some(Self::LiteRuntime),
+                _ => None,
+            }
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MessageOptions {
+    /// Set true to use the old proto1 MessageSet wire format for extensions.
+    /// This is provided for backwards-compatibility with the MessageSet wire
+    /// format.  You should not use this for any other reason:  It's less
+    /// efficient, has fewer features, and is more complicated.
+    ///
+    /// The message must be defined exactly as follows:
+    ///    message Foo {
+    ///      option message_set_wire_format = true;
+    ///      extensions 4 to max;
+    ///    }
+    /// Note that the message cannot have any defined fields; MessageSets only
+    /// have extensions.
+    ///
+    /// All extensions of your type must be singular messages; e.g. they cannot
+    /// be int32s, enums, or repeated messages.
+    ///
+    /// Because this is an option, the above two restrictions are not enforced by
+    /// the protocol compiler.
+    #[prost(bool, optional, tag="1", default="false")]
+    pub message_set_wire_format: ::core::option::Option<bool>,
+    /// Disables the generation of the standard "descriptor()" accessor, which can
+    /// conflict with a field of the same name.  This is meant to make migration
+    /// from proto1 easier; new code should avoid fields named "descriptor".
+    #[prost(bool, optional, tag="2", default="false")]
+    pub no_standard_descriptor_accessor: ::core::option::Option<bool>,
+    /// Is this message deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the message, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating messages.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// NOTE: Do not set the option in .proto files. Always use the maps syntax
+    /// instead. The option should only be implicitly set by the proto compiler
+    /// parser.
+    ///
+    /// Whether the message is an automatically generated map entry type for the
+    /// maps field.
+    ///
+    /// For maps fields:
+    ///      map<KeyType, ValueType> map_field = 1;
+    /// The parsed descriptor looks like:
+    ///      message MapFieldEntry {
+    ///          option map_entry = true;
+    ///          optional KeyType key = 1;
+    ///          optional ValueType value = 2;
+    ///      }
+    ///      repeated MapFieldEntry map_field = 1;
+    ///
+    /// Implementations may choose not to generate the map_entry=true message, but
+    /// use a native map in the target language to hold the keys and values.
+    /// The reflection APIs in such implementations still need to work as
+    /// if the field is a repeated message field.
+    #[prost(bool, optional, tag="7")]
+    pub map_entry: ::core::option::Option<bool>,
+    /// Enable the legacy handling of JSON field name conflicts.  This lowercases
+    /// and strips underscored from the fields before comparison in proto3 only.
+    /// The new behavior takes `json_name` into account and applies to proto2 as
+    /// well.
+    ///
+    /// This should only be used as a temporary measure against broken builds due
+    /// to the change in behavior for JSON field name conflicts.
+    ///
+    /// TODO(b/261750190) This is legacy behavior we plan to remove once downstream
+    /// teams have had time to migrate.
+    #[deprecated]
+    #[prost(bool, optional, tag="11")]
+    pub deprecated_legacy_json_field_conflicts: ::core::option::Option<bool>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="12")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldOptions {
+    /// The ctype option instructs the C++ code generator to use a different
+    /// representation of the field than it normally would.  See the specific
+    /// options below.  This option is only implemented to support use of
+    /// \[ctype=CORD\] and \[ctype=STRING\] (the default) on non-repeated fields of
+    /// type "bytes" in the open source release -- sorry, we'll try to include
+    /// other types in a future version!
+    #[prost(enumeration="field_options::CType", optional, tag="1", default="String")]
+    pub ctype: ::core::option::Option<i32>,
+    /// The packed option can be enabled for repeated primitive fields to enable
+    /// a more efficient representation on the wire. Rather than repeatedly
+    /// writing the tag and type for each element, the entire array is encoded as
+    /// a single length-delimited blob. In proto3, only explicit setting it to
+    /// false will avoid using packed encoding.
+    #[prost(bool, optional, tag="2")]
+    pub packed: ::core::option::Option<bool>,
+    /// The jstype option determines the JavaScript type used for values of the
+    /// field.  The option is permitted only for 64 bit integral and fixed types
+    /// (int64, uint64, sint64, fixed64, sfixed64).  A field with jstype JS_STRING
+    /// is represented as JavaScript string, which avoids loss of precision that
+    /// can happen when a large value is converted to a floating point JavaScript.
+    /// Specifying JS_NUMBER for the jstype causes the generated JavaScript code to
+    /// use the JavaScript "number" type.  The behavior of the default option
+    /// JS_NORMAL is implementation dependent.
+    ///
+    /// This option is an enum to permit additional types to be added, e.g.
+    /// goog.math.Integer.
+    #[prost(enumeration="field_options::JsType", optional, tag="6", default="JsNormal")]
+    pub jstype: ::core::option::Option<i32>,
+    /// Should this field be parsed lazily?  Lazy applies only to message-type
+    /// fields.  It means that when the outer message is initially parsed, the
+    /// inner message's contents will not be parsed but instead stored in encoded
+    /// form.  The inner message will actually be parsed when it is first accessed.
+    ///
+    /// This is only a hint.  Implementations are free to choose whether to use
+    /// eager or lazy parsing regardless of the value of this option.  However,
+    /// setting this option true suggests that the protocol author believes that
+    /// using lazy parsing on this field is worth the additional bookkeeping
+    /// overhead typically needed to implement it.
+    ///
+    /// This option does not affect the public interface of any generated code;
+    /// all method signatures remain the same.  Furthermore, thread-safety of the
+    /// interface is not affected by this option; const methods remain safe to
+    /// call from multiple threads concurrently, while non-const methods continue
+    /// to require exclusive access.
+    ///
+    /// Note that implementations may choose not to check required fields within
+    /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
+    /// may return true even if the inner message has missing required fields.
+    /// This is necessary because otherwise the inner message would have to be
+    /// parsed in order to perform the check, defeating the purpose of lazy
+    /// parsing.  An implementation which chooses not to check required fields
+    /// must be consistent about it.  That is, for any particular sub-message, the
+    /// implementation must either *always* check its required fields, or *never*
+    /// check its required fields, regardless of whether or not the message has
+    /// been parsed.
+    ///
+    /// As of May 2022, lazy verifies the contents of the byte stream during
+    /// parsing.  An invalid byte stream will cause the overall parsing to fail.
+    #[prost(bool, optional, tag="5", default="false")]
+    pub lazy: ::core::option::Option<bool>,
+    /// unverified_lazy does no correctness checks on the byte stream. This should
+    /// only be used where lazy with verification is prohibitive for performance
+    /// reasons.
+    #[prost(bool, optional, tag="15", default="false")]
+    pub unverified_lazy: ::core::option::Option<bool>,
+    /// Is this field deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for accessors, or it will be completely ignored; in the very least, this
+    /// is a formalization for deprecating fields.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// For Google-internal migration only. Do not use.
+    #[prost(bool, optional, tag="10", default="false")]
+    pub weak: ::core::option::Option<bool>,
+    /// Indicate that the field value should not be printed out when using debug
+    /// formats, e.g. when the field contains sensitive credentials.
+    #[prost(bool, optional, tag="16", default="false")]
+    pub debug_redact: ::core::option::Option<bool>,
+    #[prost(enumeration="field_options::OptionRetention", optional, tag="17")]
+    pub retention: ::core::option::Option<i32>,
+    #[prost(enumeration="field_options::OptionTargetType", repeated, packed="false", tag="19")]
+    pub targets: ::prost::alloc::vec::Vec<i32>,
+    #[prost(message, repeated, tag="20")]
+    pub edition_defaults: ::prost::alloc::vec::Vec<field_options::EditionDefault>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="21")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `FieldOptions`.
+pub mod field_options {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct EditionDefault {
+        #[prost(string, optional, tag="1")]
+        pub edition: ::core::option::Option<::prost::alloc::string::String>,
+        /// Textproto value.
+        #[prost(string, optional, tag="2")]
+        pub value: ::core::option::Option<::prost::alloc::string::String>,
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum CType {
+        /// Default mode.
+        String = 0,
+        /// The option \[ctype=CORD\] may be applied to a non-repeated field of type
+        /// "bytes". It indicates that in C++, the data should be stored in a Cord
+        /// instead of a string.  For very large strings, this may reduce memory
+        /// fragmentation. It may also allow better performance when parsing from a
+        /// Cord, or when parsing with aliasing enabled, as the parsed Cord may then
+        /// alias the original buffer.
+        Cord = 1,
+        StringPiece = 2,
+    }
+    impl CType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                CType::String => "STRING",
+                CType::Cord => "CORD",
+                CType::StringPiece => "STRING_PIECE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STRING" => Some(Self::String),
+                "CORD" => Some(Self::Cord),
+                "STRING_PIECE" => Some(Self::StringPiece),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum JsType {
+        /// Use the default type.
+        JsNormal = 0,
+        /// Use JavaScript strings.
+        JsString = 1,
+        /// Use JavaScript numbers.
+        JsNumber = 2,
+    }
+    impl JsType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                JsType::JsNormal => "JS_NORMAL",
+                JsType::JsString => "JS_STRING",
+                JsType::JsNumber => "JS_NUMBER",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "JS_NORMAL" => Some(Self::JsNormal),
+                "JS_STRING" => Some(Self::JsString),
+                "JS_NUMBER" => Some(Self::JsNumber),
+                _ => None,
+            }
+        }
+    }
+    /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
+    /// Note: as of January 2023, support for this is in progress and does not yet
+    /// have an effect (b/264593489).
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum OptionRetention {
+        RetentionUnknown = 0,
+        RetentionRuntime = 1,
+        RetentionSource = 2,
+    }
+    impl OptionRetention {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                OptionRetention::RetentionUnknown => "RETENTION_UNKNOWN",
+                OptionRetention::RetentionRuntime => "RETENTION_RUNTIME",
+                OptionRetention::RetentionSource => "RETENTION_SOURCE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "RETENTION_UNKNOWN" => Some(Self::RetentionUnknown),
+                "RETENTION_RUNTIME" => Some(Self::RetentionRuntime),
+                "RETENTION_SOURCE" => Some(Self::RetentionSource),
+                _ => None,
+            }
+        }
+    }
+    /// This indicates the types of entities that the field may apply to when used
+    /// as an option. If it is unset, then the field may be freely used as an
+    /// option on any kind of entity. Note: as of January 2023, support for this is
+    /// in progress and does not yet have an effect (b/264593489).
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum OptionTargetType {
+        TargetTypeUnknown = 0,
+        TargetTypeFile = 1,
+        TargetTypeExtensionRange = 2,
+        TargetTypeMessage = 3,
+        TargetTypeField = 4,
+        TargetTypeOneof = 5,
+        TargetTypeEnum = 6,
+        TargetTypeEnumEntry = 7,
+        TargetTypeService = 8,
+        TargetTypeMethod = 9,
+    }
+    impl OptionTargetType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                OptionTargetType::TargetTypeUnknown => "TARGET_TYPE_UNKNOWN",
+                OptionTargetType::TargetTypeFile => "TARGET_TYPE_FILE",
+                OptionTargetType::TargetTypeExtensionRange => "TARGET_TYPE_EXTENSION_RANGE",
+                OptionTargetType::TargetTypeMessage => "TARGET_TYPE_MESSAGE",
+                OptionTargetType::TargetTypeField => "TARGET_TYPE_FIELD",
+                OptionTargetType::TargetTypeOneof => "TARGET_TYPE_ONEOF",
+                OptionTargetType::TargetTypeEnum => "TARGET_TYPE_ENUM",
+                OptionTargetType::TargetTypeEnumEntry => "TARGET_TYPE_ENUM_ENTRY",
+                OptionTargetType::TargetTypeService => "TARGET_TYPE_SERVICE",
+                OptionTargetType::TargetTypeMethod => "TARGET_TYPE_METHOD",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "TARGET_TYPE_UNKNOWN" => Some(Self::TargetTypeUnknown),
+                "TARGET_TYPE_FILE" => Some(Self::TargetTypeFile),
+                "TARGET_TYPE_EXTENSION_RANGE" => Some(Self::TargetTypeExtensionRange),
+                "TARGET_TYPE_MESSAGE" => Some(Self::TargetTypeMessage),
+                "TARGET_TYPE_FIELD" => Some(Self::TargetTypeField),
+                "TARGET_TYPE_ONEOF" => Some(Self::TargetTypeOneof),
+                "TARGET_TYPE_ENUM" => Some(Self::TargetTypeEnum),
+                "TARGET_TYPE_ENUM_ENTRY" => Some(Self::TargetTypeEnumEntry),
+                "TARGET_TYPE_SERVICE" => Some(Self::TargetTypeService),
+                "TARGET_TYPE_METHOD" => Some(Self::TargetTypeMethod),
+                _ => None,
+            }
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OneofOptions {
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="1")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumOptions {
+    /// Set this option to true to allow mapping different tag names to the same
+    /// value.
+    #[prost(bool, optional, tag="2")]
+    pub allow_alias: ::core::option::Option<bool>,
+    /// Is this enum deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the enum, or it will be completely ignored; in the very least, this
+    /// is a formalization for deprecating enums.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// Enable the legacy handling of JSON field name conflicts.  This lowercases
+    /// and strips underscored from the fields before comparison in proto3 only.
+    /// The new behavior takes `json_name` into account and applies to proto2 as
+    /// well.
+    /// TODO(b/261750190) Remove this legacy behavior once downstream teams have
+    /// had time to migrate.
+    #[deprecated]
+    #[prost(bool, optional, tag="6")]
+    pub deprecated_legacy_json_field_conflicts: ::core::option::Option<bool>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="7")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnumValueOptions {
+    /// Is this enum value deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the enum value, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating enum values.
+    #[prost(bool, optional, tag="1", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="2")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// Indicate that fields annotated with this enum value should not be printed
+    /// out when using debug formats, e.g. when the field contains sensitive
+    /// credentials.
+    #[prost(bool, optional, tag="3", default="false")]
+    pub debug_redact: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServiceOptions {
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="34")]
+    pub features: ::core::option::Option<FeatureSet>,
+    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    //    framework.  We apologize for hoarding these numbers to ourselves, but
+    //    we were already using them long before we decided to release Protocol
+    //    Buffers.
+
+    /// Is this service deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the service, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating services.
+    #[prost(bool, optional, tag="33", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MethodOptions {
+    // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
+    //    framework.  We apologize for hoarding these numbers to ourselves, but
+    //    we were already using them long before we decided to release Protocol
+    //    Buffers.
+
+    /// Is this method deprecated?
+    /// Depending on the target platform, this can emit Deprecated annotations
+    /// for the method, or it will be completely ignored; in the very least,
+    /// this is a formalization for deprecating methods.
+    #[prost(bool, optional, tag="33", default="false")]
+    pub deprecated: ::core::option::Option<bool>,
+    #[prost(enumeration="method_options::IdempotencyLevel", optional, tag="34", default="IdempotencyUnknown")]
+    pub idempotency_level: ::core::option::Option<i32>,
+    /// Any features defined in the specific edition.
+    #[prost(message, optional, tag="35")]
+    pub features: ::core::option::Option<FeatureSet>,
+    /// The parser stores options it doesn't recognize here. See above.
+    #[prost(message, repeated, tag="999")]
+    pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
+}
+/// Nested message and enum types in `MethodOptions`.
+pub mod method_options {
+    /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
+    /// or neither? HTTP based RPC implementation may choose GET verb for safe
+    /// methods, and PUT verb for idempotent methods instead of the default POST.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum IdempotencyLevel {
+        IdempotencyUnknown = 0,
+        /// implies idempotent
+        NoSideEffects = 1,
+        /// idempotent, but may have side effects
+        Idempotent = 2,
+    }
+    impl IdempotencyLevel {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                IdempotencyLevel::IdempotencyUnknown => "IDEMPOTENCY_UNKNOWN",
+                IdempotencyLevel::NoSideEffects => "NO_SIDE_EFFECTS",
+                IdempotencyLevel::Idempotent => "IDEMPOTENT",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "IDEMPOTENCY_UNKNOWN" => Some(Self::IdempotencyUnknown),
+                "NO_SIDE_EFFECTS" => Some(Self::NoSideEffects),
+                "IDEMPOTENT" => Some(Self::Idempotent),
+                _ => None,
+            }
+        }
+    }
+}
+/// A message representing a option the parser does not recognize. This only
+/// appears in options protos created by the compiler::Parser class.
+/// DescriptorPool resolves these when building Descriptor objects. Therefore,
+/// options protos in descriptor objects (e.g. returned by Descriptor::options(),
+/// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
+/// in them.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UninterpretedOption {
+    #[prost(message, repeated, tag="2")]
+    pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
+    /// The value of the uninterpreted option, in whatever type the tokenizer
+    /// identified it as during parsing. Exactly one of these should be set.
+    #[prost(string, optional, tag="3")]
+    pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint64, optional, tag="4")]
+    pub positive_int_value: ::core::option::Option<u64>,
+    #[prost(int64, optional, tag="5")]
+    pub negative_int_value: ::core::option::Option<i64>,
+    #[prost(double, optional, tag="6")]
+    pub double_value: ::core::option::Option<f64>,
+    #[prost(bytes="vec", optional, tag="7")]
+    pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(string, optional, tag="8")]
+    pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
+}
+/// Nested message and enum types in `UninterpretedOption`.
+pub mod uninterpreted_option {
+    /// The name of the uninterpreted option.  Each string represents a segment in
+    /// a dot-separated name.  is_extension is true iff a segment represents an
+    /// extension (denoted with parentheses in options specs in .proto files).
+    /// E.g.,{ ["foo", false], ["bar.baz", true], ["moo", false] } represents
+    /// "foo.(bar.baz).moo".
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct NamePart {
+        #[prost(string, required, tag="1")]
+        pub name_part: ::prost::alloc::string::String,
+        #[prost(bool, required, tag="2")]
+        pub is_extension: bool,
+    }
+}
+// ===================================================================
+// Features
+
+/// TODO(b/274655146) Enums in C++ gencode (and potentially other languages) are
+/// not well scoped.  This means that each of the feature enums below can clash
+/// with each other.  The short names we've chosen maximize call-site
+/// readability, but leave us very open to this scenario.  A future feature will
+/// be designed and implemented to handle this, hopefully before we ever hit a
+/// conflict here.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FeatureSet {
+    #[prost(enumeration="feature_set::FieldPresence", optional, tag="1")]
+    pub field_presence: ::core::option::Option<i32>,
+    #[prost(enumeration="feature_set::EnumType", optional, tag="2")]
+    pub enum_type: ::core::option::Option<i32>,
+    #[prost(enumeration="feature_set::RepeatedFieldEncoding", optional, tag="3")]
+    pub repeated_field_encoding: ::core::option::Option<i32>,
+    #[prost(enumeration="feature_set::StringFieldValidation", optional, tag="4")]
+    pub string_field_validation: ::core::option::Option<i32>,
+    #[prost(enumeration="feature_set::MessageEncoding", optional, tag="5")]
+    pub message_encoding: ::core::option::Option<i32>,
+    #[prost(enumeration="feature_set::JsonFormat", optional, tag="6")]
+    pub json_format: ::core::option::Option<i32>,
+    #[prost(message, optional, boxed, tag="999")]
+    pub raw_features: ::core::option::Option<::prost::alloc::boxed::Box<FeatureSet>>,
+}
+/// Nested message and enum types in `FeatureSet`.
+pub mod feature_set {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum FieldPresence {
+        Unknown = 0,
+        Explicit = 1,
+        Implicit = 2,
+        LegacyRequired = 3,
+    }
+    impl FieldPresence {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                FieldPresence::Unknown => "FIELD_PRESENCE_UNKNOWN",
+                FieldPresence::Explicit => "EXPLICIT",
+                FieldPresence::Implicit => "IMPLICIT",
+                FieldPresence::LegacyRequired => "LEGACY_REQUIRED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "FIELD_PRESENCE_UNKNOWN" => Some(Self::Unknown),
+                "EXPLICIT" => Some(Self::Explicit),
+                "IMPLICIT" => Some(Self::Implicit),
+                "LEGACY_REQUIRED" => Some(Self::LegacyRequired),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum EnumType {
+        Unknown = 0,
+        Open = 1,
+        Closed = 2,
+    }
+    impl EnumType {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                EnumType::Unknown => "ENUM_TYPE_UNKNOWN",
+                EnumType::Open => "OPEN",
+                EnumType::Closed => "CLOSED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "ENUM_TYPE_UNKNOWN" => Some(Self::Unknown),
+                "OPEN" => Some(Self::Open),
+                "CLOSED" => Some(Self::Closed),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum RepeatedFieldEncoding {
+        Unknown = 0,
+        Packed = 1,
+        Expanded = 2,
+    }
+    impl RepeatedFieldEncoding {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                RepeatedFieldEncoding::Unknown => "REPEATED_FIELD_ENCODING_UNKNOWN",
+                RepeatedFieldEncoding::Packed => "PACKED",
+                RepeatedFieldEncoding::Expanded => "EXPANDED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "REPEATED_FIELD_ENCODING_UNKNOWN" => Some(Self::Unknown),
+                "PACKED" => Some(Self::Packed),
+                "EXPANDED" => Some(Self::Expanded),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum StringFieldValidation {
+        Unknown = 0,
+        Mandatory = 1,
+        Hint = 2,
+        None = 3,
+    }
+    impl StringFieldValidation {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                StringFieldValidation::Unknown => "STRING_FIELD_VALIDATION_UNKNOWN",
+                StringFieldValidation::Mandatory => "MANDATORY",
+                StringFieldValidation::Hint => "HINT",
+                StringFieldValidation::None => "NONE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STRING_FIELD_VALIDATION_UNKNOWN" => Some(Self::Unknown),
+                "MANDATORY" => Some(Self::Mandatory),
+                "HINT" => Some(Self::Hint),
+                "NONE" => Some(Self::None),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum MessageEncoding {
+        Unknown = 0,
+        LengthPrefixed = 1,
+        Delimited = 2,
+    }
+    impl MessageEncoding {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                MessageEncoding::Unknown => "MESSAGE_ENCODING_UNKNOWN",
+                MessageEncoding::LengthPrefixed => "LENGTH_PREFIXED",
+                MessageEncoding::Delimited => "DELIMITED",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "MESSAGE_ENCODING_UNKNOWN" => Some(Self::Unknown),
+                "LENGTH_PREFIXED" => Some(Self::LengthPrefixed),
+                "DELIMITED" => Some(Self::Delimited),
+                _ => None,
+            }
+        }
+    }
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum JsonFormat {
+        Unknown = 0,
+        Allow = 1,
+        LegacyBestEffort = 2,
+    }
+    impl JsonFormat {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                JsonFormat::Unknown => "JSON_FORMAT_UNKNOWN",
+                JsonFormat::Allow => "ALLOW",
+                JsonFormat::LegacyBestEffort => "LEGACY_BEST_EFFORT",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "JSON_FORMAT_UNKNOWN" => Some(Self::Unknown),
+                "ALLOW" => Some(Self::Allow),
+                "LEGACY_BEST_EFFORT" => Some(Self::LegacyBestEffort),
+                _ => None,
+            }
+        }
+    }
+}
+// ===================================================================
+// Optional source code info
+
+/// Encapsulates information about the original source file from which a
+/// FileDescriptorProto was generated.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SourceCodeInfo {
+    /// A Location identifies a piece of source code in a .proto file which
+    /// corresponds to a particular definition.  This information is intended
+    /// to be useful to IDEs, code indexers, documentation generators, and similar
+    /// tools.
+    ///
+    /// For example, say we have a file like:
+    ///    message Foo {
+    ///      optional string foo = 1;
+    ///    }
+    /// Let's look at just the field definition:
+    ///    optional string foo = 1;
+    ///    ^       ^^     ^^  ^  ^^^
+    ///    a       bc     de  f  ghi
+    /// We have the following locations:
+    ///    span   path               represents
+    ///    [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
+    ///    [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
+    ///    [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
+    ///    [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
+    ///    [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    ///
+    /// Notes:
+    /// - A location may refer to a repeated field itself (i.e. not to any
+    ///    particular index within it).  This is used whenever a set of elements are
+    ///    logically enclosed in a single code segment.  For example, an entire
+    ///    extend block (possibly containing multiple extension definitions) will
+    ///    have an outer location whose path refers to the "extensions" repeated
+    ///    field without an index.
+    /// - Multiple locations may have the same path.  This happens when a single
+    ///    logical declaration is spread out across multiple places.  The most
+    ///    obvious example is the "extend" block again -- there may be multiple
+    ///    extend blocks in the same scope, each of which will have the same path.
+    /// - A location's span is not always a subset of its parent's span.  For
+    ///    example, the "extendee" of an extension declaration appears at the
+    ///    beginning of the "extend" block and is shared by all extensions within
+    ///    the block.
+    /// - Just because a location's span is a subset of some other location's span
+    ///    does not mean that it is a descendant.  For example, a "group" defines
+    ///    both a type and a field in a single declaration.  Thus, the locations
+    ///    corresponding to the type and field and their components will overlap.
+    /// - Code which tries to interpret locations should probably be designed to
+    ///    ignore those that it doesn't understand, as more types of locations could
+    ///    be recorded in the future.
+    #[prost(message, repeated, tag="1")]
+    pub location: ::prost::alloc::vec::Vec<source_code_info::Location>,
+}
+/// Nested message and enum types in `SourceCodeInfo`.
+pub mod source_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Location {
+        /// Identifies which part of the FileDescriptorProto was defined at this
+        /// location.
+        ///
+        /// Each element is a field number or an index.  They form a path from
+        /// the root FileDescriptorProto to the place where the definition occurs.
+        /// For example, this path:
+        ///    [ 4, 3, 2, 7, 1 ]
+        /// refers to:
+        ///    file.message_type(3)  // 4, 3
+        ///        .field(7)         // 2, 7
+        ///        .name()           // 1
+        /// This is because FileDescriptorProto.message_type has field number 4:
+        ///    repeated DescriptorProto message_type = 4;
+        /// and DescriptorProto.field has field number 2:
+        ///    repeated FieldDescriptorProto field = 2;
+        /// and FieldDescriptorProto.name has field number 1:
+        ///    optional string name = 1;
+        ///
+        /// Thus, the above path gives the location of a field name.  If we removed
+        /// the last element:
+        ///    [ 4, 3, 2, 7 ]
+        /// this path refers to the whole field declaration (from the beginning
+        /// of the label to the terminating semicolon).
+        #[prost(int32, repeated, tag="1")]
+        pub path: ::prost::alloc::vec::Vec<i32>,
+        /// Always has exactly three or four elements: start line, start column,
+        /// end line (optional, otherwise assumed same as start line), end column.
+        /// These are packed into a single field for efficiency.  Note that line
+        /// and column numbers are zero-based -- typically you will want to add
+        /// 1 to each before displaying to a user.
+        #[prost(int32, repeated, tag="2")]
+        pub span: ::prost::alloc::vec::Vec<i32>,
+        /// If this SourceCodeInfo represents a complete declaration, these are any
+        /// comments appearing before and after the declaration which appear to be
+        /// attached to the declaration.
+        ///
+        /// A series of line comments appearing on consecutive lines, with no other
+        /// tokens appearing on those lines, will be treated as a single comment.
+        ///
+        /// leading_detached_comments will keep paragraphs of comments that appear
+        /// before (but not connected to) the current element. Each paragraph,
+        /// separated by empty lines, will be one comment element in the repeated
+        /// field.
+        ///
+        /// Only the comment content is provided; comment markers (e.g. //) are
+        /// stripped out.  For block comments, leading whitespace and an asterisk
+        /// will be stripped from the beginning of each line other than the first.
+        /// Newlines are included in the output.
+        ///
+        /// Examples:
+        ///
+        ///    optional int32 foo = 1;  // Comment attached to foo.
+        ///    // Comment attached to bar.
+        ///    optional int32 bar = 2;
+        ///
+        ///    optional string baz = 3;
+        ///    // Comment attached to baz.
+        ///    // Another line attached to baz.
+        ///
+        ///    // Comment attached to moo.
+        ///    //
+        ///    // Another line attached to moo.
+        ///    optional double moo = 4;
+        ///
+        ///    // Detached comment for corge. This is not leading or trailing comments
+        ///    // to moo or corge because there are blank lines separating it from
+        ///    // both.
+        ///
+        ///    // Detached comment for corge paragraph 2.
+        ///
+        ///    optional string corge = 5;
+        ///    /* Block comment attached
+        ///     * to corge.  Leading asterisks
+        ///     * will be removed. */
+        ///    /* Block comment attached to
+        ///     * grault. */
+        ///    optional int32 grault = 6;
+        ///
+        ///    // ignored detached comments.
+        #[prost(string, optional, tag="3")]
+        pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
+        #[prost(string, optional, tag="4")]
+        pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
+        #[prost(string, repeated, tag="6")]
+        pub leading_detached_comments: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    }
+}
+/// Describes the relationship between generated code and its original source
+/// file. A GeneratedCodeInfo message is associated with only one generated
+/// source file, but may contain references to different source .proto files.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GeneratedCodeInfo {
+    /// An Annotation connects some span of text in generated code to an element
+    /// of its generating .proto file.
+    #[prost(message, repeated, tag="1")]
+    pub annotation: ::prost::alloc::vec::Vec<generated_code_info::Annotation>,
+}
+/// Nested message and enum types in `GeneratedCodeInfo`.
+pub mod generated_code_info {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Annotation {
+        /// Identifies the element in the original source .proto file. This field
+        /// is formatted the same as SourceCodeInfo.Location.path.
+        #[prost(int32, repeated, tag="1")]
+        pub path: ::prost::alloc::vec::Vec<i32>,
+        /// Identifies the filesystem path to the original source .proto.
+        #[prost(string, optional, tag="2")]
+        pub source_file: ::core::option::Option<::prost::alloc::string::String>,
+        /// Identifies the starting offset in bytes in the generated code
+        /// that relates to the identified object.
+        #[prost(int32, optional, tag="3")]
+        pub begin: ::core::option::Option<i32>,
+        /// Identifies the ending offset in bytes in the generated code that
+        /// relates to the identified object. The end offset should be one past
+        /// the last relevant byte (so the length of the text = end - begin).
+        #[prost(int32, optional, tag="4")]
+        pub end: ::core::option::Option<i32>,
+        #[prost(enumeration="annotation::Semantic", optional, tag="5")]
+        pub semantic: ::core::option::Option<i32>,
+    }
+    /// Nested message and enum types in `Annotation`.
+    pub mod annotation {
+        /// Represents the identified object's effect on the element in the original
+        /// .proto file.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+        #[repr(i32)]
+        pub enum Semantic {
+            /// There is no effect or the effect is indescribable.
+            None = 0,
+            /// The element is set or otherwise mutated.
+            Set = 1,
+            /// An alias to the element is returned.
+            Alias = 2,
+        }
+        impl Semantic {
+            /// String value of the enum field names used in the ProtoBuf definition.
+            ///
+            /// The values are not transformed in any way and thus are considered stable
+            /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+            pub fn as_str_name(&self) -> &'static str {
+                match self {
+                    Semantic::None => "NONE",
+                    Semantic::Set => "SET",
+                    Semantic::Alias => "ALIAS",
+                }
+            }
+            /// Creates an enum from field names used in the ProtoBuf definition.
+            pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+                match value {
+                    "NONE" => Some(Self::None),
+                    "SET" => Some(Self::Set),
+                    "ALIAS" => Some(Self::Alias),
+                    _ => None,
+                }
+            }
+        }
+    }
+}
+/// A Duration represents a signed, fixed-length span of time represented
+/// as a count of seconds and fractions of seconds at nanosecond
+/// resolution. It is independent of any calendar and concepts like "day"
+/// or "month". It is related to Timestamp in that the difference between
+/// two Timestamp values is a Duration and it can be added or subtracted
+/// from a Timestamp. Range is approximately +-10,000 years.
+///
+/// # Examples
+///
+/// Example 1: Compute Duration from two Timestamps in pseudo code.
+///
+///      Timestamp start = ...;
+///      Timestamp end = ...;
+///      Duration duration = ...;
+///
+///      duration.seconds = end.seconds - start.seconds;
+///      duration.nanos = end.nanos - start.nanos;
+///
+///      if (duration.seconds < 0 && duration.nanos > 0) {
+///        duration.seconds += 1;
+///        duration.nanos -= 1000000000;
+///      } else if (duration.seconds > 0 && duration.nanos < 0) {
+///        duration.seconds -= 1;
+///        duration.nanos += 1000000000;
+///      }
+///
+/// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+///
+///      Timestamp start = ...;
+///      Duration duration = ...;
+///      Timestamp end = ...;
+///
+///      end.seconds = start.seconds + duration.seconds;
+///      end.nanos = start.nanos + duration.nanos;
+///
+///      if (end.nanos < 0) {
+///        end.seconds -= 1;
+///        end.nanos += 1000000000;
+///      } else if (end.nanos >= 1000000000) {
+///        end.seconds += 1;
+///        end.nanos -= 1000000000;
+///      }
+///
+/// Example 3: Compute Duration from datetime.timedelta in Python.
+///
+///      td = datetime.timedelta(days=3, minutes=10)
+///      duration = Duration()
+///      duration.FromTimedelta(td)
+///
+/// # JSON Mapping
+///
+/// In JSON format, the Duration type is encoded as a string rather than an
+/// object, where the string ends in the suffix "s" (indicating seconds) and
+/// is preceded by the number of seconds, with nanoseconds expressed as
+/// fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+/// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+/// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+/// microsecond should be expressed in JSON format as "3.000001s".
+///
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Duration {
+    /// Signed seconds of the span of time. Must be from -315,576,000,000
+    /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
+    /// 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+    #[prost(int64, tag="1")]
+    pub seconds: i64,
+    /// Signed fractions of a second at nanosecond resolution of the span
+    /// of time. Durations less than one second are represented with a 0
+    /// `seconds` field and a positive or negative `nanos` field. For durations
+    /// of one second or more, a non-zero value for the `nanos` field must be
+    /// of the same sign as the `seconds` field. Must be from -999,999,999
+    /// to +999,999,999 inclusive.
+    #[prost(int32, tag="2")]
+    pub nanos: i32,
+}
+/// A generic empty message that you can re-use to avoid defining duplicated
+/// empty messages in your APIs. A typical example is to use it as the request
+/// or the response type of an API method. For instance:
+///
+///      service Foo {
+///        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+///      }
+///
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Empty {
+}
+/// `FieldMask` represents a set of symbolic field paths, for example:
+///
+///      paths: "f.a"
+///      paths: "f.b.d"
+///
+/// Here `f` represents a field in some root message, `a` and `b`
+/// fields in the message found in `f`, and `d` a field found in the
+/// message in `f.b`.
+///
+/// Field masks are used to specify a subset of fields that should be
+/// returned by a get operation or modified by an update operation.
+/// Field masks also have a custom JSON encoding (see below).
+///
+/// # Field Masks in Projections
+///
+/// When used in the context of a projection, a response message or
+/// sub-message is filtered by the API to only contain those fields as
+/// specified in the mask. For example, if the mask in the previous
+/// example is applied to a response message as follows:
+///
+///      f {
+///        a : 22
+///        b {
+///          d : 1
+///          x : 2
+///        }
+///        y : 13
+///      }
+///      z: 8
+///
+/// The result will not contain specific values for fields x,y and z
+/// (their value will be set to the default, and omitted in proto text
+/// output):
+///
+///
+///      f {
+///        a : 22
+///        b {
+///          d : 1
+///        }
+///      }
+///
+/// A repeated field is not allowed except at the last position of a
+/// paths string.
+///
+/// If a FieldMask object is not present in a get operation, the
+/// operation applies to all fields (as if a FieldMask of all fields
+/// had been specified).
+///
+/// Note that a field mask does not necessarily apply to the
+/// top-level response message. In case of a REST get operation, the
+/// field mask applies directly to the response, but in case of a REST
+/// list operation, the mask instead applies to each individual message
+/// in the returned resource list. In case of a REST custom method,
+/// other definitions may be used. Where the mask applies will be
+/// clearly documented together with its declaration in the API.  In
+/// any case, the effect on the returned resource/resources is required
+/// behavior for APIs.
+///
+/// # Field Masks in Update Operations
+///
+/// A field mask in update operations specifies which fields of the
+/// targeted resource are going to be updated. The API is required
+/// to only change the values of the fields as specified in the mask
+/// and leave the others untouched. If a resource is passed in to
+/// describe the updated values, the API ignores the values of all
+/// fields not covered by the mask.
+///
+/// If a repeated field is specified for an update operation, new values will
+/// be appended to the existing repeated field in the target resource. Note that
+/// a repeated field is only allowed in the last position of a `paths` string.
+///
+/// If a sub-message is specified in the last position of the field mask for an
+/// update operation, then new value will be merged into the existing sub-message
+/// in the target resource.
+///
+/// For example, given the target message:
+///
+///      f {
+///        b {
+///          d: 1
+///          x: 2
+///        }
+///        c: \[1\]
+///      }
+///
+/// And an update message:
+///
+///      f {
+///        b {
+///          d: 10
+///        }
+///        c: \[2\]
+///      }
+///
+/// then if the field mask is:
+///
+///   paths: ["f.b", "f.c"]
+///
+/// then the result will be:
+///
+///      f {
+///        b {
+///          d: 10
+///          x: 2
+///        }
+///        c: [1, 2]
+///      }
+///
+/// An implementation may provide options to override this default behavior for
+/// repeated and message fields.
+///
+/// In order to reset a field's value to the default, the field must
+/// be in the mask and set to the default value in the provided resource.
+/// Hence, in order to reset all fields of a resource, provide a default
+/// instance of the resource and set all fields in the mask, or do
+/// not provide a mask as described below.
+///
+/// If a field mask is not present on update, the operation applies to
+/// all fields (as if a field mask of all fields has been specified).
+/// Note that in the presence of schema evolution, this may mean that
+/// fields the client does not know and has therefore not filled into
+/// the request will be reset to their default. If this is unwanted
+/// behavior, a specific service may require a client to always specify
+/// a field mask, producing an error if not.
+///
+/// As with get operations, the location of the resource which
+/// describes the updated values in the request message depends on the
+/// operation kind. In any case, the effect of the field mask is
+/// required to be honored by the API.
+///
+/// ## Considerations for HTTP REST
+///
+/// The HTTP kind of an update operation which uses a field mask must
+/// be set to PATCH instead of PUT in order to satisfy HTTP semantics
+/// (PUT must only be used for full updates).
+///
+/// # JSON Encoding of Field Masks
+///
+/// In JSON, a field mask is encoded as a single string where paths are
+/// separated by a comma. Fields name in each path are converted
+/// to/from lower-camel naming conventions.
+///
+/// As an example, consider the following message declarations:
+///
+///      message Profile {
+///        User user = 1;
+///        Photo photo = 2;
+///      }
+///      message User {
+///        string display_name = 1;
+///        string address = 2;
+///      }
+///
+/// In proto a field mask for `Profile` may look as such:
+///
+///      mask {
+///        paths: "user.display_name"
+///        paths: "photo"
+///      }
+///
+/// In JSON, the same mask is represented as below:
+///
+///      {
+///        mask: "user.displayName,photo"
+///      }
+///
+/// # Field Masks and Oneof Fields
+///
+/// Field masks treat fields in oneofs just as regular fields. Consider the
+/// following message:
+///
+///      message SampleMessage {
+///        oneof test_oneof {
+///          string name = 4;
+///          SubMessage sub_message = 9;
+///        }
+///      }
+///
+/// The field mask can be:
+///
+///      mask {
+///        paths: "name"
+///      }
+///
+/// Or:
+///
+///      mask {
+///        paths: "sub_message"
+///      }
+///
+/// Note that oneof type names ("test_oneof" in this case) cannot be used in
+/// paths.
+///
+/// ## Field Mask Verification
+///
+/// The implementation of any API method which has a FieldMask type field in the
+/// request should verify the included field paths, and return an
+/// `INVALID_ARGUMENT` error if any path is unmappable.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FieldMask {
+    /// The set of field mask paths.
+    #[prost(string, repeated, tag="1")]
+    pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// `Struct` represents a structured data value, consisting of fields
+/// which map to dynamically typed values. In some languages, `Struct`
+/// might be supported by a native representation. For example, in
+/// scripting languages like JS a struct is represented as an
+/// object. The details of that representation are described together
+/// with the proto support for the language.
+///
+/// The JSON representation for `Struct` is JSON object.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Struct {
+    /// Unordered map of dynamically typed values.
+    #[prost(map="string, message", tag="1")]
+    pub fields: ::std::collections::HashMap<::prost::alloc::string::String, Value>,
+}
+/// `Value` represents a dynamically typed value which can be either
+/// null, a number, a string, a boolean, a recursive struct value, or a
+/// list of values. A producer of value is expected to set one of these
+/// variants. Absence of any variant indicates an error.
+///
+/// The JSON representation for `Value` is JSON value.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Value {
+    /// The kind of value.
+    #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
+    pub kind: ::core::option::Option<value::Kind>,
+}
+/// Nested message and enum types in `Value`.
+pub mod value {
+    /// The kind of value.
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Kind {
+        /// Represents a null value.
+        #[prost(enumeration="super::NullValue", tag="1")]
+        NullValue(i32),
+        /// Represents a double value.
+        #[prost(double, tag="2")]
+        NumberValue(f64),
+        /// Represents a string value.
+        #[prost(string, tag="3")]
+        StringValue(::prost::alloc::string::String),
+        /// Represents a boolean value.
+        #[prost(bool, tag="4")]
+        BoolValue(bool),
+        /// Represents a structured value.
+        #[prost(message, tag="5")]
+        StructValue(super::Struct),
+        /// Represents a repeated `Value`.
+        #[prost(message, tag="6")]
+        ListValue(super::ListValue),
+    }
+}
+/// `ListValue` is a wrapper around a repeated field of values.
+///
+/// The JSON representation for `ListValue` is JSON array.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListValue {
+    /// Repeated field of dynamically typed values.
+    #[prost(message, repeated, tag="1")]
+    pub values: ::prost::alloc::vec::Vec<Value>,
+}
+/// `NullValue` is a singleton enumeration to represent the null value for the
+/// `Value` type union.
+///
+/// The JSON representation for `NullValue` is JSON `null`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum NullValue {
+    /// Null value.
+    NullValue = 0,
+}
+impl NullValue {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            NullValue::NullValue => "NULL_VALUE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NULL_VALUE" => Some(Self::NullValue),
+            _ => None,
+        }
+    }
+}
+/// A Timestamp represents a point in time independent of any time zone or local
+/// calendar, encoded as a count of seconds and fractions of seconds at
+/// nanosecond resolution. The count is relative to an epoch at UTC midnight on
+/// January 1, 1970, in the proleptic Gregorian calendar which extends the
+/// Gregorian calendar backwards to year one.
+///
+/// All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+/// second table is needed for interpretation, using a [24-hour linear
+/// smear](<https://developers.google.com/time/smear>).
+///
+/// The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+/// restricting to that range, we ensure that we can convert to and from [RFC
+/// 3339](<https://www.ietf.org/rfc/rfc3339.txt>) date strings.
+///
+/// # Examples
+///
+/// Example 1: Compute Timestamp from POSIX `time()`.
+///
+///      Timestamp timestamp;
+///      timestamp.set_seconds(time(NULL));
+///      timestamp.set_nanos(0);
+///
+/// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+///
+///      struct timeval tv;
+///      gettimeofday(&tv, NULL);
+///
+///      Timestamp timestamp;
+///      timestamp.set_seconds(tv.tv_sec);
+///      timestamp.set_nanos(tv.tv_usec * 1000);
+///
+/// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+///
+///      FILETIME ft;
+///      GetSystemTimeAsFileTime(&ft);
+///      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+///
+///      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///      Timestamp timestamp;
+///      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///
+/// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+///
+///      long millis = System.currentTimeMillis();
+///
+///      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///          .setNanos((int) ((millis % 1000) * 1000000)).build();
+///
+/// Example 5: Compute Timestamp from Java `Instant.now()`.
+///
+///      Instant now = Instant.now();
+///
+///      Timestamp timestamp =
+///          Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+///              .setNanos(now.getNano()).build();
+///
+/// Example 6: Compute Timestamp from current time in Python.
+///
+///      timestamp = Timestamp()
+///      timestamp.GetCurrentTime()
+///
+/// # JSON Mapping
+///
+/// In JSON format, the Timestamp type is encoded as a string in the
+/// [RFC 3339](<https://www.ietf.org/rfc/rfc3339.txt>) format. That is, the
+/// format is "{year}-{month}-{day}T{hour}:{min}:{sec}\[.{frac_sec}\]Z"
+/// where {year} is always expressed using four digits while {month}, {day},
+/// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+/// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+/// are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+/// is required. A proto3 JSON serializer should always use UTC (as indicated by
+/// "Z") when printing the Timestamp type and a proto3 JSON parser should be
+/// able to accept both UTC and other timezones (as indicated by an offset).
+///
+/// For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+/// 01:30 UTC on January 15, 2017.
+///
+/// In JavaScript, one can convert a Date object to this format using the
+/// standard
+/// \[toISOString()\](<https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>)
+/// method. In Python, a standard `datetime.datetime` object can be converted
+/// to this format using
+/// \[`strftime`\](<https://docs.python.org/2/library/time.html#time.strftime>) with
+/// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+/// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](
+/// <http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime(>)
+/// ) to obtain a formatter capable of generating timestamps in this format.
+///
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Timestamp {
+    /// Represents seconds of UTC time since Unix epoch
+    /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+    /// 9999-12-31T23:59:59Z inclusive.
+    #[prost(int64, tag="1")]
+    pub seconds: i64,
+    /// Non-negative fractions of a second at nanosecond resolution. Negative
+    /// second values with fractions must still have non-negative nanos values
+    /// that count forward in time. Must be from 0 to 999,999,999
+    /// inclusive.
+    #[prost(int32, tag="2")]
+    pub nanos: i32,
+}
+/// Wrapper message for `double`.
+///
+/// The JSON representation for `DoubleValue` is JSON number.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DoubleValue {
+    /// The double value.
+    #[prost(double, tag="1")]
+    pub value: f64,
+}
+/// Wrapper message for `float`.
+///
+/// The JSON representation for `FloatValue` is JSON number.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FloatValue {
+    /// The float value.
+    #[prost(float, tag="1")]
+    pub value: f32,
+}
+/// Wrapper message for `int64`.
+///
+/// The JSON representation for `Int64Value` is JSON string.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Int64Value {
+    /// The int64 value.
+    #[prost(int64, tag="1")]
+    pub value: i64,
+}
+/// Wrapper message for `uint64`.
+///
+/// The JSON representation for `UInt64Value` is JSON string.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UInt64Value {
+    /// The uint64 value.
+    #[prost(uint64, tag="1")]
+    pub value: u64,
+}
+/// Wrapper message for `int32`.
+///
+/// The JSON representation for `Int32Value` is JSON number.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Int32Value {
+    /// The int32 value.
+    #[prost(int32, tag="1")]
+    pub value: i32,
+}
+/// Wrapper message for `uint32`.
+///
+/// The JSON representation for `UInt32Value` is JSON number.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UInt32Value {
+    /// The uint32 value.
+    #[prost(uint32, tag="1")]
+    pub value: u32,
+}
+/// Wrapper message for `bool`.
+///
+/// The JSON representation for `BoolValue` is JSON `true` and `false`.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BoolValue {
+    /// The bool value.
+    #[prost(bool, tag="1")]
+    pub value: bool,
+}
+/// Wrapper message for `string`.
+///
+/// The JSON representation for `StringValue` is JSON string.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StringValue {
+    /// The string value.
+    #[prost(string, tag="1")]
+    pub value: ::prost::alloc::string::String,
+}
+/// Wrapper message for `bytes`.
+///
+/// The JSON representation for `BytesValue` is JSON string.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BytesValue {
+    /// The bytes value.
+    #[prost(bytes="vec", tag="1")]
+    pub value: ::prost::alloc::vec::Vec<u8>,
+}
+// @@protoc_insertion_point(module)

--- a/src/gen/google.rpc.context.rs
+++ b/src/gen/google.rpc.context.rs
@@ -50,7 +50,7 @@ pub struct AttributeContext {
     pub api: ::core::option::Option<attribute_context::Api>,
     /// Supports extensions for advanced use cases, such as logs and metrics.
     #[prost(message, repeated, tag="8")]
-    pub extensions: ::prost::alloc::vec::Vec<::prost_types::Any>,
+    pub extensions: ::prost::alloc::vec::Vec<super::super::protobuf::Any>,
 }
 /// Nested message and enum types in `AttributeContext`.
 pub mod attribute_context {
@@ -157,7 +157,7 @@ pub mod attribute_context {
         /// SAML assertions are similarly specified, but with an identity provider
         /// dependent structure.
         #[prost(message, optional, tag="4")]
-        pub claims: ::core::option::Option<::prost_types::Struct>,
+        pub claims: ::core::option::Option<super::super::super::protobuf::Struct>,
         /// A list of access level resource names that allow resources to be
         /// accessed by authenticated requester. It is part of Secure GCP processing
         /// for the incoming request. An access level string has the format:
@@ -203,7 +203,7 @@ pub mod attribute_context {
         /// The timestamp when the `destination` service receives the last byte of
         /// the request.
         #[prost(message, optional, tag="9")]
-        pub time: ::core::option::Option<::prost_types::Timestamp>,
+        pub time: ::core::option::Option<super::super::super::protobuf::Timestamp>,
         /// The HTTP request size in bytes. If unknown, it must be -1.
         #[prost(int64, tag="10")]
         pub size: i64,
@@ -241,13 +241,13 @@ pub mod attribute_context {
         /// The timestamp when the `destination` service sends the last byte of
         /// the response.
         #[prost(message, optional, tag="4")]
-        pub time: ::core::option::Option<::prost_types::Timestamp>,
+        pub time: ::core::option::Option<super::super::super::protobuf::Timestamp>,
         /// The amount of time it takes the backend service to fully respond to a
         /// request. Measured from when the destination service starts to send the
         /// request to the backend until when the destination service receives the
         /// complete response from the backend.
         #[prost(message, optional, tag="5")]
-        pub backend_latency: ::core::option::Option<::prost_types::Duration>,
+        pub backend_latency: ::core::option::Option<super::super::super::protobuf::Duration>,
     }
     /// This message defines core attributes for a resource. A resource is an
     /// addressable (named) entity provided by the destination service. For
@@ -305,16 +305,16 @@ pub mod attribute_context {
         /// Output only. The timestamp when the resource was created. This may
         /// be either the time creation was initiated or when it was completed.
         #[prost(message, optional, tag="8")]
-        pub create_time: ::core::option::Option<::prost_types::Timestamp>,
+        pub create_time: ::core::option::Option<super::super::super::protobuf::Timestamp>,
         /// Output only. The timestamp when the resource was last updated. Any
         /// change to the resource made by users must refresh this value.
         /// Changes to a resource made by the service should refresh this value.
         #[prost(message, optional, tag="9")]
-        pub update_time: ::core::option::Option<::prost_types::Timestamp>,
+        pub update_time: ::core::option::Option<super::super::super::protobuf::Timestamp>,
         /// Output only. The timestamp when the resource was deleted.
         /// If the resource is not deleted, this must be empty.
         #[prost(message, optional, tag="10")]
-        pub delete_time: ::core::option::Option<::prost_types::Timestamp>,
+        pub delete_time: ::core::option::Option<super::super::super::protobuf::Timestamp>,
         /// Output only. An opaque value that uniquely identifies a version or
         /// generation of a resource. It can be used to confirm that the client
         /// and server agree on the ordering of a resource being written.

--- a/src/gen/google.rpc.rs
+++ b/src/gen/google.rpc.rs
@@ -22,7 +22,7 @@ pub struct Status {
     /// A list of messages that carry the error details.  There is a common set of
     /// message types for APIs to use.
     #[prost(message, repeated, tag="3")]
-    pub details: ::prost::alloc::vec::Vec<::prost_types::Any>,
+    pub details: ::prost::alloc::vec::Vec<super::protobuf::Any>,
 }
 /// The canonical error codes for gRPC APIs.
 ///
@@ -293,7 +293,7 @@ pub struct ErrorInfo {
 pub struct RetryInfo {
     /// Clients should wait at least this long between retrying the same request.
     #[prost(message, optional, tag="1")]
-    pub retry_delay: ::core::option::Option<::prost_types::Duration>,
+    pub retry_delay: ::core::option::Option<super::protobuf::Duration>,
 }
 /// Describes additional debugging info.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/src/gen/proto.rpc.webrtc.v1.rs
+++ b/src/gen/proto.rpc.webrtc.v1.rs
@@ -51,7 +51,7 @@ pub struct RequestHeaders {
     #[prost(message, optional, tag="2")]
     pub metadata: ::core::option::Option<Metadata>,
     #[prost(message, optional, tag="3")]
-    pub timeout: ::core::option::Option<::prost_types::Duration>,
+    pub timeout: ::core::option::Option<super::super::super::super::google::protobuf::Duration>,
 }
 /// A RequestMessage contains individual gRPC messages and a potential
 /// end-of-stream (EOS) marker.
@@ -250,7 +250,7 @@ pub struct AnswerRequestInitStage {
     #[prost(message, optional, tag="2")]
     pub optional_config: ::core::option::Option<WebRtcConfig>,
     #[prost(message, optional, tag="3")]
-    pub deadline: ::core::option::Option<::prost_types::Timestamp>,
+    pub deadline: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 /// AnswerRequestUpdateStage is multiply used to trickle in ICE candidates to
 /// the controlled (answerer) side.

--- a/src/gen/viam.app.cloudslam.v1.rs
+++ b/src/gen/viam.app.cloudslam.v1.rs
@@ -6,7 +6,7 @@
 pub struct StartMappingSessionRequest {
     /// The given config contains details such as sensor, map package and algorithm-specific fields required to run slam.
     #[prost(message, optional, tag="1")]
-    pub slam_config: ::core::option::Option<::prost_types::Struct>,
+    pub slam_config: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
     /// Version to use for slam, defaults stable
     #[prost(string, tag="2")]
     pub slam_version: ::prost::alloc::string::String,
@@ -21,6 +21,8 @@ pub struct StartMappingSessionRequest {
     /// Version to use for viam, defaults stable
     #[prost(string, tag="7")]
     pub viam_server_version: ::prost::alloc::string::String,
+    #[prost(bool, tag="8")]
+    pub is_online: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -84,8 +86,6 @@ pub struct ListMappingSessionsResponse {
 pub struct StopMappingSessionRequest {
     #[prost(string, tag="1")]
     pub session_id: ::prost::alloc::string::String,
-    #[prost(bool, tag="2")]
-    pub save_map: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -94,6 +94,41 @@ pub struct StopMappingSessionResponse {
     pub package_id: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
+}
+// GetMappingSessionMetadataByID
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetMappingSessionMetadataByIdRequest {
+    #[prost(string, tag="1")]
+    pub session_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetMappingSessionMetadataByIdResponse {
+    #[prost(message, optional, tag="1")]
+    pub session_metadata: ::core::option::Option<MappingMetadata>,
+}
+// UpdateMappingSessionMetadataByID
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateMappingSessionMetadataByIdRequest {
+    #[prost(string, tag="1")]
+    pub session_id: ::prost::alloc::string::String,
+    /// “success”, “failed to start”, etc
+    #[prost(string, tag="2")]
+    pub end_status: ::prost::alloc::string::String,
+    /// set at the time of job closeout and used as the package version
+    #[prost(message, optional, tag="3")]
+    pub time_cloud_run_job_ended: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
+    /// additional details on the end status if needed, such as errors
+    #[prost(string, tag="4")]
+    pub error_msg: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateMappingSessionMetadataByIdResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -109,16 +144,16 @@ pub struct MappingMetadata {
     pub robot_id: ::prost::alloc::string::String,
     /// time this document was created
     #[prost(message, optional, tag="4")]
-    pub time_start_submitted: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_start_submitted: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     /// time the cloud run job started
     #[prost(message, optional, tag="5")]
-    pub time_cloud_run_job_started: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_cloud_run_job_started: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     /// time StopSlamSession was called
     #[prost(message, optional, tag="6")]
-    pub time_end_submitted: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_end_submitted: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     /// time the cloud run job ended
     #[prost(message, optional, tag="7")]
-    pub time_cloud_run_job_ended: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_cloud_run_job_ended: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     /// “success”, “failed to start”, etc
     #[prost(string, tag="8")]
     pub end_status: ::prost::alloc::string::String,
@@ -137,5 +172,8 @@ pub struct MappingMetadata {
     /// a robot config for a slam session
     #[prost(string, tag="13")]
     pub config: ::prost::alloc::string::String,
+    /// additional details on the end status if needed, such as errors
+    #[prost(string, tag="14")]
+    pub error_msg: ::prost::alloc::string::String,
 }
 // @@protoc_insertion_point(module)

--- a/src/gen/viam.app.data.v1.rs
+++ b/src/gen/viam.app.data.v1.rs
@@ -86,7 +86,7 @@ pub struct CaptureMetadata {
     #[prost(string, tag="10")]
     pub method_name: ::prost::alloc::string::String,
     #[prost(map="string, message", tag="11")]
-    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Any>,
+    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::super::google::protobuf::Any>,
     #[prost(string, repeated, tag="12")]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, tag="13")]
@@ -97,9 +97,9 @@ pub struct CaptureMetadata {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CaptureInterval {
     #[prost(message, optional, tag="1")]
-    pub start: ::core::option::Option<::prost_types::Timestamp>,
+    pub start: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
-    pub end: ::core::option::Option<::prost_types::Timestamp>,
+    pub end: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 /// TabularDataByFilterRequest requests tabular data based on filter values
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -109,6 +109,8 @@ pub struct TabularDataByFilterRequest {
     pub data_request: ::core::option::Option<DataRequest>,
     #[prost(bool, tag="2")]
     pub count_only: bool,
+    #[prost(bool, tag="3")]
+    pub include_internal_data: bool,
 }
 /// TabularDataByFilterResponse provides the data and metadata of tabular data
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -129,13 +131,13 @@ pub struct TabularDataByFilterResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TabularData {
     #[prost(message, optional, tag="1")]
-    pub data: ::core::option::Option<::prost_types::Struct>,
+    pub data: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
     #[prost(uint32, tag="2")]
     pub metadata_index: u32,
     #[prost(message, optional, tag="3")]
-    pub time_requested: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_requested: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="4")]
-    pub time_received: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_received: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -155,6 +157,8 @@ pub struct BinaryDataByFilterRequest {
     pub include_binary: bool,
     #[prost(bool, tag="3")]
     pub count_only: bool,
+    #[prost(bool, tag="4")]
+    pub include_internal_data: bool,
 }
 /// BinaryDataByFilterResponse provides the data and metadata of binary (image + file) data when a filter is provided
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -187,10 +191,6 @@ pub struct BinaryDataByIDsRequest {
     pub include_binary: bool,
     #[prost(message, repeated, tag="3")]
     pub binary_ids: ::prost::alloc::vec::Vec<BinaryId>,
-    /// Replaced by binary_ids
-    #[deprecated]
-    #[prost(string, repeated, tag="1")]
-    pub file_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// BinaryDataByIDsResponse provides the data and metadata of binary (image + file) data when a filter is provided
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -234,9 +234,9 @@ pub struct BinaryMetadata {
     #[prost(message, optional, tag="2")]
     pub capture_metadata: ::core::option::Option<CaptureMetadata>,
     #[prost(message, optional, tag="3")]
-    pub time_requested: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_requested: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="4")]
-    pub time_received: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_received: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="5")]
     pub file_name: ::prost::alloc::string::String,
     #[prost(string, tag="6")]
@@ -260,12 +260,32 @@ pub struct DeleteTabularDataByFilterResponse {
     #[prost(uint64, tag="1")]
     pub deleted_count: u64,
 }
+/// DeleteTabularDataRequest deletes the data from the organization that is older than `delete_older_than_days`.
+/// For example if `delete_older_than_days` is 10, this deletes any data that was captured up to 10 days ago.
+/// If it is 0, all existing data is deleted.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteTabularDataRequest {
+    #[prost(string, tag="1")]
+    pub organization_id: ::prost::alloc::string::String,
+    #[prost(uint32, tag="2")]
+    pub delete_older_than_days: u32,
+}
+/// DeleteBinaryDataResponse returns the number of tabular datapoints deleted.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteTabularDataResponse {
+    #[prost(uint64, tag="1")]
+    pub deleted_count: u64,
+}
 /// DeleteBinaryDataByFilterRequest deletes the data and metadata of binary data when a filter is provided
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteBinaryDataByFilterRequest {
     #[prost(message, optional, tag="1")]
     pub filter: ::core::option::Option<Filter>,
+    #[prost(bool, tag="2")]
+    pub include_internal_data: bool,
 }
 /// DeleteBinaryDataByFilterResponse returns the number of binary files deleted when a filter is provided
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -280,10 +300,6 @@ pub struct DeleteBinaryDataByFilterResponse {
 pub struct DeleteBinaryDataByIDsRequest {
     #[prost(message, repeated, tag="2")]
     pub binary_ids: ::prost::alloc::vec::Vec<BinaryId>,
-    /// Replaced by binary_ids
-    #[deprecated]
-    #[prost(string, repeated, tag="1")]
-    pub file_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// DeleteBinaryDataByIDsResponse returns the number of binary files deleted when binary ids are provided
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -300,10 +316,6 @@ pub struct AddTagsToBinaryDataByIDsRequest {
     pub binary_ids: ::prost::alloc::vec::Vec<BinaryId>,
     #[prost(string, repeated, tag="2")]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Replaced by binary_ids
-    #[deprecated]
-    #[prost(string, repeated, tag="1")]
-    pub file_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -330,10 +342,6 @@ pub struct RemoveTagsFromBinaryDataByIDsRequest {
     pub binary_ids: ::prost::alloc::vec::Vec<BinaryId>,
     #[prost(string, repeated, tag="2")]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
-    /// Replaced by binary_ids
-    #[deprecated]
-    #[prost(string, repeated, tag="1")]
-    pub file_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// RemoveTagsFromBinaryDataByIDsResponse returns the number of binary files which had tags removed
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -387,10 +395,6 @@ pub struct AddBoundingBoxToImageByIdRequest {
     pub x_max_normalized: f64,
     #[prost(double, tag="6")]
     pub y_max_normalized: f64,
-    /// Replaced by binary_id
-    #[deprecated]
-    #[prost(string, tag="1")]
-    pub file_id: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -405,10 +409,6 @@ pub struct RemoveBoundingBoxFromImageByIdRequest {
     pub binary_id: ::core::option::Option<BinaryId>,
     #[prost(string, tag="2")]
     pub bbox_id: ::prost::alloc::string::String,
-    /// Replaced by binary_id
-    #[deprecated]
-    #[prost(string, tag="1")]
-    pub file_id: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -425,6 +425,33 @@ pub struct BoundingBoxLabelsByFilterRequest {
 pub struct BoundingBoxLabelsByFilterResponse {
     #[prost(string, repeated, tag="1")]
     pub labels: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+/// ConfigureDatabaseUserRequest accepts a Viam organization ID and a password for the database user
+/// being configured. Viam uses gRPC over TLS, so the entire request will be encrypted while in
+/// flight, including the password.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConfigureDatabaseUserRequest {
+    #[prost(string, tag="1")]
+    pub organization_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub password: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ConfigureDatabaseUserResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetDatabaseConnectionRequest {
+    #[prost(string, tag="1")]
+    pub organization_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetDatabaseConnectionResponse {
+    #[prost(string, tag="1")]
+    pub hostname: ::prost::alloc::string::String,
 }
 /// Order specifies the order in which data is returned.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/src/gen/viam.app.datasync.v1.rs
+++ b/src/gen/viam.app.datasync.v1.rs
@@ -38,11 +38,34 @@ pub struct FileUploadResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamingDataCaptureUploadRequest {
+    #[prost(oneof="streaming_data_capture_upload_request::UploadPacket", tags="1, 2")]
+    pub upload_packet: ::core::option::Option<streaming_data_capture_upload_request::UploadPacket>,
+}
+/// Nested message and enum types in `StreamingDataCaptureUploadRequest`.
+pub mod streaming_data_capture_upload_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum UploadPacket {
+        #[prost(message, tag="1")]
+        Metadata(super::DataCaptureUploadMetadata),
+        #[prost(bytes, tag="2")]
+        Data(::prost::alloc::vec::Vec<u8>),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct StreamingDataCaptureUploadResponse {
+    #[prost(string, tag="1")]
+    pub file_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SensorMetadata {
     #[prost(message, optional, tag="1")]
-    pub time_requested: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_requested: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
-    pub time_received: ::core::option::Option<::prost_types::Timestamp>,
+    pub time_received: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -58,7 +81,7 @@ pub mod sensor_data {
 #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
         #[prost(message, tag="2")]
-        Struct(::prost_types::Struct),
+        Struct(super::super::super::super::super::google::protobuf::Struct),
         #[prost(bytes, tag="3")]
         Binary(::prost::alloc::vec::Vec<u8>),
     }
@@ -85,7 +108,7 @@ pub struct UploadMetadata {
     #[prost(string, tag="7")]
     pub file_name: ::prost::alloc::string::String,
     #[prost(map="string, message", tag="8")]
-    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Any>,
+    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::super::google::protobuf::Any>,
     #[prost(string, tag="9")]
     pub file_extension: ::prost::alloc::string::String,
     #[prost(string, repeated, tag="10")]
@@ -95,9 +118,9 @@ pub struct UploadMetadata {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CaptureInterval {
     #[prost(message, optional, tag="1")]
-    pub start: ::core::option::Option<::prost_types::Timestamp>,
+    pub start: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
-    pub end: ::core::option::Option<::prost_types::Timestamp>,
+    pub end: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -111,11 +134,19 @@ pub struct DataCaptureMetadata {
     #[prost(enumeration="DataType", tag="5")]
     pub r#type: i32,
     #[prost(map="string, message", tag="6")]
-    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Any>,
+    pub method_parameters: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::super::google::protobuf::Any>,
     #[prost(string, tag="7")]
     pub file_extension: ::prost::alloc::string::String,
     #[prost(string, repeated, tag="8")]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DataCaptureUploadMetadata {
+    #[prost(message, optional, tag="1")]
+    pub upload_metadata: ::core::option::Option<UploadMetadata>,
+    #[prost(message, optional, tag="2")]
+    pub sensor_metadata: ::core::option::Option<SensorMetadata>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/src/gen/viam.app.mltraining.v1.rs
+++ b/src/gen/viam.app.mltraining.v1.rs
@@ -55,13 +55,11 @@ pub struct TrainingJobMetadata {
     #[prost(enumeration="TrainingStatus", tag="2")]
     pub status: i32,
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="4")]
-    pub last_modified: ::core::option::Option<::prost_types::Timestamp>,
+    pub last_modified: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="5")]
     pub synced_model_id: ::prost::alloc::string::String,
-    #[prost(string, tag="6")]
-    pub user_email: ::prost::alloc::string::String,
     #[prost(string, tag="7")]
     pub id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="8")]

--- a/src/gen/viam.app.packages.v1.rs
+++ b/src/gen/viam.app.packages.v1.rs
@@ -23,7 +23,7 @@ pub struct PackageInfo {
     #[prost(message, repeated, tag="5")]
     pub files: ::prost::alloc::vec::Vec<FileInfo>,
     #[prost(message, optional, tag="6")]
-    pub metadata: ::core::option::Option<::prost_types::Struct>,
+    pub metadata: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -60,6 +60,8 @@ pub struct DeletePackageRequest {
     pub id: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
+    #[prost(enumeration="PackageType", tag="3")]
+    pub r#type: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -73,7 +75,7 @@ pub struct Package {
     #[prost(string, tag="2")]
     pub url: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="4")]
     pub checksum: ::prost::alloc::string::String,
     #[prost(string, tag="5")]
@@ -127,6 +129,7 @@ pub enum PackageType {
     MlModel = 2,
     Module = 3,
     SlamMap = 4,
+    BoardDefs = 5,
 }
 impl PackageType {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -140,6 +143,7 @@ impl PackageType {
             PackageType::MlModel => "PACKAGE_TYPE_ML_MODEL",
             PackageType::Module => "PACKAGE_TYPE_MODULE",
             PackageType::SlamMap => "PACKAGE_TYPE_SLAM_MAP",
+            PackageType::BoardDefs => "PACKAGE_TYPE_BOARD_DEFS",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -150,6 +154,7 @@ impl PackageType {
             "PACKAGE_TYPE_ML_MODEL" => Some(Self::MlModel),
             "PACKAGE_TYPE_MODULE" => Some(Self::Module),
             "PACKAGE_TYPE_SLAM_MAP" => Some(Self::SlamMap),
+            "PACKAGE_TYPE_BOARD_DEFS" => Some(Self::BoardDefs),
             _ => None,
         }
     }

--- a/src/gen/viam.app.v1.rs
+++ b/src/gen/viam.app.v1.rs
@@ -9,9 +9,9 @@ pub struct Robot {
     #[prost(string, tag="3")]
     pub location: ::prost::alloc::string::String,
     #[prost(message, optional, tag="4")]
-    pub last_access: ::core::option::Option<::prost_types::Timestamp>,
+    pub last_access: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="5")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -32,11 +32,11 @@ pub struct RobotPart {
     #[prost(string, tag="12")]
     pub location_id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="5")]
-    pub robot_config: ::core::option::Option<::prost_types::Struct>,
+    pub robot_config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(message, optional, tag="6")]
-    pub last_access: ::core::option::Option<::prost_types::Timestamp>,
+    pub last_access: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="7")]
-    pub user_supplied_info: ::core::option::Option<::prost_types::Struct>,
+    pub user_supplied_info: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(bool, tag="8")]
     pub main_part: bool,
     #[prost(string, tag="9")]
@@ -44,7 +44,7 @@ pub struct RobotPart {
     #[prost(string, tag="11")]
     pub local_fqdn: ::prost::alloc::string::String,
     #[prost(message, optional, tag="13")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     /// List of secrets allowed for authentication.
     #[prost(message, repeated, tag="14")]
     pub secrets: ::prost::alloc::vec::Vec<SharedSecret>,
@@ -57,7 +57,7 @@ pub struct RobotPartHistoryEntry {
     #[prost(string, tag="2")]
     pub robot: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub when: ::core::option::Option<::prost_types::Timestamp>,
+    pub when: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="4")]
     pub old: ::core::option::Option<RobotPart>,
 }
@@ -73,13 +73,15 @@ pub struct Organization {
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="4")]
     pub public_namespace: ::prost::alloc::string::String,
     /// GCS region of the organization. Locations created under this org will have their GCS region set to this by default and packages
     /// associated with this org will be stored in this region.
     #[prost(string, tag="5")]
     pub default_region: ::prost::alloc::string::String,
+    #[prost(string, optional, tag="6")]
+    pub cid: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,7 +91,9 @@ pub struct OrganizationMember {
     #[prost(string, repeated, tag="2")]
     pub emails: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(message, optional, tag="3")]
-    pub date_added: ::core::option::Option<::prost_types::Timestamp>,
+    pub date_added: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+    #[prost(message, optional, tag="4")]
+    pub last_login: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -105,9 +109,9 @@ pub struct OrganizationInvite {
     #[prost(string, tag="2")]
     pub email: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
-    #[prost(int64, tag="4")]
-    pub robot_count: i64,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+    #[prost(message, repeated, tag="4")]
+    pub authorizations: ::prost::alloc::vec::Vec<Authorization>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -157,6 +161,8 @@ pub struct UpdateOrganizationRequest {
     /// The new GCS region to associate the org with.
     #[prost(string, optional, tag="4")]
     pub region: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="5")]
+    pub cid: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -316,7 +322,7 @@ pub struct Location {
     pub organizations: ::prost::alloc::vec::Vec<LocationOrganization>,
     /// Location creation timestamp.
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     ///
     #[prost(int32, tag="7")]
     pub robot_count: i32,
@@ -335,7 +341,7 @@ pub struct SharedSecret {
     pub secret: ::prost::alloc::string::String,
     /// Date/time the secret was first created.
     #[prost(message, optional, tag="3")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     /// State of the shared secret. In most cases it should be enabled. We may support
     /// disabling a specific secret while keeping it in the database.
     #[prost(enumeration="shared_secret::State", tag="4")]
@@ -604,17 +610,17 @@ pub struct LogEntry {
     #[prost(string, tag="2")]
     pub level: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub time: ::core::option::Option<::prost_types::Timestamp>,
+    pub time: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="4")]
     pub logger_name: ::prost::alloc::string::String,
     #[prost(string, tag="5")]
     pub message: ::prost::alloc::string::String,
     #[prost(message, optional, tag="6")]
-    pub caller: ::core::option::Option<::prost_types::Struct>,
+    pub caller: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(string, tag="7")]
     pub stack: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="8")]
-    pub fields: ::prost::alloc::vec::Vec<::prost_types::Struct>,
+    pub fields: ::prost::alloc::vec::Vec<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -660,7 +666,7 @@ pub struct UpdateRobotPartRequest {
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub robot_config: ::core::option::Option<::prost_types::Struct>,
+    pub robot_config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -690,6 +696,30 @@ pub struct DeleteRobotPartRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotApiKeysRequest {
+    #[prost(string, tag="1")]
+    pub robot_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ApiKey {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="4")]
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotApiKeysResponse {
+    #[prost(message, repeated, tag="1")]
+    pub api_keys: ::prost::alloc::vec::Vec<ApiKey>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteRobotPartResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -700,13 +730,13 @@ pub struct Fragment {
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub fragment: ::core::option::Option<::prost_types::Struct>,
+    pub fragment: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(string, tag="4")]
     pub organization_owner: ::prost::alloc::string::String,
     #[prost(bool, tag="5")]
     pub public: bool,
     #[prost(message, optional, tag="6")]
-    pub created_on: ::core::option::Option<::prost_types::Timestamp>,
+    pub created_on: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="7")]
     pub organization_name: ::prost::alloc::string::String,
     /// number of robot parts using this fragment
@@ -751,7 +781,7 @@ pub struct CreateFragmentRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub config: ::core::option::Option<::prost_types::Struct>,
+    pub config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(string, tag="3")]
     pub organization_id: ::prost::alloc::string::String,
 }
@@ -769,7 +799,7 @@ pub struct UpdateFragmentRequest {
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub config: ::core::option::Option<::prost_types::Struct>,
+    pub config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(bool, optional, tag="4")]
     pub public: ::core::option::Option<bool>,
 }
@@ -902,6 +932,8 @@ pub struct Authorization {
     pub identity_id: ::prost::alloc::string::String,
     #[prost(string, tag="6")]
     pub organization_id: ::prost::alloc::string::String,
+    #[prost(string, tag="7")]
+    pub identity_type: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -922,6 +954,18 @@ pub struct RemoveRoleRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveRoleResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChangeRoleRequest {
+    #[prost(message, optional, tag="1")]
+    pub old_authorization: ::core::option::Option<Authorization>,
+    #[prost(message, optional, tag="2")]
+    pub new_authorization: ::core::option::Option<Authorization>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ChangeRoleResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -974,7 +1018,7 @@ pub struct CreateModuleRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateModuleResponse {
-    /// The id of the module containing the namespace and name
+    /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
     /// The detail page of the module
@@ -984,12 +1028,9 @@ pub struct CreateModuleResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateModuleRequest {
-    /// The id of the module being updated, containing module name or namespace and module name
+    /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
-    /// The organization of the module being updated, required if no namespace exists in the module_id
-    #[prost(string, optional, tag="7")]
-    pub organization_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The visibility that should be set for the module
     #[prost(enumeration="Visibility", tag="2")]
     pub visibility: i32,
@@ -1026,12 +1067,9 @@ pub struct Model {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ModuleFileInfo {
-    /// The id of the module being uploaded, containing module name or namespace and module name
+    /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
-    /// The organization of the module being updated, required if no namespace exists in the module_id
-    #[prost(string, optional, tag="4")]
-    pub organization_id: ::core::option::Option<::prost::alloc::string::String>,
     /// The semver string that represents the new major/minor/patch version of the module
     #[prost(string, tag="2")]
     pub version: ::prost::alloc::string::String,
@@ -1068,12 +1106,9 @@ pub struct UploadModuleFileResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetModuleRequest {
-    /// The id of the module being retrieved, containing module name or namespace and module name
+    /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
-    /// The organization of the module being updated, required if no namespace exists in the module_id
-    #[prost(string, optional, tag="2")]
-    pub organization_id: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1085,12 +1120,9 @@ pub struct GetModuleResponse {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Module {
-    /// The id of the module, containing module name or namespace and module name
+    /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
-    /// The id of the organization that owns the module
-    #[prost(string, tag="10")]
-    pub organization_id: ::prost::alloc::string::String,
     /// The name of the module
     #[prost(string, tag="2")]
     pub name: ::prost::alloc::string::String,
@@ -1098,6 +1130,7 @@ pub struct Module {
     #[prost(enumeration="Visibility", tag="3")]
     pub visibility: i32,
     /// The versions of the module that are available
+    /// When this is returned from the backend, the versions are sorted in ascending order by the semver version
     #[prost(message, repeated, tag="4")]
     pub versions: ::prost::alloc::vec::Vec<VersionHistory>,
     /// The url to reference for documentation, code, etc.
@@ -1109,15 +1142,22 @@ pub struct Module {
     /// A list of models that are available in the module
     #[prost(message, repeated, tag="7")]
     pub models: ::prost::alloc::vec::Vec<Model>,
-    /// The executable to run to start the module program
-    #[prost(string, tag="11")]
-    pub entrypoint: ::prost::alloc::string::String,
     /// The total number of robots using this module
     #[prost(int64, tag="8")]
     pub total_robot_usage: i64,
     /// The total number of organizations using this module
     #[prost(int64, tag="9")]
     pub total_organization_usage: i64,
+    /// The id of the organization that owns the module
+    #[prost(string, tag="10")]
+    pub organization_id: ::prost::alloc::string::String,
+    /// The executable to run to start the module program
+    #[prost(string, tag="11")]
+    pub entrypoint: ::prost::alloc::string::String,
+    /// The public namespace of the organization that owns the module
+    /// This is empty if no public namespace is set
+    #[prost(string, tag="12")]
+    pub public_namespace: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1128,6 +1168,12 @@ pub struct VersionHistory {
     /// The uploads that are available for this module version
     #[prost(message, repeated, tag="2")]
     pub files: ::prost::alloc::vec::Vec<Uploads>,
+    /// The models that this verion of the module provides
+    #[prost(message, repeated, tag="3")]
+    pub models: ::prost::alloc::vec::Vec<Model>,
+    /// The entrypoint for this version of the module
+    #[prost(string, tag="4")]
+    pub entrypoint: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1137,7 +1183,7 @@ pub struct Uploads {
     pub platform: ::prost::alloc::string::String,
     /// The time when the file was uploaded
     #[prost(message, optional, tag="2")]
-    pub uploaded_at: ::core::option::Option<::prost_types::Timestamp>,
+    pub uploaded_at: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1184,6 +1230,22 @@ pub struct OrgDetails {
 pub struct ListOrganizationsByUserResponse {
     #[prost(message, repeated, tag="1")]
     pub orgs: ::prost::alloc::vec::Vec<OrgDetails>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateKeyRequest {
+    #[prost(message, repeated, tag="1")]
+    pub authorizations: ::prost::alloc::vec::Vec<Authorization>,
+    #[prost(string, tag="2")]
+    pub name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateKeyResponse {
+    #[prost(string, tag="1")]
+    pub key: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub id: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
@@ -1251,15 +1313,15 @@ pub struct InvoiceSummary {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub invoice_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub invoice_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(double, tag="3")]
     pub invoice_amount: f64,
     #[prost(string, tag="4")]
     pub status: ::prost::alloc::string::String,
     #[prost(message, optional, tag="5")]
-    pub due_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub due_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="6")]
-    pub paid_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub paid_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1275,7 +1337,7 @@ pub struct BillableResourceEvent {
     #[prost(string, tag="5")]
     pub usage_cost: ::prost::alloc::string::String,
     #[prost(message, optional, tag="6")]
-    pub occurred_at: ::core::option::Option<::prost_types::Timestamp>,
+    pub occurred_at: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="7")]
     pub user_name: ::prost::alloc::string::String,
 }
@@ -1285,13 +1347,13 @@ pub struct Invoice {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub invoice_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub invoice_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(double, tag="3")]
     pub invoice_amount: f64,
     #[prost(string, tag="4")]
     pub status: ::prost::alloc::string::String,
     #[prost(message, optional, tag="5")]
-    pub due_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub due_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, repeated, tag="6")]
     pub items: ::prost::alloc::vec::Vec<BillableResourceEvent>,
     #[prost(string, tag="7")]
@@ -1351,9 +1413,9 @@ pub struct GetCurrentMonthUsageRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCurrentMonthUsageResponse {
     #[prost(message, optional, tag="1")]
-    pub start_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub start_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
-    pub end_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub end_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(double, tag="3")]
     pub cloud_storage_usage_cost: f64,
     #[prost(double, tag="4")]
@@ -1385,7 +1447,7 @@ pub struct GetUnpaidBalanceResponse {
     #[prost(double, tag="1")]
     pub unpaid_balance: f64,
     #[prost(message, optional, tag="2")]
-    pub unpaid_balance_due_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub unpaid_balance_due_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 /// TODO(APP-1865) may want to remove
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1431,6 +1493,9 @@ pub struct GetOrgBillingInformationResponse {
     /// defined if type is PAYMENT_METHOD_TYPE_CARD
     #[prost(message, optional, tag="3")]
     pub method: ::core::option::Option<PaymentMethodCard>,
+    /// Only return billing_tier for billing dashboard admin users
+    #[prost(string, optional, tag="4")]
+    pub billing_tier: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1474,7 +1539,7 @@ pub struct GetBillingSummaryResponse {
     pub current_month_balance: f64,
     /// due date for current month usage
     #[prost(message, optional, tag="7")]
-    pub current_month_due_date: ::core::option::Option<::prost_types::Timestamp>,
+    pub current_month_due_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, tag="8")]
     pub invoice_email: ::prost::alloc::string::String,
     #[prost(message, optional, tag="9")]
@@ -1604,7 +1669,7 @@ pub struct ComponentConfig {
     #[prost(message, repeated, tag="7")]
     pub service_configs: ::prost::alloc::vec::Vec<ResourceLevelServiceConfig>,
     #[prost(message, optional, tag="8")]
-    pub attributes: ::core::option::Option<::prost_types::Struct>,
+    pub attributes: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(string, tag="9")]
     pub api: ::prost::alloc::string::String,
 }
@@ -1616,7 +1681,7 @@ pub struct ResourceLevelServiceConfig {
     pub r#type: ::prost::alloc::string::String,
     /// TODO(adam): Should this be move to a structured type as defined in the typescript frontend.
     #[prost(message, optional, tag="2")]
-    pub attributes: ::core::option::Option<::prost_types::Struct>,
+    pub attributes: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 /// A ProcessConfig describes how to manage a system process.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1637,7 +1702,7 @@ pub struct ProcessConfig {
     #[prost(int32, tag="7")]
     pub stop_signal: i32,
     #[prost(message, optional, tag="8")]
-    pub stop_timeout: ::core::option::Option<::prost_types::Duration>,
+    pub stop_timeout: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1651,13 +1716,15 @@ pub struct ServiceConfig {
     #[prost(string, tag="3")]
     pub r#type: ::prost::alloc::string::String,
     #[prost(message, optional, tag="4")]
-    pub attributes: ::core::option::Option<::prost_types::Struct>,
+    pub attributes: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(string, repeated, tag="5")]
     pub depends_on: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     #[prost(string, tag="6")]
     pub model: ::prost::alloc::string::String,
     #[prost(string, tag="9")]
     pub api: ::prost::alloc::string::String,
+    #[prost(message, repeated, tag="10")]
+    pub service_configs: ::prost::alloc::vec::Vec<ResourceLevelServiceConfig>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1677,7 +1744,7 @@ pub struct NetworkConfig {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SessionsConfig {
     #[prost(message, optional, tag="1")]
-    pub heartbeat_window: ::core::option::Option<::prost_types::Duration>,
+    pub heartbeat_window: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1695,7 +1762,7 @@ pub struct JwksFile {
     /// JSON Web Keys (JWKS) file as arbitary json.
     /// See <https://www.rfc-editor.org/rfc/rfc7517>
     #[prost(message, optional, tag="1")]
-    pub json: ::core::option::Option<::prost_types::Struct>,
+    pub json: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 /// ExternalAuthConfig describes how a viam managed robot can accept
 /// credentials signed by the cloud app.
@@ -1711,7 +1778,7 @@ pub struct AuthHandlerConfig {
     #[prost(enumeration="CredentialsType", tag="1")]
     pub r#type: i32,
     #[prost(message, optional, tag="5")]
-    pub config: ::core::option::Option<::prost_types::Struct>,
+    pub config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1863,9 +1930,9 @@ pub struct RemoteConfig {
     #[prost(bool, tag="6")]
     pub insecure: bool,
     #[prost(message, optional, tag="7")]
-    pub connection_check_interval: ::core::option::Option<::prost_types::Duration>,
+    pub connection_check_interval: ::core::option::Option<super::super::super::google::protobuf::Duration>,
     #[prost(message, optional, tag="8")]
-    pub reconnect_interval: ::core::option::Option<::prost_types::Duration>,
+    pub reconnect_interval: ::core::option::Option<super::super::super::google::protobuf::Duration>,
     #[prost(message, repeated, tag="9")]
     pub service_configs: ::prost::alloc::vec::Vec<ResourceLevelServiceConfig>,
     /// Secret is a helper for a robot location secret.
@@ -1979,7 +2046,7 @@ pub struct NeedsRestartResponse {
     #[prost(bool, tag="2")]
     pub must_restart: bool,
     #[prost(message, optional, tag="3")]
-    pub restart_check_interval: ::core::option::Option<::prost_types::Duration>,
+    pub restart_check_interval: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 /// ModuleConfig is the configuration for a module.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/src/gen/viam.common.v1.rs
+++ b/src/gen/viam.common.v1.rs
@@ -239,7 +239,7 @@ pub struct ResponseMetadata {
     /// Note: If correlating between other resources, be sure that the means
     /// of measuring the capture are similar enough such that comparison can be made between them.
     #[prost(message, optional, tag="1")]
-    pub captured_at: ::core::option::Option<::prost_types::Timestamp>,
+    pub captured_at: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
 }
 /// DoCommandRequest represents a generic DoCommand input
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -248,14 +248,14 @@ pub struct DoCommandRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub command: ::core::option::Option<::prost_types::Struct>,
+    pub command: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 /// DoCommandResponse represents a generic DoCommand output
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DoCommandResponse {
     #[prost(message, optional, tag="1")]
-    pub result: ::core::option::Option<::prost_types::Struct>,
+    pub result: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -263,6 +263,9 @@ pub struct GetKinematicsRequest {
     /// The component name
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -281,6 +284,9 @@ pub struct GetGeometriesRequest {
     /// The component name
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.arm.v1.rs
+++ b/src/gen/viam.component.arm.v1.rs
@@ -7,7 +7,7 @@ pub struct GetEndPositionRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,7 +34,7 @@ pub struct GetJointPositionsRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -57,7 +57,7 @@ pub struct MoveToPositionRequest {
     pub to: ::core::option::Option<super::super::super::common::v1::Pose>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -75,7 +75,7 @@ pub struct MoveToJointPositionsRequest {
     pub positions: ::core::option::Option<JointPositions>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,7 +89,7 @@ pub struct StopRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.audioinput.v1.rs
+++ b/src/gen/viam.component.audioinput.v1.rs
@@ -6,7 +6,7 @@ pub struct RecordRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub duration: ::core::option::Option<::prost_types::Duration>,
+    pub duration: ::core::option::Option<super::super::super::super::google::protobuf::Duration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -71,7 +71,7 @@ pub struct PropertiesResponse {
     #[prost(uint32, tag="1")]
     pub channel_count: u32,
     #[prost(message, optional, tag="2")]
-    pub latency: ::core::option::Option<::prost_types::Duration>,
+    pub latency: ::core::option::Option<super::super::super::super::google::protobuf::Duration>,
     #[prost(uint32, tag="3")]
     pub sample_rate: u32,
     #[prost(uint32, tag="4")]

--- a/src/gen/viam.component.base.v1.rs
+++ b/src/gen/viam.component.base.v1.rs
@@ -13,7 +13,7 @@ pub struct MoveStraightRequest {
     pub mm_per_sec: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -33,7 +33,7 @@ pub struct SpinRequest {
     pub degs_per_sec: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -47,7 +47,7 @@ pub struct StopRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -67,7 +67,7 @@ pub struct SetPowerRequest {
     pub angular: ::core::option::Option<super::super::super::common::v1::Vector3>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -87,7 +87,7 @@ pub struct SetVelocityRequest {
     pub angular: ::core::option::Option<super::super::super::common::v1::Vector3>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -112,7 +112,7 @@ pub struct GetPropertiesRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -121,5 +121,7 @@ pub struct GetPropertiesResponse {
     pub width_meters: f64,
     #[prost(double, tag="2")]
     pub turning_radius_meters: f64,
+    #[prost(double, tag="3")]
+    pub wheel_circumference_meters: f64,
 }
 // @@protoc_insertion_point(module)

--- a/src/gen/viam.component.board.v1.rs
+++ b/src/gen/viam.component.board.v1.rs
@@ -6,7 +6,7 @@ pub struct StatusRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -25,7 +25,7 @@ pub struct SetGpioRequest {
     pub high: bool,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -40,7 +40,7 @@ pub struct GetGpioRequest {
     pub pin: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -57,7 +57,7 @@ pub struct PwmRequest {
     pub pin: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -78,7 +78,7 @@ pub struct SetPwmRequest {
     pub duty_cycle_pct: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -93,7 +93,7 @@ pub struct PwmFrequencyRequest {
     pub pin: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -112,7 +112,7 @@ pub struct SetPwmFrequencyRequest {
     pub frequency_hz: u64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -129,7 +129,7 @@ pub struct ReadAnalogReaderRequest {
     pub analog_reader_name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -148,7 +148,7 @@ pub struct GetDigitalInterruptValueRequest {
     pub digital_interrupt_name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -167,10 +167,10 @@ pub struct SetPowerModeRequest {
     pub power_mode: i32,
     /// Requested duration to stay in `power_mode`
     #[prost(message, optional, tag="3")]
-    pub duration: ::core::option::Option<::prost_types::Duration>,
+    pub duration: ::core::option::Option<super::super::super::super::google::protobuf::Duration>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.camera.v1.rs
+++ b/src/gen/viam.component.camera.v1.rs
@@ -8,6 +8,9 @@ pub struct GetImageRequest {
     /// Requested MIME type of response
     #[prost(string, tag="2")]
     pub mime_type: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -58,6 +61,9 @@ pub struct RenderFrameRequest {
     /// Requested MIME type of response
     #[prost(string, tag="2")]
     pub mime_type: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -68,6 +74,9 @@ pub struct GetPointCloudRequest {
     /// Requested MIME type of response
     #[prost(string, tag="2")]
     pub mime_type: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.encoder.v1.rs
+++ b/src/gen/viam.component.encoder.v1.rs
@@ -14,7 +14,7 @@ pub struct GetPositionRequest {
     pub position_type: ::core::option::Option<i32>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -32,7 +32,7 @@ pub struct ResetPositionRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -46,7 +46,7 @@ pub struct GetPropertiesRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.gantry.v1.rs
+++ b/src/gen/viam.component.gantry.v1.rs
@@ -6,7 +6,7 @@ pub struct GetPositionRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -27,7 +27,7 @@ pub struct MoveToPositionRequest {
     pub speeds_mm_per_sec: ::prost::alloc::vec::Vec<f64>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -40,7 +40,7 @@ pub struct HomeRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -56,7 +56,7 @@ pub struct GetLengthsRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -72,7 +72,7 @@ pub struct StopRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.gripper.v1.rs
+++ b/src/gen/viam.component.gripper.v1.rs
@@ -5,7 +5,7 @@ pub struct OpenRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -17,7 +17,7 @@ pub struct GrabRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -25,7 +25,7 @@ pub struct GrabResponse {
     #[prost(bool, tag="1")]
     pub success: bool,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -34,7 +34,7 @@ pub struct StopRequest {
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.inputcontroller.v1.rs
+++ b/src/gen/viam.component.inputcontroller.v1.rs
@@ -7,7 +7,7 @@ pub struct GetControlsRequest {
     pub controller: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -25,7 +25,7 @@ pub struct GetEventsRequest {
     pub controller: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -46,7 +46,7 @@ pub struct TriggerEventRequest {
     pub event: ::core::option::Option<Event>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -57,7 +57,7 @@ pub struct TriggerEventResponse {
 pub struct Event {
     /// Timestamp of event
     #[prost(message, optional, tag="1")]
-    pub time: ::core::option::Option<::prost_types::Timestamp>,
+    pub time: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     /// An event type (eg: ButtonPress, ButtonRelease)
     #[prost(string, tag="2")]
     pub event: ::prost::alloc::string::String,
@@ -79,7 +79,7 @@ pub struct StreamEventsRequest {
     pub events: ::prost::alloc::vec::Vec<stream_events_request::Events>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 /// Nested message and enum types in `StreamEventsRequest`.
 pub mod stream_events_request {

--- a/src/gen/viam.component.motor.v1.rs
+++ b/src/gen/viam.component.motor.v1.rs
@@ -10,7 +10,7 @@ pub struct SetPowerRequest {
     pub power_pct: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -30,7 +30,7 @@ pub struct GoForRequest {
     pub revolutions: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -50,7 +50,7 @@ pub struct GoToRequest {
     pub position_revolutions: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -67,7 +67,7 @@ pub struct ResetZeroPositionRequest {
     pub offset: f64,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -81,7 +81,7 @@ pub struct GetPositionRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -98,7 +98,7 @@ pub struct StopRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -112,7 +112,7 @@ pub struct IsPoweredRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -134,7 +134,7 @@ pub struct GetPropertiesRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.movementsensor.v1.rs
+++ b/src/gen/viam.component.movementsensor.v1.rs
@@ -7,7 +7,7 @@ pub struct GetLinearVelocityRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -24,7 +24,7 @@ pub struct GetAngularVelocityRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -41,12 +41,12 @@ pub struct GetCompassHeadingRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCompassHeadingResponse {
-    /// A number from 0-359 where
+    /// A number from 0-359 in degrees where
     /// 0 is North, 90 is East, 180 is South, and 270 is   West
     #[prost(double, tag="1")]
     pub value: f64,
@@ -59,11 +59,13 @@ pub struct GetOrientationRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetOrientationResponse {
+    /// Orientation is returned as an orientation message with
+    /// OX OY OZ as unit-normalized components of the axis of the vector, and Theta in degrees
     #[prost(message, optional, tag="1")]
     pub orientation: ::core::option::Option<super::super::super::common::v1::Orientation>,
 }
@@ -75,11 +77,13 @@ pub struct GetPositionRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPositionResponse {
+    /// Position is returned in a coordinate of latitute and longitude
+    /// and an altidue in meters
     #[prost(message, optional, tag="1")]
     pub coordinate: ::core::option::Option<super::super::super::common::v1::GeoPoint>,
     #[prost(float, tag="2")]
@@ -93,7 +97,7 @@ pub struct GetPropertiesRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -119,7 +123,7 @@ pub struct GetAccuracyRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -135,7 +139,7 @@ pub struct GetLinearAccelerationRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.posetracker.v1.rs
+++ b/src/gen/viam.component.posetracker.v1.rs
@@ -12,7 +12,7 @@ pub struct GetPosesRequest {
     pub body_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.component.powersensor.v1.rs
+++ b/src/gen/viam.component.powersensor.v1.rs
@@ -1,25 +1,8 @@
 // @generated
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MoveRequest {
-    /// the name of the servo, as registered
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-    /// the degrees by which to rotate the servo. Accepted values are between 0 and 180
-    #[prost(uint32, tag="2")]
-    pub angle_deg: u32,
-    /// Additional arguments to the method
-    #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MoveResponse {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetPositionRequest {
-    /// the name of the servo, as registered
+pub struct GetVoltageRequest {
+    /// Name of a power sensor
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
@@ -28,43 +11,49 @@ pub struct GetPositionRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct GetPositionResponse {
-    /// the degrees from neutral by which the servo is currently rotated. Values are between 0 and 180
-    #[prost(uint32, tag="1")]
-    pub position_deg: u32,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StopRequest {
-    /// Name of a servo
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-    /// Additional arguments to the method
-    #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct StopResponse {
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Status {
-    #[prost(uint32, tag="1")]
-    pub position_deg: u32,
+pub struct GetVoltageResponse {
+    /// Voltage in volts
+    #[prost(double, tag="1")]
+    pub volts: f64,
+    /// Bool describing whether the voltage is DC or AC
     #[prost(bool, tag="2")]
-    pub is_moving: bool,
+    pub is_ac: bool,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IsMovingRequest {
+pub struct GetCurrentRequest {
+    /// Name of a power sensor
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct IsMovingResponse {
-    #[prost(bool, tag="1")]
-    pub is_moving: bool,
+pub struct GetCurrentResponse {
+    /// Current in amperes
+    #[prost(double, tag="1")]
+    pub amperes: f64,
+    /// Bool descibing whether the current is DC or AC
+    #[prost(bool, tag="2")]
+    pub is_ac: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPowerRequest {
+    /// Name of a power sensor
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPowerResponse {
+    /// Power in watts
+    #[prost(double, tag="1")]
+    pub watts: f64,
 }
 // @@protoc_insertion_point(module)

--- a/src/gen/viam.component.sensor.v1.rs
+++ b/src/gen/viam.component.sensor.v1.rs
@@ -7,12 +7,12 @@ pub struct GetReadingsRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetReadingsResponse {
     #[prost(map="string, message", tag="1")]
-    pub readings: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub readings: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::super::google::protobuf::Value>,
 }
 // @@protoc_insertion_point(module)

--- a/src/gen/viam.robot.v1.rs
+++ b/src/gen/viam.robot.v1.rs
@@ -6,7 +6,7 @@ pub struct FrameSystemConfig {
     #[prost(message, optional, tag="1")]
     pub frame: ::core::option::Option<super::super::common::v1::Transform>,
     #[prost(message, optional, tag="2")]
-    pub kinematics: ::core::option::Option<::prost_types::Struct>,
+    pub kinematics: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -102,9 +102,9 @@ pub struct Operation {
     #[prost(string, tag="2")]
     pub method: ::prost::alloc::string::String,
     #[prost(message, optional, tag="3")]
-    pub arguments: ::core::option::Option<::prost_types::Struct>,
+    pub arguments: ::core::option::Option<super::super::super::google::protobuf::Struct>,
     #[prost(message, optional, tag="4")]
-    pub started: ::core::option::Option<::prost_types::Timestamp>,
+    pub started: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(string, optional, tag="5")]
     pub session_id: ::core::option::Option<::prost::alloc::string::String>,
 }
@@ -182,7 +182,7 @@ pub struct Discovery {
     #[prost(message, optional, tag="1")]
     pub query: ::core::option::Option<DiscoveryQuery>,
     #[prost(message, optional, tag="2")]
-    pub results: ::core::option::Option<::prost_types::Struct>,
+    pub results: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -202,7 +202,7 @@ pub struct Status {
     #[prost(message, optional, tag="1")]
     pub name: ::core::option::Option<super::super::common::v1::ResourceName>,
     #[prost(message, optional, tag="2")]
-    pub status: ::core::option::Option<::prost_types::Struct>,
+    pub status: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -223,7 +223,7 @@ pub struct StreamStatusRequest {
     pub resource_names: ::prost::alloc::vec::Vec<super::super::common::v1::ResourceName>,
     /// how often to send a new status.
     #[prost(message, optional, tag="2")]
-    pub every: ::core::option::Option<::prost_types::Duration>,
+    pub every: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -237,7 +237,7 @@ pub struct StopExtraParameters {
     #[prost(message, optional, tag="1")]
     pub name: ::core::option::Option<super::super::common::v1::ResourceName>,
     #[prost(message, optional, tag="2")]
-    pub params: ::core::option::Option<::prost_types::Struct>,
+    pub params: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -263,7 +263,7 @@ pub struct StartSessionResponse {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
     #[prost(message, optional, tag="2")]
-    pub heartbeat_window: ::core::option::Option<::prost_types::Duration>,
+    pub heartbeat_window: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.service.datamanager.v1.rs
+++ b/src/gen/viam.service.datamanager.v1.rs
@@ -6,7 +6,7 @@ pub struct SyncRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.service.mlmodel.v1.rs
+++ b/src/gen/viam.service.mlmodel.v1.rs
@@ -5,16 +5,19 @@ pub struct InferRequest {
     /// name of the model service
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
-    /// this is a struct of input arrays/tensors as specified in the metadata
-    #[prost(message, optional, tag="2")]
-    pub input_data: ::core::option::Option<::prost_types::Struct>,
+    /// the input data is provided as set of named flat tensors
+    #[prost(message, optional, tag="3")]
+    pub input_tensors: ::core::option::Option<FlatTensors>,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InferResponse {
-    /// this is a struct of output arrays/tensors as specified in the metadata
-    #[prost(message, optional, tag="2")]
-    pub output_data: ::core::option::Option<::prost_types::Struct>,
+    /// the output data is provided as a set of named flat tensors
+    #[prost(message, optional, tag="3")]
+    pub output_tensors: ::core::option::Option<FlatTensors>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -22,6 +25,9 @@ pub struct MetadataRequest {
     /// name of the model service
     #[prost(string, tag="1")]
     pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -69,7 +75,7 @@ pub struct TensorInfo {
     pub associated_files: ::prost::alloc::vec::Vec<File>,
     /// anything else you want to say
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -83,6 +89,115 @@ pub struct File {
     /// How to associate the arrays/tensors to the labels in the file
     #[prost(enumeration="LabelType", tag="3")]
     pub label_type: i32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataInt8 {
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataUInt8 {
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataInt16 {
+    /// packs two 16-bit numbers per entry - explicitly little-endian
+    /// so big-endian producers/consumers must compensate
+    #[prost(fixed32, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataUInt16 {
+    /// packs two 16-bit numbers per entry - explicitly little-endian
+    /// so big-endian producers/consumers must compensate
+    #[prost(fixed32, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataInt32 {
+    #[prost(sfixed32, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<i32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataUInt32 {
+    #[prost(fixed32, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataInt64 {
+    #[prost(sfixed64, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<i64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataUInt64 {
+    #[prost(fixed64, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataFloat {
+    #[prost(float, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<f32>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensorDataDouble {
+    #[prost(double, repeated, tag="1")]
+    pub data: ::prost::alloc::vec::Vec<f64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensor {
+    /// the shape of the provided tensor as a list of integer extents
+    #[prost(fixed64, repeated, tag="1")]
+    pub shape: ::prost::alloc::vec::Vec<u64>,
+    /// the flat data to be interpreted per the above shape information
+    #[prost(oneof="flat_tensor::Tensor", tags="2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
+    pub tensor: ::core::option::Option<flat_tensor::Tensor>,
+}
+/// Nested message and enum types in `FlatTensor`.
+pub mod flat_tensor {
+    /// the flat data to be interpreted per the above shape information
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Tensor {
+        #[prost(message, tag="2")]
+        Int8Tensor(super::FlatTensorDataInt8),
+        #[prost(message, tag="3")]
+        Uint8Tensor(super::FlatTensorDataUInt8),
+        #[prost(message, tag="4")]
+        Int16Tensor(super::FlatTensorDataInt16),
+        #[prost(message, tag="5")]
+        Uint16Tensor(super::FlatTensorDataUInt16),
+        #[prost(message, tag="6")]
+        Int32Tensor(super::FlatTensorDataInt32),
+        #[prost(message, tag="7")]
+        Uint32Tensor(super::FlatTensorDataUInt32),
+        #[prost(message, tag="8")]
+        Int64Tensor(super::FlatTensorDataInt64),
+        #[prost(message, tag="9")]
+        Uint64Tensor(super::FlatTensorDataUInt64),
+        #[prost(message, tag="10")]
+        FloatTensor(super::FlatTensorDataFloat),
+        #[prost(message, tag="11")]
+        DoubleTensor(super::FlatTensorDataDouble),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FlatTensors {
+    /// A name-indexed collection of flat tensor objects
+    #[prost(map="string, message", tag="1")]
+    pub tensors: ::std::collections::HashMap<::prost::alloc::string::String, FlatTensor>,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/src/gen/viam.service.motion.v1.rs
+++ b/src/gen/viam.service.motion.v1.rs
@@ -21,7 +21,7 @@ pub struct MoveRequest {
     pub constraints: ::core::option::Option<Constraints>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -46,13 +46,35 @@ pub struct MoveOnMapRequest {
     pub slam_service_name: ::core::option::Option<super::super::super::common::v1::ResourceName>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MoveOnMapResponse {
     #[prost(bool, tag="1")]
     pub success: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MotionConfiguration {
+    /// The name of the vision service(s) that will be used to detect obstacles
+    #[prost(message, repeated, tag="1")]
+    pub vision_services: ::prost::alloc::vec::Vec<super::super::super::common::v1::ResourceName>,
+    /// Sets the frequency to poll for the position of the robot
+    #[prost(double, optional, tag="2")]
+    pub position_polling_frequency_hz: ::core::option::Option<f64>,
+    /// Sets the frequency to poll the vision service(s) for new obstacles
+    #[prost(double, optional, tag="3")]
+    pub obstacle_polling_frequency_hz: ::core::option::Option<f64>,
+    /// Sets the distance in meters that a robot is allowed to deviate from the motion plan
+    #[prost(double, optional, tag="4")]
+    pub plan_deviation_m: ::core::option::Option<f64>,
+    /// Optional linear velocity to target when moving
+    #[prost(double, optional, tag="5")]
+    pub linear_m_per_sec: ::core::option::Option<f64>,
+    /// Optional angular velocity to target when turning
+    #[prost(double, optional, tag="6")]
+    pub angular_degs_per_sec: ::core::option::Option<f64>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -75,40 +97,16 @@ pub struct MoveOnGlobeRequest {
     /// Obstacles to be considered for motion planning
     #[prost(message, repeated, tag="6")]
     pub obstacles: ::prost::alloc::vec::Vec<super::super::super::common::v1::GeoObstacle>,
-    /// Optional linear velocity to target when moving
-    #[prost(float, optional, tag="7")]
-    pub linear_meters_per_sec: ::core::option::Option<f32>,
-    /// Optional angular velocity to target when turning
-    #[prost(float, optional, tag="8")]
-    pub angular_deg_per_sec: ::core::option::Option<f32>,
+    /// Optional set of motion configuration options
+    #[prost(message, optional, tag="7")]
+    pub motion_configuration: ::core::option::Option<MotionConfiguration>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MoveOnGlobeResponse {
-    #[prost(bool, tag="1")]
-    pub success: bool,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MoveSingleComponentRequest {
-    #[prost(string, tag="1")]
-    pub name: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub destination: ::core::option::Option<super::super::super::common::v1::PoseInFrame>,
-    #[prost(message, optional, tag="3")]
-    pub component_name: ::core::option::Option<super::super::super::common::v1::ResourceName>,
-    #[prost(message, optional, tag="4")]
-    pub world_state: ::core::option::Option<super::super::super::common::v1::WorldState>,
-    /// Additional arguments to the method
-    #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct MoveSingleComponentResponse {
     #[prost(bool, tag="1")]
     pub success: bool,
 }
@@ -131,7 +129,7 @@ pub struct GetPoseRequest {
     pub supplemental_transforms: ::prost::alloc::vec::Vec<super::super::super::common::v1::Transform>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -152,7 +150,8 @@ pub struct Constraints {
     #[prost(message, repeated, tag="3")]
     pub collision_specification: ::prost::alloc::vec::Vec<CollisionSpecification>,
 }
-/// LinearConstraint specifies that the component being moved should move linearly relative to its goal. It does not constrain the motion of components other than the `component_name` specified in motion.Move
+/// LinearConstraint specifies that the component being moved should move linearly relative to its goal.
+/// It does not constrain the motion of components other than the `component_name` specified in motion.Move
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LinearConstraint {
@@ -163,7 +162,8 @@ pub struct LinearConstraint {
     #[prost(float, optional, tag="2")]
     pub orientation_tolerance_degs: ::core::option::Option<f32>,
 }
-/// OrientationConstraint specifies that the component being moved will not deviate its orientation beyond some threshold relative to the goal. It does not constrain the motion of components other than the `component_name` specified in motion.Move
+/// OrientationConstraint specifies that the component being moved will not deviate its orientation beyond some threshold relative
+/// to the goal. It does not constrain the motion of components other than the `component_name` specified in motion.Move
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OrientationConstraint {

--- a/src/gen/viam.service.navigation.v1.rs
+++ b/src/gen/viam.service.navigation.v1.rs
@@ -6,7 +6,7 @@ pub struct GetModeRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -23,7 +23,7 @@ pub struct SetModeRequest {
     pub mode: i32,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -44,13 +44,17 @@ pub struct GetLocationRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLocationResponse {
     #[prost(message, optional, tag="1")]
     pub location: ::core::option::Option<super::super::super::common::v1::GeoPoint>,
+    /// A number from [0-360) where 0 is north
+    /// 90 is east, 180 is south, 270 is west
+    #[prost(double, tag="2")]
+    pub compass_heading: f64,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -59,7 +63,7 @@ pub struct GetWaypointsRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -76,7 +80,7 @@ pub struct AddWaypointRequest {
     pub location: ::core::option::Option<super::super::super::common::v1::GeoPoint>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -91,7 +95,7 @@ pub struct RemoveWaypointRequest {
     pub id: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -108,7 +112,7 @@ pub struct GetObstaclesRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.service.sensors.v1.rs
+++ b/src/gen/viam.service.sensors.v1.rs
@@ -6,7 +6,7 @@ pub struct GetSensorsRequest {
     pub name: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -23,7 +23,7 @@ pub struct GetReadingsRequest {
     pub sensor_names: ::prost::alloc::vec::Vec<super::super::super::common::v1::ResourceName>,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -31,7 +31,7 @@ pub struct Readings {
     #[prost(message, optional, tag="1")]
     pub name: ::core::option::Option<super::super::super::common::v1::ResourceName>,
     #[prost(map="string, message", tag="2")]
-    pub readings: ::std::collections::HashMap<::prost::alloc::string::String, ::prost_types::Value>,
+    pub readings: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::super::google::protobuf::Value>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.service.shell.v1.rs
+++ b/src/gen/viam.service.shell.v1.rs
@@ -8,7 +8,7 @@ pub struct ShellRequest {
     pub data_in: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/gen/viam.service.slam.v1.rs
+++ b/src/gen/viam.service.slam.v1.rs
@@ -17,7 +17,7 @@ pub struct GetPositionResponse {
     pub component_reference: ::prost::alloc::string::String,
     /// Additional information in the response
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -76,6 +76,6 @@ pub struct GetLatestMapInfoRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetLatestMapInfoResponse {
     #[prost(message, optional, tag="1")]
-    pub last_map_update: ::core::option::Option<::prost_types::Timestamp>,
+    pub last_map_update: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
 }
 // @@protoc_insertion_point(module)

--- a/src/gen/viam.service.vision.v1.rs
+++ b/src/gen/viam.service.vision.v1.rs
@@ -19,7 +19,7 @@ pub struct GetDetectionsRequest {
     pub mime_type: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -38,7 +38,7 @@ pub struct GetDetectionsFromCameraRequest {
     #[prost(string, tag="2")]
     pub camera_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -89,7 +89,7 @@ pub struct GetClassificationsRequest {
     pub n: i32,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -111,7 +111,7 @@ pub struct GetClassificationsFromCameraRequest {
     pub n: i32,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -143,7 +143,7 @@ pub struct GetObjectPointCloudsRequest {
     pub mime_type: ::prost::alloc::string::String,
     /// Additional arguments to the method
     #[prost(message, optional, tag="99")]
-    pub extra: ::core::option::Option<::prost_types::Struct>,
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,10 @@ pub mod google {
         #![allow(clippy::derive_partial_eq_without_eq)]
         include!("gen/google.rpc.rs");
     }
+    pub mod protobuf {
+        #![allow(clippy::derive_partial_eq_without_eq)]
+        include!("gen/google.protobuf.rs");
+    }
 }
 
 pub mod proto {
@@ -179,6 +183,8 @@ pub mod proto {
 #[macro_use]
 extern crate trackable;
 
+use std::time;
+
 use stun_codec::rfc5245::attributes::*;
 use stun_codec::rfc5389::attributes::*;
 stun_codec::define_attribute_enums!(
@@ -197,3 +203,19 @@ stun_codec::define_attribute_enums!(
         UseCandidate
     ]
 );
+
+pub struct DurationParseFailure;
+
+impl TryFrom<google::protobuf::Duration> for time::Duration {
+    type Error = DurationParseFailure;
+    fn try_from(duration: google::protobuf::Duration) -> Result<Self, Self::Error> {
+        if duration.seconds >= 0 && duration.nanos >= 0 {
+            Ok(time::Duration::new(
+                duration.seconds as u64,
+                duration.nanos as u32,
+            ))
+        } else {
+            Err(DurationParseFailure)
+        }
+    }
+}


### PR DESCRIPTION
We are switching from BTreeMap to HashMap this should result in slightly lower runtime ram consumption and a slightly smaller binary in debug mode