### PR TITLE
RSDK-6421 Add support for sccache to micro-rdk canon images

### DIFF
--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -4,8 +4,8 @@ RUN apt update && apt-get install -y --no-install-recommends git libudev-dev mak
 RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 RUN cargo binstall cargo-espflash --install-path /usr/ -y
 RUN cargo binstall espup --install-path /usr/ -y
-RUN cargo install ldproxy --root /usr/ 
-
+RUN cargo install ldproxy --root /usr/
+RUN cargo install sccache --root /usr/
 
 WORKDIR /qemu
 RUN git clone --depth 1 --branch esp-develop https://github.com/espressif/qemu
@@ -62,7 +62,8 @@ RUN RUST_VERSION=$RUST_VERSION \
 COPY --from=builder /usr/cargo-espflash /usr/bin
 COPY --from=builder /usr/bin/ldproxy /usr/bin
 COPY --from=builder /usr/espup /usr/bin
-   
+COPY --from=builder /usr/bin/sccache /usr/bin
+
 WORKDIR /host/
 
 RUN useradd -s /bin/bash -m testbot && \
@@ -95,7 +96,9 @@ RUN rm -rf $CARGO_HOME/registry
 RUN echo "PATH=$PATH" >> ~/.bash_profile && \
     echo ". $ESP_ROOT/export-esp.sh" >> ~/.bash_profile && \
     echo ". $IDF_PATH/export.sh"  >> ~/.bash_profile && \
-    echo "CARGO_HOME=/host/.cargo-docker-registry" >> ~/.bash_profile
+    echo "CARGO_HOME=/host/.cargo-docker-registry" >> ~/.bash_profile && \
+    echo "[[ -v SCCACHE ]] && export RUSTC_WRAPPER=/usr/bin/sccache" >> ~/.bash_profile && \
+    echo "[[ -v SCCACHE ]] && export SCCACHE_DIR=/host/.sccache" >> ~/.bash_profile
 
 USER root
 

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -34,11 +34,11 @@ ENV RUSTUP_HOME=/opt/rust/rustup \
 
 RUN apt update && apt dist-upgrade -y
 
-RUN apt update 
+RUN apt update
 
 RUN apt-get install -y --no-install-recommends git wget flex bison gperf python3 python3-pip python3-virtualenv cmake ninja-build ccache libffi-dev libssl-dev libudev-dev dfu-util libusb-1.0-0 openssh-client software-properties-common python3-venv sudo && \
     apt-get install -y --no-install-recommends cmake && \
-    update-alternatives --install /usr/bin/python python /usr/bin/python3 10 
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
 
 RUN RUST_VERSION=$RUST_VERSION \
@@ -96,9 +96,9 @@ RUN rm -rf $CARGO_HOME/registry
 RUN echo "PATH=$PATH" >> ~/.bash_profile && \
     echo ". $ESP_ROOT/export-esp.sh" >> ~/.bash_profile && \
     echo ". $IDF_PATH/export.sh"  >> ~/.bash_profile && \
-    echo "CARGO_HOME=/host/.cargo-docker-registry" >> ~/.bash_profile && \
+    echo "CARGO_HOME=/host/.micro-rdk-docker-caches/cargo-registry" >> ~/.bash_profile && \
     echo "[[ -v SCCACHE ]] && export RUSTC_WRAPPER=/usr/bin/sccache" >> ~/.bash_profile && \
-    echo "[[ -v SCCACHE ]] && export SCCACHE_DIR=/host/.sccache" >> ~/.bash_profile
+    echo "[[ -v SCCACHE ]] && export SCCACHE_DIR=/host/.micro-rdk-docker-caches/sccache" >> ~/.bash_profile
 
 USER root
 
@@ -108,4 +108,4 @@ RUN apt-get install make build-essential pkg-config -y && apt-get autoremove -y 
 COPY --from=builder /qemu/qemu/build/qemu-system-xtensa /usr/bin
 
 RUN chmod -R a+rwx $ESP_ROOT && \
-    chown -R testbot:testbot $ESP_ROOT    
+    chown -R testbot:testbot $ESP_ROOT


### PR DESCRIPTION
After this change, running `canon --profile ... env SCCACHE=1 ...` will enable `sccache` in the canon environment by setting `RUSTC_WRAPPER=/usr/bin/sccache` and `SCCACHE_DIR=/host/.sccache`, by analogy with the existing `.cargo-docker-registry` host-based cargo cache.

That makes it opt-in. It'd be nice, perhaps, if canon supported setting `env: ...` in your canon config file so you could opt-in to it persistently under a name, but it doesn't seem to. 

I'll confess to being very tempted to introduce as part of this change a new `.micro-rdk-canon-shared-state` or similarly named directory and push the `.cargo-docker-registry` and `.sccache` directories under it, without the leading `.`s. Let me know if you feel that's worthwhile, as it would be a pretty minimal change above what is here.

This currently comes with no controls over the cache size, but that can easily be added later if found to be needed.