### PR TITLE
add functionality to import micro-RDK as a library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 /examples/viam.json
 /canary/.venv/*
 .vscode
+components_esp32.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ embedded-hal = { version = "0.2.7", features = ["unproven"] }
 embedded-svc = "0.26.4"
 embuild = "0.31.3"
 env_logger = "0.10.1"
-esp-idf-svc = "= 0.47.3"
+esp-idf-svc = { version = "= 0.47.3", default-features = false }
 espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor_changes" }
 futures = "0.3.28"
 futures-lite = "1.12.0"

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ clippy-native:
 	cargo clippy -p micro-rdk --no-deps --features native --no-default-features -- -Dwarnings
 
 clippy-esp32:
-	cargo +esp clippy -p micro-rdk  --features esp32 --no-default-features --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort -- -Dwarnings
+	cargo +esp clippy -p micro-rdk  --features esp32 --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort -- -Dwarnings
 
 clippy-cli:
 	cargo clippy -p micro-rdk-installer --no-default-features -- -Dwarnings

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ native:
 	cargo run -p examples  --bin native-server
 
 build-qemu:
-	cargo +esp build -p examples  --bin esp32-server  --features qemu --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort && cargo espflash save-image --package examples --features qemu --merge --chip esp32 target/xtensa-esp32-espidf/debug/debug.bin -T examples/esp32/partitions.csv -s 4mb  --bin esp32-server --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort
+	cargo +esp build -p examples  --bin esp32-server  --features qemu binstart --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort && cargo espflash save-image --package examples --features qemu --merge --chip esp32 target/xtensa-esp32-espidf/debug/debug.bin -T examples/esp32/partitions.csv -s 4mb  --bin esp32-server --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort
 
 
 sim-local: cargo-ver build-qemu

--- a/components_esp32.lock
+++ b/components_esp32.lock
@@ -1,0 +1,9 @@
+dependencies:
+  idf:
+    component_hash: null
+    source:
+      type: idf
+    version: 4.4.4
+manifest_hash: 15fbb127b962db41e3dd7e0dcb77260d0aebcbb2c50404982bcc8ce4dd461af0
+target: esp32
+version: 1.0.0

--- a/components_esp32.lock
+++ b/components_esp32.lock
@@ -1,9 +1,0 @@
-dependencies:
-  idf:
-    component_hash: null
-    source:
-      type: idf
-    version: 4.4.4
-manifest_hash: 15fbb127b962db41e3dd7e0dcb77260d0aebcbb2c50404982bcc8ce4dd461af0
-target: esp32
-version: 1.0.0

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ async-channel.workspace = true
 embedded-hal.workspace = true
 embedded-svc.workspace = true
 futures-lite.workspace = true
-micro-rdk = { workspace = true, features = ["esp32"] }
+micro-rdk = { workspace = true, features = ["esp32", "binstart"], default-features = true }
 reqwless.workspace = true
 smol.workspace = true
 

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -15,7 +15,9 @@ links = "micro_rdk"
 crate-type = ["lib"]
 
 [features]
-default = []
+default = ["esp-idf-svc/std", "esp-idf-svc/alloc"]
+binstart = ["esp-idf-svc/binstart"]
+libstart = ["esp-idf-svc/libstart"]
 camera = []
 esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal"]
 native = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address", "dep:openssl", "dep:rcgen", "dep:async-std-openssl"]


### PR DESCRIPTION
This changes things so that, by default, micro-RDK will be compiled as a library dependency in an external module or project (in other words, esp-idf-svc will not be compiled with the `binstart` feature in micro-RDK)

For all projects meant to be the main application on an esp32, the `binstart` feature will have to be specified for the micro-RDK dependency (see the changes in `examples/Cargo.toml` for an example)

This PR also exposes the `libstart` feature on esp-idf-svc