### PR TITLE
RSDK-5973 - ESP32 connection canary

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,38 @@
+name: Hourly ESP32 Connection Canary
+
+on:
+  workflow_call:
+    secrets:
+      MONGODB_TEST_OUTPUT_URI:
+        required: true
+      ESP32_CANARY_ROBOT:
+        required: true
+      ESP32_CANARY_API_KEY:
+        required: true
+      ESP32_CANARY_API_KEY_ID:
+        required: true
+  schedule:
+    - cron:  '0 * * * *'
+
+env:
+  MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+  ESP32_CANARY_ROBOT: ${{ secrets.ESP32_CANARY_ROBOT }}
+  ESP32_CANARY_API_KEY: ${{ secrets.ESP32_CANARY_API_KEY }}
+  ESP32_CANARY_API_KEY_ID: ${{ secrets.ESP32_CANARY_API_KEY_ID }}
+
+jobs:
+  canary:
+    runs-on: x64
+    defaults: 
+      run:
+        working-directory: ./canary
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Run Canary
+        run: |
+          python -m pip install -r requirements.txt
+          python canary_test.py

--- a/.github/workflows/canary_summary.yml
+++ b/.github/workflows/canary_summary.yml
@@ -1,0 +1,29 @@
+name: Daily ESP32 Connection Summary
+
+on:
+  workflow_call:
+    secrets:
+      MONGODB_TEST_OUTPUT_URI:
+        required: true
+  schedule:
+    - cron:  '30 23 * * *'
+
+env:
+  MONGODB_TEST_OUTPUT_URI: ${{ secrets.MONGODB_TEST_OUTPUT_URI }}
+
+jobs:
+  canary:
+    runs-on: x64
+    defaults: 
+      run:
+        working-directory: ./canary
+        shell: bash
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: Run Canary
+        run: |
+          python -m pip install -r requirements.txt
+          python canary_summary.py

--- a/canary/canary_test.py
+++ b/canary/canary_test.py
@@ -1,0 +1,82 @@
+import asyncio
+import datetime
+import os
+import time
+
+from pymongo import MongoClient
+from typing import Coroutine, Any
+from viam.robot.client import RobotClient, DialOptions
+from viam.components.board import Board
+
+async def connect(robot_address: str, api_key: str, api_key_id: str) -> Coroutine[Any, Any, RobotClient]:
+    opts = RobotClient.Options(
+        refresh_interval=0,     	 
+        check_connection_interval=0,
+        attempt_reconnect_interval=0,
+        disable_sessions=True,
+        dial_options=DialOptions.with_api_key(api_key_id=api_key_id,api_key=api_key)
+    )
+    return await RobotClient.at_address(robot_address, opts)
+
+async def main():
+    mongo_connection_str = os.environ["MONGODB_TEST_OUTPUT_URI"]
+    db_client = MongoClient(mongo_connection_str)
+    db = db_client["esp32_canary"]
+    coll = db["hourly_results"]
+
+    timestamp = datetime.datetime.now()
+
+    default_item = {
+        "_id": timestamp,
+        "connection_success": False,
+        "board_api_success": False,
+        "error": "",
+        "connection_latency_ms": 0
+    }
+
+    robot_address = os.environ["ESP32_CANARY_ROBOT"]
+    api_key = os.environ["ESP32_CANARY_API_KEY"]
+    api_key_id = os.environ["ESP32_CANARY_API_KEY_ID"]
+
+    print(f"connecting to robot at {robot_address} ...")
+
+    start = time.time()
+    connection_attempts = 5
+    for i in range(5):
+        try:
+            robot = await connect(robot_address, api_key, api_key_id)
+            connection_attempts = i + 1
+            break
+        except Exception as e:
+            if i == 4:
+                default_item["error"] = str(e)
+                coll.insert_one(default_item)
+                raise e
+            print(e)
+        time.sleep(0.5)
+
+    connectivity_time = (time.time() - start) * 1000
+    default_item["connection_success"] = True
+    default_item["connection_latency_ms"] = connectivity_time
+    default_item["connection_attempts"] = connection_attempts
+
+    try:
+        board = Board.from_robot(robot, "board")
+        board_return_value = await board.gpio_pin_by_name("32")
+        _ = await board_return_value.get()
+        await board_return_value.set(True)
+        value = await board_return_value.get()
+        if not value:
+            raise ValueError("Pin not set to high successfully")
+        default_item["board_api_success"] = True
+    except Exception as e:
+        default_item["error"] = str(e)
+        coll.insert_one(default_item)
+        raise e
+    
+    coll.insert_one(default_item)
+
+    await robot.close()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/canary/daily_summary.py
+++ b/canary/daily_summary.py
@@ -15,8 +15,8 @@ def main():
 
     mongo_connection_str = os.environ["MONGODB_TEST_OUTPUT_URI"]
     db_client = MongoClient(mongo_connection_str)
