### PR TITLE
Workspace based dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,78 @@ opt-level = "s"
 debug = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
+[workspace.dependencies]
+anyhow = "1.0.71"
+async-channel = "1.8.0"
+async-io = "=1.12.0"
+async-std-openssl = "0.6.3"
+base64 = "0.21.0"
+bitfield = "0.14.0"
+bytecodec = "0.4.15"
+bytes = "1.2.1"
+chrono = "0.4.31"
+clap = "=4.3.23"
+const-gen = "1.3.0"
+crc32fast = "1.3.2"
+der = { version = "0.7.7", features = ["pem", "alloc", "zeroize"] }
+dialoguer = "0.10.4"
+either = "1.8.0"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
+embedded-svc = "0.26.4"
+embuild = "0.31.3"
+env_logger = "0.10.1"
+esp-idf-svc = "= 0.47.3"
+espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor_changes" }
+futures = "0.3.28"
+futures-lite = "1.12.0"
+gethostname = "0.4.3"
+h2 = "0.3.22"
+hyper = { version = "0.14.20", default-features = false, features = ["server", "stream", "http2"] }
+ignore = "=0.4.20"
+lazy_static = "1.4.0"
+local-ip-address = "0.5.3"
+log = "0.4.20"
+md5 = "0.7.0"
+mdns-sd = { version = "0.5.10", default-features = false, features = ["async"] }
+micro-rdk = { path = "./micro-rdk", default-features = false, features = [] }
+micro-rdk-macros = { path = "./micro-rdk-macros" }
+once_cell = "1.18.0"
+openssl = { version = "0.10.50" }
+packed_struct = "0.10.1"
+pin-project-lite = "0.2.9"
+proc-macro-crate = "2.0.0"
+proc-macro2 = "1.0.67"
+prost = "0.11.0"
+prost-types = "0.11.1"
+quote = "1.0.33"
+rand = "0.8.5"
+rcgen = "0.11.1"
+reqwest = "0.11.20"
+reqwless = "0.5.0"
+ring = "0.16.20"
+rustls = { version = "0.20.7", features = ["logging", "tls12"] }
+rustls-pemfile = { version = "1.0.2" }
+scopeguard = "1.2.0"
+sctp-proto = "0.1.4"
+sdp = "0.5.1"
+secrecy = { version = "0.8.0", features = ["serde"] }
+serde = { version = "1.0.156", features = ["derive"] }
+serde_json = "1.0.97"
+sha2 = "0.10.6"
+smol = "1.2"
+smol-timeout = "0.6.0"
+socket2 = "0.4.9"
+stun_codec = { version = "0.3.0" , git = "https://github.com/viamrobotics/stun_codec"}
+syn = "1.0.109"
+tempfile = "3.8.0"
+test-log = "0.2.11"
+thiserror = "1.0.47"
+tokio = { version = "1.29.1", default-features = false }
+trackable = "1.2.0"
+url = "2.4.0"
+viam = { version = ">=0.0.17", git = "https://github.com/viamrobotics/viam-rust-sdk.git" }
+viam-rust-utils = "0.1.2"
+webpki-roots = "0.22.6"
+
 [template]
 sub_templates = ["templates/project", "templates/module"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -18,16 +18,12 @@ qemu = []
 micro-rdk = { workspace = true, features = ["native"], default-features = false }
 env_logger.workspace = true
 local-ip-address.workspace = true
-log.workspace = true
-anyhow = { workspace = true, features = ["backtrace"] }
 
 
 [target.'cfg(target_os="espidf")'.dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
 embedded-svc.workspace = true
 embedded-hal.workspace = true
 micro-rdk = { workspace = true, features = ["esp32"] }
-log.workspace = true
 async-channel.workspace = true
 smol.workspace = true
 futures-lite.workspace = true
@@ -35,9 +31,11 @@ reqwless.workspace = true
 
 
 [dependencies]
+anyhow = { workspace = true, features = ["backtrace"] }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
+log.workspace = true
 
 
 [build-dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,44 +15,44 @@ publish = false
 qemu = []
 
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
-micro-rdk = { workspace = true, features = ["native"], default-features = false }
 env_logger.workspace = true
 local-ip-address.workspace = true
+micro-rdk = { workspace = true, features = ["native"], default-features = false }
 
 
 [target.'cfg(target_os="espidf")'.dependencies]
-embedded-svc.workspace = true
-embedded-hal.workspace = true
-micro-rdk = { workspace = true, features = ["esp32"] }
 async-channel.workspace = true
-smol.workspace = true
+embedded-hal.workspace = true
+embedded-svc.workspace = true
 futures-lite.workspace = true
+micro-rdk = { workspace = true, features = ["esp32"] }
 reqwless.workspace = true
+smol.workspace = true
 
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }
+log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-log.workspace = true
 
 
 [build-dependencies]
 anyhow.workspace = true
 const-gen.workspace = true
+der.workspace = true
 embuild.workspace = true
 gethostname.workspace = true
 local-ip-address.workspace = true
 prost-types.workspace = true
+rcgen.workspace = true
+ring.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
-viam.workspace = true
 viam-rust-utils.workspace = true
-rcgen.workspace = true
-ring.workspace = true
-der.workspace = true
+viam.workspace = true
 
 [[bin]]
 name = "native-server"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -15,46 +15,46 @@ publish = false
 qemu = []
 
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
-micro-rdk = { path = "../micro-rdk", features = ["native"], default-features = false }
-env_logger = "0.10.0"
-local-ip-address = { version = "0.4.9" }
-log = "0.4"
-anyhow = { version = "1", features = ["backtrace"] }
+micro-rdk = { workspace = true, features = ["native"], default-features = false }
+env_logger.workspace = true
+local-ip-address.workspace = true
+log.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 
 
 [target.'cfg(target_os="espidf")'.dependencies]
-anyhow = {version = "1", features = ["backtrace"]}
-embedded-svc = "0.26.4"
-embedded-hal = { version = "0.2.7", features = ["unproven"]}
-micro-rdk = { path = "../micro-rdk", default-features = false, features = ["esp32"] }
-log = "0.4"
-async-channel = "1.8.0"
-smol = "1.2"
-futures-lite = "1.12.0"
-reqwless = "0.5.0"
+anyhow = { workspace = true, features = ["backtrace"] }
+embedded-svc.workspace = true
+embedded-hal.workspace = true
+micro-rdk = { workspace = true, features = ["esp32"] }
+log.workspace = true
+async-channel.workspace = true
+smol.workspace = true
+futures-lite.workspace = true
+reqwless.workspace = true
 
 
 [dependencies]
-serde = "1.0.145"
-serde_json = "1.0.97"
-thiserror = "1.0.47"
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 
 
 [build-dependencies]
-anyhow = "1"
-const-gen = "1.3.0"
-embuild = "0.31.3"
-gethostname = "0.4.1"
-local-ip-address = "0.4.9"
-prost-types = "0.11.1"
-serde = { version="1.0.145",features=["derive"] }
-serde_json = "1.0.86"
-tokio = { version = "1", features = ["full"] }
-viam = { version = ">=0.0.17", git = "https://github.com/viamrobotics/viam-rust-sdk.git" }
-viam-rust-utils = ">=0.0.25"
-rcgen = { version =  "0.10.0" }
-ring = "0.16"
-der = {version = "0.7.7", features = ["pem", "alloc","zeroize"] }
+anyhow.workspace = true
+const-gen.workspace = true
+embuild.workspace = true
+gethostname.workspace = true
+local-ip-address.workspace = true
+prost-types.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
+viam.workspace = true
+viam-rust-utils.workspace = true
+rcgen.workspace = true
+ring.workspace = true
+der.workspace = true
 
 [[bin]]
 name = "native-server"

--- a/micro-rdk-installer/Cargo.toml
+++ b/micro-rdk-installer/Cargo.toml
@@ -13,26 +13,26 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.71"
-clap = { version = "=4.3.23", features = ["derive"] }
-crc32fast = "1.3.2"
-der = {version = "0.7.7", features = ["pem", "alloc","zeroize"] }
-dialoguer = "0.10.4"
-env_logger = "0.10.1"
-espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor_changes" }
-gethostname = "0.4.3"
-local-ip-address = "0.5.3"
-log = "0.4.20"
-md5 = "0.7.0"
-packed_struct = "0.10.1"
-rcgen = "0.11.1"
-reqwest = "0.11.20"
-ring = "0.16.20"
-secrecy = { version = "0.8.0", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tempfile = "3.8.0"
-thiserror = "1.0.46"
-tokio = "1.29.1"
-viam = { version = ">=0.0.7", git = "https://github.com/viamrobotics/viam-rust-sdk.git" }
-viam-rust-utils = "0.1.2"
+anyhow = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+crc32fast.workspace = true
+der.workspace = true
+dialoguer.workspace = true
+env_logger.workspace = true
+espflash.workspace = true
+gethostname.workspace = true
+local-ip-address.workspace = true
+log.workspace = true
+md5.workspace = true
+packed_struct.workspace = true
+rcgen.workspace = true
+reqwest.workspace = true
+ring.workspace = true
+secrecy.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+viam.workspace = true
+viam-rust-utils.workspace = true

--- a/micro-rdk-installer/Cargo.toml
+++ b/micro-rdk-installer/Cargo.toml
@@ -34,5 +34,5 @@ serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
-viam.workspace = true
 viam-rust-utils.workspace = true
+viam.workspace = true

--- a/micro-rdk-macros/Cargo.toml
+++ b/micro-rdk-macros/Cargo.toml
@@ -15,14 +15,14 @@ version.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro-crate = "2.0.0"
-proc-macro2 = "1.0.67"
-quote = "1.0.33"
-syn = "1.0.109"
+proc-macro-crate.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 
 [dev-dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-micro-rdk = { path = "../micro-rdk", features = ["native"] }
+anyhow = { workspace = true, features = ["backtrace"] }
+micro-rdk = { workspace = true, features = ["native"] }
 
 [[test]]
 name = "do-command-tests"

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -28,49 +28,49 @@ env_logger.workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 async-channel.workspace = true
 async-io.workspace = true
+async-std-openssl = { workspace = true, optional = true }
+base64.workspace = true
+bitfield.workspace = true
+bytecodec.workspace = true
 bytes.workspace = true
+chrono.workspace = true
 either.workspace = true
 embedded-hal = { workspace = true, optional = true }
 embedded-svc = { workspace = true, optional = true }
 esp-idf-svc = { workspace = true, optional = true }
-futures.workspace = true
 futures-lite.workspace = true
+futures.workspace = true
 h2.workspace = true
 hyper.workspace = true
+ignore.workspace = true
 lazy_static.workspace = true
 local-ip-address = { workspace = true, optional = true }
 log.workspace = true
 mdns-sd = { workspace = true, optional = true }
+micro-rdk-macros.workspace = true
+once_cell.workspace = true
+openssl = { workspace = true, optional = true }
+pin-project-lite.workspace = true
 prost.workspace = true
-rustls = { workspace = true, optional = true }
-rustls-pemfile = { workspace = true, optional = true }
-sctp-proto.workspace = true
-smol.workspace = true
-smol-timeout.workspace = true
-sdp.workspace = true
-socket2.workspace = true
-tokio.workspace = true
-webpki-roots = { workspace = true, optional = true }
-base64.workspace = true
-serde.workspace = true
-serde_json.workspace = true
 rand.workspace = true
 rcgen = { workspace = true, optional = true }
-sha2.workspace = true
-stun_codec.workspace = true
-bytecodec.workspace = true
-trackable.workspace = true
-openssl = { workspace = true, optional = true }
-async-std-openssl = { workspace = true, optional = true }
-thiserror.workspace = true
-pin-project-lite.workspace = true
-url.workspace = true
-once_cell.workspace = true
-chrono.workspace = true
-micro-rdk-macros.workspace = true
-ignore.workspace = true
-bitfield.workspace = true
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
 scopeguard.workspace = true
+sctp-proto.workspace = true
+sdp.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+smol-timeout.workspace = true
+smol.workspace = true
+socket2.workspace = true
+stun_codec.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+trackable.workspace = true
+url.workspace = true
+webpki-roots = { workspace = true, optional = true }
 
 [build-dependencies]
 anyhow.workspace = true

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -21,58 +21,58 @@ esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal"]
 native = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address", "dep:openssl", "dep:rcgen", "dep:async-std-openssl"]
 
 [dev-dependencies]
-test-log = "0.2.11"
-env_logger = "0.10.0"
+test-log.workspace = true
+env_logger.workspace = true
 
 [dependencies]
-anyhow = { version = "1", features = ["backtrace"] }
-async-channel = "1.8.0"
-async-io = "=1.12.0"
-bytes = "1.2.1"
-either = "1.8.0"
-embedded-hal = { version = "0.2.7", features = ["unproven"], optional = true }
-embedded-svc = { version = "0.26.4", optional = true }
-esp-idf-svc = { version = "= 0.47.3",  optional = true }
-futures = "0.3.28"
-futures-lite = "1.12.0"
-h2 = "0.3.22"
-hyper = { version="0.14.20", default-features = false, features = ["server","stream","http2"] }
-lazy_static = "1.4.0"
-local-ip-address = { version = "0.4.9", optional = true }
-log = "0.4"
-mdns-sd = { version = "0.5.10", optional = true, default-features = false, features = ["async"] }
-prost = "0.11.0"
-rustls = { version = "0.20.7", features = ["logging","tls12"], optional = true }
-rustls-pemfile = { version = "1.0.2", optional = true }
-sctp-proto = "0.1.4"
-smol = "1.2"
-smol-timeout = "0.6.0"
-sdp = "0.5.1"
-socket2 = "0.4.9"
-tokio = { version = "1", default-features = false }
-webpki-roots = { version = "0.22.6", optional = true }
-base64 = "0.21.0"
-serde = {version = "1.0.156",features = ["derive"]      }
-serde_json = "1.0.94"
-rand = "0.8.5"
-rcgen = {version = "0.10.0", optional = true }
-sha2 = "0.10.6"
-stun_codec = { version = "0.3.0" , git = "https://github.com/viamrobotics/stun_codec"}
-bytecodec = "0.4.15"
-trackable = "1.2.0"
-openssl = {version = "0.10.50",  optional = true }
-async-std-openssl = {version = "0.6.3", optional = true }
-thiserror = "1.0.40"
-pin-project-lite = "0.2.9"
-url = "2.4.0"
-once_cell = "1.18.0"
-chrono = "0.4.31"
-micro-rdk-macros = { path = "../micro-rdk-macros" }
-ignore = "=0.4.20"
-bitfield = "0.14.0"
-scopeguard = "1.2.0"
+anyhow = { workspace = true, features = ["backtrace"] }
+async-channel.workspace = true
+async-io.workspace = true
+bytes.workspace = true
+either.workspace = true
+embedded-hal = { workspace = true, optional = true }
+embedded-svc = { workspace = true, optional = true }
+esp-idf-svc = { workspace = true, optional = true }
+futures.workspace = true
+futures-lite.workspace = true
+h2.workspace = true
+hyper.workspace = true
+lazy_static.workspace = true
+local-ip-address = { workspace = true, optional = true }
+log.workspace = true
+mdns-sd = { workspace = true, optional = true }
+prost.workspace = true
+rustls = { workspace = true, optional = true }
+rustls-pemfile = { workspace = true, optional = true }
+sctp-proto.workspace = true
+smol.workspace = true
+smol-timeout.workspace = true
+sdp.workspace = true
+socket2.workspace = true
+tokio.workspace = true
+webpki-roots = { workspace = true, optional = true }
+base64.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+rand.workspace = true
+rcgen = { workspace = true, optional = true }
+sha2.workspace = true
+stun_codec.workspace = true
+bytecodec.workspace = true
+trackable.workspace = true
+openssl = { workspace = true, optional = true }
+async-std-openssl = { workspace = true, optional = true }
+thiserror.workspace = true
+pin-project-lite.workspace = true
+url.workspace = true
+once_cell.workspace = true
+chrono.workspace = true
+micro-rdk-macros.workspace = true
+ignore.workspace = true
+bitfield.workspace = true
+scopeguard.workspace = true
 
 [build-dependencies]
-anyhow = "1"
-const-gen = "1.3.0"
-embuild = "0.31.3"
+anyhow.workspace = true
+const-gen.workspace = true
+embuild.workspace = true


### PR DESCRIPTION
This had been something I'd hoped to do as part of converting to a workspace per #149, but since I didn't finish the work for that PR it wasn't included. It's maybe controversial? I'm not sure.

Anyway, this change moves us to use workspace dependency inheritance for all dependencies in the workspace crates.

The only downside to doing this that I'm aware of is that `cargo add` doesn't currently have support for adding directly at the workspace level, so if we `cargo add` a new dependency, we will need to manually pull it up to the top-level `Cargo.toml`, at least until https://github.com/rust-lang/cargo/issues/10608 gets resolved one way or another.

On the other hand, with this change in place, if we do `cargo add` of an existing dependency in a new location, it will import it with `.workspace = true`, which is nice.

Overall, I think this will make it easier to see what dependencies we are declaring at a glance, and easier to make upgrades in one place for crates used in multiple workspace sub-crates.