### PR TITLE
`Board` docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ format:
 doc:
 	cargo doc --no-default-features --features esp32 --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort
 
+doc-open:
+	cargo doc --no-default-features --features esp32 --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --open
+
 size:
 	find . -name "esp-build.map" -exec ${IDF_PATH}/tools/idf_size.py {} \;
 

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -2,35 +2,19 @@
 
 #![allow(dead_code)]
 use crate::{
-    common::{
-        analog::AnalogReader,
-        status::Status,
-    },
+    common::{analog::AnalogReader, status::Status},
     google,
-    proto::{
-        common, 
-        component::board::v1::PowerMode
-    },
+    proto::{common, component::board::v1::PowerMode},
 };
 
-use log::*;
 use core::cell::RefCell;
-use std::{
-    collections::HashMap,
-    rc::Rc,
-    sync::Arc,
-    sync::Mutex,
-    time::Duration,
-};
+use log::*;
+use std::{collections::HashMap, rc::Rc, sync::Arc, sync::Mutex, time::Duration};
 
 use super::{
     analog::FakeAnalogReader,
     config::ConfigType,
-    i2c::{
-        FakeI2CHandle, 
-        FakeI2cConfig, 
-        I2CHandle, 
-        I2cHandleType},
+    i2c::{FakeI2CHandle, FakeI2cConfig, I2CHandle, I2cHandleType},
     registry::ComponentRegistry,
 };
 
@@ -63,12 +47,9 @@ pub trait Board: Status {
     ) -> anyhow::Result<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>;
 
     /// Set the board to the indicated [PowerMode]
-    fn set_power_mode(
-        &self,
-        mode: PowerMode,
-        duration: Option<Duration>,
-    ) -> anyhow::Result<()>;
+    fn set_power_mode(&self, mode: PowerMode, duration: Option<Duration>) -> anyhow::Result<()>;
 
+    /// Get a wrapped [I2CHandle] by name.
     fn get_i2c_by_name(&self, name: String) -> anyhow::Result<I2cHandleType>;
 
     /// Return the amount of detected interrupt events on a pin. Should error if the
@@ -86,8 +67,9 @@ pub trait Board: Status {
     /// Get the PWM frequency of the pin
     fn get_pwm_frequency(&self, pin: i32) -> anyhow::Result<u64>;
 
-    /// Set the pin to the given PWM frequency (in Hz). 
-    /// When frequency is 0, the board will unregister the pin and PWM signal
+    /// Set the pin to the given PWM frequency (in Hz).
+    /// When frequency is 0, the board will unregister the pin and PWM channel from
+    /// the timer and removes the PWM signal.
     fn set_pwm_frequency(&mut self, pin: i32, frequency_hz: u64) -> anyhow::Result<()>;
 }
 
@@ -193,11 +175,7 @@ impl Board for FakeBoard {
         }
     }
 