-    db = db_client["esp32_canary"]
-    coll = db["hourly_results"]
+    db = db_client["micrordk_canary"]
+    coll = db["raw_results"]
 
     print("getting hourly results...")
 
@@ -24,26 +24,28 @@ def main():
     latency_sum = 0
     successes = 0
     connection_failures = 0
+    board_api_successes = 0
     board_api_failures = 0
     connection_attempts = 0
+    num_results = 0
     for record in result_set:
+        num_results += 1
         if record["connection_success"]:
             latency_sum += record["connection_latency_ms"]
             connection_attempts += record["connection_attempts"]
-            if record["board_api_success"]:
-                successes += 1
-            else:
-                board_api_failures += 1
+            successes += 1
+            board_api_successes += record["board_api_successes"]
+            board_api_failures += record["board_api_failures"]
         else:
             connection_failures += 1
     
-    avg_connection_latency_ms = latency_sum / successes
-    avg_connection_attempts = connection_attempts / successes
-
-    total_runs = successes + connection_failures + board_api_failures
-    if total_runs == 0:
+    if num_results == 0:
         raise Exception(f"no hourly canary results found for {today}")
+
+    avg_connection_latency_ms = latency_sum / successes if successes != 0 else 0
+    avg_connection_attempts = connection_attempts / num_results
     