-    fn set_power_mode(
-        &self,
-        mode: PowerMode,
-        duration: Option<Duration>,
-    ) -> anyhow::Result<()> {
+    fn set_power_mode(&self, mode: PowerMode, duration: Option<Duration>) -> anyhow::Result<()> {
         info!(
             "set power mode to {} for {} milliseconds",
             mode.as_str_name(),
@@ -297,11 +275,7 @@ where
         self.lock().unwrap().get_analog_reader_by_name(name)
     }
 
-    fn set_power_mode(
-        &self,
-        mode: PowerMode,
-        duration: Option<Duration>,
-    ) -> anyhow::Result<()> {
+    fn set_power_mode(&self, mode: PowerMode, duration: Option<Duration>) -> anyhow::Result<()> {
         self.lock().unwrap().set_power_mode(mode, duration)
     }
 

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -77,17 +77,17 @@ pub trait Board: Status {
         anyhow::bail!("this board does not support digital interrupts")
     }
 
-    /// Get the pin's given duty cycle
+    /// Get the pin's given duty cycle, returns percentage as float between 0.0 and 1.0
     fn get_pwm_duty(&self, pin: i32) -> f64;
 
-    /// Set the pin to the given duty cycle 
+    /// Set the pin to the given duty cycle , `duty_cycle_pct` is a float between 0.0 and 1.0
     fn set_pwm_duty(&mut self, pin: i32, duty_cycle_pct: f64) -> anyhow::Result<()>;
 
     /// Get the PWM frequency of the pin
     fn get_pwm_frequency(&self, pin: i32) -> anyhow::Result<u64>;
 
     /// Set the pin to the given PWM frequency (in Hz). 
-    /// When frequency is 0, it will use the board’s default PWM frequency.
+    /// When frequency is 0, the board will unregister the pin and PWM signal
     fn set_pwm_frequency(&mut self, pin: i32, frequency_hz: u64) -> anyhow::Result<()>;
 }
 

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -66,7 +66,6 @@ pub trait Board: Status {
     fn get_pwm_duty(&self, pin: i32) -> f64;
 
     /// Set the pin to the given duty cycle , `duty_cycle_pct` is a float between 0.0 and 1.0.
-    /// If the `pin` does not use PWM,
     fn set_pwm_duty(&mut self, pin: i32, duty_cycle_pct: f64) -> anyhow::Result<()>;
 
     /// Get the PWM frequency of the pin

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -1,4 +1,4 @@
-//! general-purpose compute board
+//! Abstraction of a general-purpose compute board
 
 #![allow(dead_code)]
 use crate::{
@@ -45,7 +45,7 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     }
 }
 
-/// The [Board] trait represents the functionality of a physical general purpose compute board that contains various components such as analog readers and digital interrupts.
+/// The [Board] trait represents the functionality of a general purpose compute board that contains various components such as analog readers and digital interrupts.
 pub trait Board: Status {
     /// Set a pin to high(`true`) or low(`false`)
     fn set_gpio_pin_level(&mut self, pin: i32, is_high: bool) -> anyhow::Result<()>;
@@ -84,6 +84,7 @@ pub trait Board: Status {
 /// An alias for a thread-safe handle to a struct that implements the [Board] trait
 pub type BoardType = Arc<Mutex<dyn Board>>;
 
+/// A test implementation of a generic compute board
 pub struct FakeBoard {
     analogs: Vec<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>,
     i2cs: HashMap<String, Arc<Mutex<FakeI2CHandle>>>,

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -49,33 +49,43 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
 pub trait Board: Status {
     /// Set a pin to high or low
     fn set_gpio_pin_level(&mut self, pin: i32, is_high: bool) -> anyhow::Result<()>;
+
     /// Return the current [BoardStatus] of the board
     fn get_board_status(&self) -> anyhow::Result<common::v1::BoardStatus>;
+
     /// Get the state of a pin, high(`true`) or low(`false`)
     fn get_gpio_level(&self, pin: i32) -> anyhow::Result<bool>;
+
     /// Get an [AnalogReader] by name
     fn get_analog_reader_by_name(
         &self,
         name: String,
     ) -> anyhow::Result<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>;
+
     /// Set the board to the indicated [PowerMode]
     fn set_power_mode(
         &self,
         mode: PowerMode,
         duration: Option<Duration>,
     ) -> anyhow::Result<()>;
+
     fn get_i2c_by_name(&self, name: String) -> anyhow::Result<I2cHandleType>;
+
     /// Return the amount of detected interrupt events on a pin. Should error if the
     /// pin has not been configured as an interrupt
     fn get_digital_interrupt_value(&self, _pin: i32) -> anyhow::Result<u32> {
         anyhow::bail!("this board does not support digital interrupts")
     }
+
     /// Get the pin's given duty cycle
     fn get_pwm_duty(&self, pin: i32) -> f64;
+
     /// Set the pin to the given duty cycle 
     fn set_pwm_duty(&mut self, pin: i32, duty_cycle_pct: f64) -> anyhow::Result<()>;
+
     /// Get the PWM frequency of the pin
     fn get_pwm_frequency(&self, pin: i32) -> anyhow::Result<u64>;
+
     /// Set the pin to the given PWM frequency (in Hz). 
     /// When frequency is 0, it will use the board’s default PWM frequency.
     fn set_pwm_frequency(&mut self, pin: i32, frequency_hz: u64) -> anyhow::Result<()>;
@@ -106,6 +116,7 @@ impl FakeBoard {
             pin_pwm_freq: HashMap::new(),
         }
     }
+
     pub(crate) fn from_config(cfg: ConfigType) -> anyhow::Result<BoardType> {
         let analogs = if let Ok(analog_confs) = cfg.get_attribute::<HashMap<&str, f64>>("analogs") {
             analog_confs
@@ -149,6 +160,7 @@ impl Board for FakeBoard {
         info!("set pin {} to {}", pin, is_high);
         Ok(())
     }
+
     fn get_board_status(&self) -> anyhow::Result<common::v1::BoardStatus> {
         let mut b = common::v1::BoardStatus {
             analogs: HashMap::new(),
@@ -165,10 +177,12 @@ impl Board for FakeBoard {
         });
         Ok(b)
     }
+
     fn get_gpio_level(&self, pin: i32) -> anyhow::Result<bool> {
         info!("get pin {}", pin);
         Ok(true)
     }
+
     fn get_analog_reader_by_name(
         &self,
         name: String,
@@ -178,6 +192,7 @@ impl Board for FakeBoard {
             None => Err(anyhow::anyhow!("couldn't find analog reader {}", name)),
         }
     }
+
     fn set_power_mode(
         &self,
         mode: PowerMode,
@@ -193,6 +208,7 @@ impl Board for FakeBoard {
         );
         Ok(())
     }
+
     fn get_i2c_by_name(&self, name: String) -> anyhow::Result<I2cHandleType> {
         if let Some(i2c_handle) = self.i2cs.get(&name) {
             Ok((*i2c_handle).clone())
@@ -200,16 +216,20 @@ impl Board for FakeBoard {
             anyhow::bail!("could not find I2C with name {}", name)
         }
     }
+
     fn get_pwm_duty(&self, pin: i32) -> f64 {
         *self.pin_pwms.get(&pin).unwrap_or(&0.0)
     }
+
     fn set_pwm_duty(&mut self, pin: i32, duty_cycle_pct: f64) -> anyhow::Result<()> {
         self.pin_pwms.insert(pin, duty_cycle_pct);
         Ok(())
     }
+
     fn get_pwm_frequency(&self, pin: i32) -> anyhow::Result<u64> {
         Ok(*self.pin_pwm_freq.get(&pin).unwrap_or(&0))
     }
+
     fn set_pwm_frequency(&mut self, pin: i32, frequency_hz: u64) -> anyhow::Result<()> {
         self.pin_pwm_freq.insert(pin, frequency_hz);
         Ok(())
@@ -261,12 +281,15 @@ where
     fn get_board_status(&self) -> anyhow::Result<common::v1::BoardStatus> {
         self.lock().unwrap().get_board_status()
     }
+
     fn get_gpio_level(&self, pin: i32) -> anyhow::Result<bool> {
         self.lock().unwrap().get_gpio_level(pin)
     }
+
     fn set_gpio_pin_level(&mut self, pin: i32, is_high: bool) -> anyhow::Result<()> {
         self.lock().unwrap().set_gpio_pin_level(pin, is_high)
     }
+
     fn get_analog_reader_by_name(
         &self,
         name: String,

--- a/src/common/board.rs
+++ b/src/common/board.rs
@@ -45,9 +45,9 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     }
 }
 
-/// The [Board] trait represents the functionality of a general purpose compute board that contains various components such as analog readers and digital interrupts.
+/// Represents the functionality of a general purpose compute board that contains various components such as analog readers and digital interrupts.
 pub trait Board: Status {
-    /// Set a pin to high(`true`) or low(`false`)
+    /// Set a pin to high or low
     fn set_gpio_pin_level(&mut self, pin: i32, is_high: bool) -> anyhow::Result<()>;
     /// Return the current [BoardStatus] of the board
     fn get_board_status(&self) -> anyhow::Result<common::v1::BoardStatus>;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -36,6 +36,7 @@ pub mod config;
 pub mod digital_interrupt;
 pub mod encoder;
 pub mod entry;
+pub mod generic;
 pub mod gpio_motor;
 pub mod gpio_servo;
 pub mod grpc;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,7 +19,7 @@
 //! - [conn]
 //!
 //!
-//! General Purpose Drivers 
+//! General Purpose Drivers
 //! - [gpio_motor]
 //! - [adxl345]
 //! - [mpu6050]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -17,6 +17,12 @@
 //! - [i2c]
 //! - [webrtc]
 //! - [conn]
+//!
+//!
+//! General Purpose Drivers 
+//! - [gpio_motor]
+//! - [adxl345]
+//! - [mpu6050]
 
 pub mod actuator;
 pub mod adxl345;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,4 +1,4 @@
-//! Structs, Traits, and tools used to develop [component](https://docs.viam.com/components/)
+//! Structs, traits, and utils to develop [component](https://docs.viam.com/components/)
 //! drivers.
 //!
 //! # Components
@@ -11,7 +11,7 @@
 //! - [movement_sensor]
 //! - [sensor]
 //!
-//! # Tools and Protocols
+//! # Utils
 //! - [grpc]
 //! - [grpc_client]
 //! - [i2c]

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -47,6 +47,7 @@ pub mod moisture_sensor;
 pub mod motor;
 pub mod movement_sensor;
 pub mod mpu6050;
+pub mod power_sensor;
 pub mod registry;
 pub mod robot;
 pub mod sensor;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,0 +1,62 @@
+//! Structs, Traits, and tools used to develop [component](https://docs.viam.com/components/)
+//! drivers.
+//!
+//! # Components
+//! - [actuator]
+//! - [base]
+//! - [board]
+//! - [camera]
+//! - [encoder]
+//! - [motor]
+//! - [movement_sensor]
+//! - [sensor]
+//!
+//! # Tools and Protocols
+//! - [grpc]
+//! - [grpc_client]
+//! - [i2c]
+//! - [webrtc]
+//! - [conn]
+
+pub mod actuator;
+pub mod adxl345;
+pub mod analog;
+pub mod app_client;
+pub mod base;
+pub mod board;
+pub mod camera;
+pub mod config;
+pub mod digital_interrupt;
+pub mod encoder;
+pub mod entry;
+pub mod gpio_motor;
+pub mod grpc;
+pub mod grpc_client;
+pub mod i2c;
+pub mod log;
+pub mod math_utils;
+pub mod moisture_sensor;
+pub mod motor;
+pub mod movement_sensor;
+pub mod mpu6050;
+pub mod registry;
+pub mod robot;
+pub mod sensor;
+pub mod status;
+pub mod webrtc {
+    pub mod api;
+    pub mod candidates;
+    pub mod certificate;
+    pub mod dtls;
+    pub mod exec;
+    pub mod grpc;
+    pub mod ice;
+    pub mod io;
+    pub mod sctp;
+}
+pub mod conn {
+    pub mod errors;
+    pub mod mdns;
+    pub mod server;
+    mod utils;
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,6 +10,7 @@
 //! - [motor]
 //! - [movement_sensor]
 //! - [sensor]
+//! - [servo]
 //!
 //! # Utils
 //! - [grpc]
@@ -36,6 +37,7 @@ pub mod digital_interrupt;
 pub mod encoder;
 pub mod entry;
 pub mod gpio_motor;
+pub mod gpio_servo;
 pub mod grpc;
 pub mod grpc_client;
 pub mod i2c;
@@ -48,6 +50,7 @@ pub mod mpu6050;
 pub mod registry;
 pub mod robot;
 pub mod sensor;
+pub mod servo;
 pub mod status;
 pub mod webrtc {
     pub mod api;

--- a/src/esp32/board.rs
+++ b/src/esp32/board.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
-use log::*;
 use anyhow::Context;
 use core::cell::RefCell;
+use log::*;
 use std::{
     collections::HashMap,
     rc::Rc,
@@ -11,25 +11,16 @@ use std::{
 
 use crate::{
     common::{
-        analog::{
-            AnalogReader,
-            AnalogReaderConfig,
-        },
-        board::{
-            Board, 
-            BoardType
-        },
+        analog::{AnalogReader, AnalogReaderConfig},
+        board::{Board, BoardType},
         config::ConfigType,
         digital_interrupt::DigitalInterruptConfig,
         i2c::I2cHandleType,
         registry::ComponentRegistry,
-        status::Status
+        status::Status,
     },
     google,
-    proto::{
-        common,
-        component,
-    },
+    proto::{common, component},
 };
 
 use super::{
@@ -39,13 +30,7 @@ use super::{
 };
 
 use esp_idf_hal::{
-    adc::{
-        config::Config,
-        AdcChannelDriver,
-        AdcDriver,
-        Atten11dB,
-        ADC1,
-    },
+    adc::{config::Config, AdcChannelDriver, AdcDriver, Atten11dB, ADC1},
     gpio::InterruptType,
 };
 

--- a/src/esp32/board.rs
+++ b/src/esp32/board.rs
@@ -1,35 +1,53 @@
 #![allow(dead_code)]
-use crate::common::analog::AnalogReader;
-use crate::common::analog::AnalogReaderConfig;
-use crate::common::board::Board;
-use crate::common::board::BoardType;
-use crate::common::config::ConfigType;
-use crate::common::digital_interrupt::DigitalInterruptConfig;
-use crate::common::i2c::I2cHandleType;
-use crate::common::registry::ComponentRegistry;
-use crate::common::status::Status;
-use crate::google;
-use crate::proto::common;
-use crate::proto::component;
-
+use log::*;
 use anyhow::Context;
 use core::cell::RefCell;
-use esp_idf_hal::adc::config::Config;
-use esp_idf_hal::adc::AdcChannelDriver;
-use esp_idf_hal::adc::AdcDriver;
-use esp_idf_hal::adc::Atten11dB;
-use esp_idf_hal::adc::ADC1;
-use esp_idf_hal::gpio::InterruptType;
+use std::{
+    collections::HashMap,
+    rc::Rc,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use log::*;
-use std::collections::HashMap;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use crate::{
+    common::{
+        analog::{
+            AnalogReader,
+            AnalogReaderConfig,
+        },
+        board::{
+            Board, 
+            BoardType
+        },
+        config::ConfigType,
+        digital_interrupt::DigitalInterruptConfig,
+        i2c::I2cHandleType,
+        registry::ComponentRegistry,
+        status::Status
+    },
+    google,
+    proto::{
+        common,
+        component,
+    },
+};
 
-use super::analog::Esp32AnalogReader;
-use super::i2c::{Esp32I2C, Esp32I2cConfig};
-use super::pin::Esp32GPIOPin;
+use super::{
+    analog::Esp32AnalogReader,
+    i2c::{Esp32I2C, Esp32I2cConfig},
+    pin::Esp32GPIOPin,
+};
+
+use esp_idf_hal::{
+    adc::{
+        config::Config,
+        AdcChannelDriver,
+        AdcDriver,
+        Atten11dB,
+        ADC1,
+    },
+    gpio::InterruptType,
+};
 
 pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     if registry
@@ -40,6 +58,7 @@ pub(crate) fn register_models(registry: &mut ComponentRegistry) {
     }
 }
 
+/// An ESP32 implementation that wraps esp-idf functionality
 pub struct EspBoard {
     pins: Vec<Esp32GPIOPin>,
     analogs: Vec<Rc<RefCell<dyn AnalogReader<u16, Error = anyhow::Error>>>>,

--- a/src/esp32/mod.rs
+++ b/src/esp32/mod.rs
@@ -1,4 +1,4 @@
-//! ESP32-specific implementations of common components
+//! ESP32-specific implementations of components and tools
 
 pub mod analog;
 pub mod base;

--- a/src/esp32/mod.rs
+++ b/src/esp32/mod.rs
@@ -1,0 +1,25 @@
+//! ESP32-specific implementations of common components
+
+pub mod analog;
+pub mod base;
+pub mod board;
+#[cfg(feature = "camera")]
+pub mod camera;
+pub mod certificate;
+pub mod dtls;
+pub mod encoder;
+pub mod entry;
+pub mod exec;
+pub mod i2c;
+pub mod pin;
+pub mod pulse_counter;
+pub mod pwm;
+pub mod single_encoded_motor;
+pub mod single_encoder;
+pub mod tcp;
+pub mod tls;
+pub mod utils;
+pub mod webhook;
+pub mod conn {
+    pub mod mdns;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,19 +4,9 @@ pub mod common;
 pub mod esp32;
 
 #[cfg(feature = "native")]
-pub mod native {
-    pub mod certificate;
-    pub mod dtls;
-    pub mod entry;
-    pub mod exec;
-    pub mod tcp;
-    pub mod tls;
-    pub mod conn {
-        pub mod mdns;
-    }
-}
+pub mod native;
 
-/// gRPC protobufs and prototypes
+/// gRPC protobuf utilities, auto-generated
 pub mod google {
     pub mod rpc {
         #![allow(clippy::derive_partial_eq_without_eq)]
@@ -28,7 +18,7 @@ pub mod google {
     }
 }
 
-/// gRPC protobufs
+/// gRPC prototypes from definitions in [api repository](https://github.com/viamrobotics/api/tree/main/proto/viam), auto-generated
 pub mod proto {
     pub mod common {
         pub mod v1 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,78 +1,7 @@
-pub mod common {
-    pub mod actuator;
-    pub mod adxl345;
-    pub mod analog;
-    pub mod app_client;
-    pub mod base;
-    pub mod board;
-    pub mod camera;
-    pub mod config;
-    pub mod digital_interrupt;
-    pub mod encoder;
-    pub mod entry;
-    pub mod generic;
-    pub mod gpio_motor;
-    pub mod gpio_servo;
-    pub mod grpc;
-    pub mod grpc_client;
-    pub mod i2c;
-    pub mod log;
-    pub mod math_utils;
-    pub mod moisture_sensor;
-    pub mod motor;
-    pub mod movement_sensor;
-    pub mod mpu6050;
-    pub mod power_sensor;
-    pub mod registry;
-    pub mod robot;
-    pub mod sensor;
-    pub mod servo;
-    pub mod status;
-    pub mod webrtc {
-        pub mod api;
-        pub mod candidates;
-        pub mod certificate;
-        pub mod dtls;
-        pub mod exec;
-        pub mod grpc;
-        pub mod ice;
-        pub mod io;
-        pub mod sctp;
-    }
-    pub mod conn {
-        pub mod errors;
-        pub mod mdns;
-        pub mod server;
-        mod utils;
-    }
-}
+pub mod common;
 
 #[cfg(feature = "esp32")]
-pub mod esp32 {
-    pub mod analog;
-    pub mod base;
-    pub mod board;
-    #[cfg(feature = "camera")]
-    pub mod camera;
-    pub mod certificate;
-    pub mod dtls;
-    pub mod encoder;
-    pub mod entry;
-    pub mod exec;
-    pub mod i2c;
-    pub mod pin;
-    pub mod pulse_counter;
-    pub mod pwm;
-    pub mod single_encoded_motor;
-    pub mod single_encoder;
-    pub mod tcp;
-    pub mod tls;
-    pub mod utils;
-    pub mod webhook;
-    pub mod conn {
-        pub mod mdns;
-    }
-}
+pub mod esp32;
 
 #[cfg(feature = "native")]
 pub mod native {
@@ -87,6 +16,7 @@ pub mod native {
     }
 }
 
+/// gRPC protobufs and prototypes
 pub mod google {
     pub mod rpc {
         #![allow(clippy::derive_partial_eq_without_eq)]
@@ -98,6 +28,7 @@ pub mod google {
     }
 }
 
+/// gRPC protobufs
 pub mod proto {
     pub mod common {
         pub mod v1 {

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1,0 +1,9 @@
+pub mod certificate;
+pub mod dtls;
+pub mod entry;
+pub mod exec;
+pub mod tcp;
+pub mod tls;
+pub mod conn {
+    pub mod mdns;
+}


### PR DESCRIPTION
Changes to crate documentation for developer use. 
Method descriptions try to mirror the [Python SDK](https://python.viam.dev/autoapi/viam/components/index.html).

This PR highlights different options for how documentation can be added and rendered, as well as the directory structure changes (individual `mod.rs` or using the root `lib.rs`).

If this is approved, I'll add docs for the other components.

use `make doc-open` to generate docs and view in browser