+    total_board_calls = board_api_successes + board_api_failures
 
     coll2 = db["daily_summaries"]
     summary = {
@@ -57,8 +59,12 @@ def main():
     inserted_id = coll2.insert_one(summary)
     print(f"successfully inserted stats for {inserted_id}: {summary}")
 
-    failure_rate = round((connection_failures + board_api_failures) / total_runs, 3)
+    failure_rate = round(connection_failures / num_results, 3)
     if failure_rate > FAILURE_ACCEPTABILITY:
+        raise Exception(f"Connection failure rate {failure_rate * 100}%% greater than {FAILURE_ACCEPTABILITY * 100}%%")
+    
+    board_failure_rate = round(board_api_failures / total_board_calls)
+    if board_failure_rate > FAILURE_ACCEPTABILITY:
         raise Exception(f"Connection failure rate {failure_rate * 100}%% greater than {FAILURE_ACCEPTABILITY * 100}%%")
 
 if __name__ == '__main__':

--- a/canary/daily_summary.py
+++ b/canary/daily_summary.py
@@ -1,4 +1,3 @@
-import asyncio
 import datetime
 import os
 
@@ -18,7 +17,7 @@ def main():
     db = db_client["micrordk_canary"]
     coll = db["raw_results"]
 
-    print("getting hourly results...")
+    print("getting raw results...")
 
     result_set = coll.find({ "_id": { "$gte": start_of_day, "$lt": start_of_tomorrow } })
     latency_sum = 0
@@ -40,7 +39,7 @@ def main():
             connection_failures += 1
     
     if num_results == 0:
-        raise Exception(f"no hourly canary results found for {today}")
+        raise Exception(f"no raw canary results found for {today}, please restart the canary")
 
     avg_connection_latency_ms = latency_sum / successes if successes != 0 else 0
     avg_connection_attempts = connection_attempts / num_results

--- a/canary/daily_summary.py
+++ b/canary/daily_summary.py
@@ -1,0 +1,65 @@
+import asyncio
+import datetime
+import os
+
+from dateutil import tz
+from pymongo import MongoClient
+
+FAILURE_ACCEPTABILITY = 0.2
+
+def main():
+    today = datetime.datetime.now(tz=tz.UTC).date()
+    tomorrow = today + datetime.timedelta(days=1)
+    start_of_day = datetime.datetime(today.year, today.month, today.day, tzinfo=tz.UTC)
+    start_of_tomorrow = datetime.datetime(tomorrow.year, tomorrow.month, tomorrow.day, tzinfo=tz.UTC)
+
+    mongo_connection_str = os.environ["MONGODB_TEST_OUTPUT_URI"]
+    db_client = MongoClient(mongo_connection_str)
+    db = db_client["esp32_canary"]
+    coll = db["hourly_results"]
+
+    print("getting hourly results...")
+
+    result_set = coll.find({ "_id": { "$gte": start_of_day, "$lt": start_of_tomorrow } })
+    latency_sum = 0
+    successes = 0
+    connection_failures = 0
+    board_api_failures = 0
+    connection_attempts = 0
+    for record in result_set:
+        if record["connection_success"]:
+            latency_sum += record["connection_latency_ms"]
+            connection_attempts += record["connection_attempts"]
+            if record["board_api_success"]:
+                successes += 1
+            else:
+                board_api_failures += 1
+        else:
+            connection_failures += 1
+    
+    avg_connection_latency_ms = latency_sum / successes
+    avg_connection_attempts = connection_attempts / successes
+
+    total_runs = successes + connection_failures + board_api_failures
+    if total_runs == 0:
+        raise Exception(f"no hourly canary results found for {today}")
+    
+
+    coll2 = db["daily_summaries"]
+    summary = {
+        "_id": start_of_day,
+        "successes": successes,
+        "robot_connection_failures": connection_failures,
+        "board_api_failures": board_api_failures,
+        "avg_connection_latency_ms": avg_connection_latency_ms,
+        "avg_connection_attempts": avg_connection_attempts
+    }
+    inserted_id = coll2.insert_one(summary)
+    print(f"successfully inserted stats for {inserted_id}: {summary}")
+
+    failure_rate = round((connection_failures + board_api_failures) / total_runs, 3)
+    if failure_rate > FAILURE_ACCEPTABILITY:
+        raise Exception(f"Connection failure rate {failure_rate * 100}%% greater than {FAILURE_ACCEPTABILITY * 100}%%")
+
+if __name__ == '__main__':
+    main()

--- a/canary/requirements.txt
+++ b/canary/requirements.txt
@@ -1,0 +1,2 @@
+viam-sdk
+pymongo

--- a/canary/requirements.txt
+++ b/canary/requirements.txt
@@ -1,2 +1,3 @@
 viam-sdk
 pymongo
+numpy


### PR DESCRIPTION
Testing the github actions on my own a little later before merging, but wanted to get input on the connectivity data published and the acceptability threshold in the meantime

Used the Viam Python SDK since the golang one has its own netcode that does not make use of rust-utils.

Currently implemented to get the following information every hour and save to our MongoDB instance as a database called "esp32_canary" under a collection called "hourly_results"

- could we connect to the robot?
- how long did it take to connect to the robot?
- how many attempts did it take to connect to the robot?
- could we get/set a GPIO pin on the ESP32?
- if there was a failure, we store the error as well

Additionally there is a daily summary compiled at 11:30PM UTC that records the following information and saved to the same database under a collection called "daily_summaries"

- how many successful runs?
- how many failures to connect to the robot initially?
- how many failures when making calls to the board API?
- how many attempts did it take to connect to the robot on average (when successful)?
- what was the average time it took to connect to the robot?