### PR TITLE
RSDK-6992 RSDK-6993 - implement DataCollector pt. 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ clean:
 all: clean build-esp32-bin build-native build-esp32-with-cred-bin
 
 buf-clean:
-	find src/gen -type f \( -iname "*.rs" \) -delete
+	find micro-rdk/src/gen -type f \( -iname "*.rs" \) -delete
 
 buf: buf-clean
-	buf generate buf.build/viamrobotics/goutils --template buf.gen.yaml
-	buf generate buf.build/googleapis/googleapis --template buf.gen.yaml --path google/rpc --path google/api
-	buf generate buf.build/viamrobotics/api --template buf.gen.yaml
-	buf generate buf.build/protocolbuffers/wellknowntypes --template buf.gen.yaml 
+	buf generate buf.build/viamrobotics/goutils --template micro-rdk/buf.gen.yaml
+	buf generate buf.build/googleapis/googleapis --template micro-rdk/buf.gen.yaml --path google/rpc --path google/api
+	buf generate buf.build/viamrobotics/api --template micro-rdk/buf.gen.yaml
+	buf generate buf.build/protocolbuffers/wellknowntypes --template micro-rdk/buf.gen.yaml 
 
 license-finder:
 	license_finder

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -22,6 +22,7 @@ builtin-components = []
 camera = []
 esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal", "esp-idf-svc/std", "esp-idf-svc/alloc"]
 native = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address", "dep:openssl", "dep:rcgen", "dep:async-std-openssl"]
+data = []
 
 [dev-dependencies]
 test-log.workspace = true

--- a/micro-rdk/buf.gen.yaml
+++ b/micro-rdk/buf.gen.yaml
@@ -1,7 +1,7 @@
 version: v1
 plugins:
   - plugin: buf.build/community/neoeinstein-prost:v0.2.3
-    out: src/gen/
+    out: micro-rdk/src/gen/
     opt:
       - bytes=.viam.component.camera.v1
       - bytes=.proto.rpc.webrtc.v1

--- a/micro-rdk/src/common/data_collector.rs
+++ b/micro-rdk/src/common/data_collector.rs
@@ -1,0 +1,318 @@
+use std::fmt::Display;
+
+use crate::google::protobuf::Timestamp;
+use crate::proto::app::data_sync::v1::{SensorData, SensorMetadata};
+
+use super::{
+    config::{AttributeError, Kind},
+    movement_sensor::MovementSensor,
+    robot::ResourceType,
+    sensor::{Readings, SensorError},
+};
+
+use chrono::offset::Local;
+use thiserror::Error;
+
+/// A DataCollectorConfig instance is a representation of an element
+/// of the list of "capture_methods" in the "attributes" section of a
+/// component's configuration JSON object as stored in app. Each element
+/// of "capture_methods" is meant to produce an instance of `DataCollector`
+/// as defined below
+#[derive(Debug, Clone)]
+pub struct DataCollectorConfig {
+    pub method: CollectionMethod,
+    pub capture_frequency_hz: f32,
+}
+
+impl TryFrom<&Kind> for DataCollectorConfig {
+    type Error = AttributeError;
+    fn try_from(value: &Kind) -> Result<Self, Self::Error> {
+        let method_str: String = value
+            .get("method")?
+            .ok_or(AttributeError::KeyNotFound("method".to_string()))?
+            .try_into()?;
+        let capture_frequency_hz = value
+            .get("capture_frequency_hz")?
+            .ok_or(AttributeError::KeyNotFound(
+                "capture_frequency_hz".to_string(),
+            ))?
+            .try_into()?;
+        // TODO: RSDK-7127 - Collectors that take arguments (ex. Board Analogs)
+        let method = match method_str.as_str() {
+            "Readings" => CollectionMethod::Readings,
+            "AngularVelocity" => CollectionMethod::AngularVelocity,
+            "LinearAcceleration" => CollectionMethod::LinearAcceleration,
+            "LinearVelocity" => CollectionMethod::LinearVelocity,
+            _ => {
+                return Err(AttributeError::ConversionImpossibleError);
+            }
+        };
+        Ok(DataCollectorConfig {
+            method,
+            capture_frequency_hz,
+        })
+    }
+}
+
+/// A CollectionMethod is an enum whose values are associated with
+/// a method on one or more component traits
+#[derive(Debug, Clone)]
+pub enum CollectionMethod {
+    Readings,
+    // MovementSensor methods
+    AngularVelocity,
+    LinearAcceleration,
+    LinearVelocity,
+    // TODO: RSDK-7127 - Implement collectors for all other applicable components/methods
+}
+
+impl Display for CollectionMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(
+            match self {
+                Self::Readings => "readings",
+                Self::AngularVelocity => "angularvelocity",
+                Self::LinearAcceleration => "linearacceleration",
+                Self::LinearVelocity => "linearvelocity",
+            },
+            f,
+        )
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DataCollectionError {
+    #[error("method {0} unsupported for {1}")]
+    UnsupportedMethod(CollectionMethod, String),
+    #[error("no collection methods supported for component")]
+    NoSupportedMethods,
+    #[error(transparent)]
+    SensorCollectionError(#[from] SensorError),
+}
+
+/// A DataCollector represents an association between a data collection method and
+/// a ResourceType (i.e. SensorType & Readings, BoardType & Analogs) and the frequency at
+/// which the results of the method should be stored.
+pub struct DataCollector {
+    name: String,
+    component_type: String,
+    resource: ResourceType,
+    method: CollectionMethod,
+    time_interval_ms: u64,
+}
+
+fn resource_method_pair_is_valid(resource: &ResourceType, method: &CollectionMethod) -> bool {
+    match resource {
+        ResourceType::Sensor(_) => matches!(method, CollectionMethod::Readings),
+        ResourceType::MovementSensor(_) => matches!(
+            method,
+            CollectionMethod::Readings
+                | CollectionMethod::AngularVelocity
+                | CollectionMethod::LinearAcceleration
+                | CollectionMethod::LinearVelocity
+        ),
+        _ => false,
+    }
+}
+
+impl DataCollector {
+    pub fn new(
+        name: String,
+        resource: ResourceType,
+        method: CollectionMethod,
+        capture_frequency_hz: f32,
+    ) -> Result<Self, DataCollectionError> {
+        let time_interval_ms = (1000.0 / capture_frequency_hz) as u64;
+        let component_type = resource.component_type();
+        if !resource_method_pair_is_valid(&resource, &method) {
+            return Err(DataCollectionError::UnsupportedMethod(
+                method,
+                component_type,
+            ));
+        }
+        Ok(DataCollector {
+            name,
+            component_type,
+            resource,
+            method,
+            time_interval_ms,
+        })
+    }
+
+    pub fn from_config(
+        name: String,
+        resource: ResourceType,
+        conf: DataCollectorConfig,
+    ) -> Result<Self, DataCollectionError> {
+        Self::new(name, resource, conf.method, conf.capture_frequency_hz)
+    }
+
+    pub fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    pub fn component_type(&self) -> String {
+        self.component_type.to_string()
+    }
+
+    pub fn time_interval(&self) -> u64 {
+        self.time_interval_ms
+    }
+
+    pub fn method_str(&self) -> String {
+        self.method.to_string()
+    }
+
+    /// calls the method associated with the collector and returns the resulting data
+    pub(crate) fn call_method(&mut self) -> Result<SensorData, DataCollectionError> {
+        let reading_requested_dt = Local::now().fixed_offset();
+        let data = match &mut self.resource {
+            ResourceType::Sensor(ref mut res) => match self.method {
+                CollectionMethod::Readings => res.get_generic_readings()?.into(),
+                _ => {
+                    return Err(DataCollectionError::UnsupportedMethod(
+                        self.method.clone(),
+                        "sensor".to_string(),
+                    ))
+                }
+            },
+            ResourceType::MovementSensor(ref mut res) => match self.method {
+                CollectionMethod::Readings => res.get_generic_readings()?.into(),
+                CollectionMethod::AngularVelocity => res
+                    .get_angular_velocity()?
+                    .to_data_struct("angular_velocity"),
+                CollectionMethod::LinearAcceleration => res
+                    .get_angular_velocity()?
+                    .to_data_struct("linear_acceleration"),
+                CollectionMethod::LinearVelocity => res
+                    .get_angular_velocity()?
+                    .to_data_struct("linear_velocity"),
+                #[allow(unreachable_patterns)]
+                // remove when methods for other components are implemented
+                _ => {
+                    return Err(DataCollectionError::UnsupportedMethod(
+                        self.method.clone(),
+                        "movement_sensor".to_string(),
+                    ))
+                }
+            },
+            _ => return Err(DataCollectionError::NoSupportedMethods),
+        };
+        let reading_received_dt = Local::now().fixed_offset();
+        Ok(SensorData {
+            metadata: Some(SensorMetadata {
+                time_received: Some(Timestamp {
+                    seconds: reading_requested_dt.timestamp(),
+                    nanos: reading_requested_dt.timestamp_subsec_nanos() as i32,
+                }),
+                time_requested: Some(Timestamp {
+                    seconds: reading_received_dt.timestamp(),
+                    nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
+                }),
+            }),
+            data: Some(data),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use super::{CollectionMethod, DataCollectionError, DataCollector, DataCollectorConfig};
+    use crate::common::config::{AttributeError, Kind};
+    use crate::common::robot::ResourceType;
+    use crate::common::sensor::FakeSensor;
+    use crate::google;
+    use crate::proto::app::data_sync::v1::sensor_data::Data;
+
+    #[test_log::test]
+    fn test_collector_config() -> Result<(), AttributeError> {
+        let kind_map = HashMap::from([
+            (
+                "method".to_string(),
+                Kind::StringValue("Readings".to_string()),
+            ),
+            ("capture_frequency_hz".to_string(), Kind::NumberValue(100.0)),
+        ]);
+        let conf_kind = Kind::StructValue(kind_map);
+        let conf: DataCollectorConfig = (&conf_kind).try_into()?;
+        assert!(matches!(conf.method, CollectionMethod::Readings));
+        assert_eq!(conf.capture_frequency_hz, 100.0);
+
+        let kind_map = HashMap::from([
+            (
+                "method".to_string(),
+                Kind::StringValue("AngularVelocity".to_string()),
+            ),
+            ("capture_frequency_hz".to_string(), Kind::NumberValue(100.0)),
+        ]);
+        let conf_kind = Kind::StructValue(kind_map);
+        let conf: DataCollectorConfig = (&conf_kind).try_into()?;
+        assert!(matches!(conf.method, CollectionMethod::AngularVelocity));
+        assert_eq!(conf.capture_frequency_hz, 100.0);
+
+        let kind_map = HashMap::from([
+            (
+                "method".to_string(),
+                Kind::StringValue("MethodActing".to_string()),
+            ),
+            ("capture_frequency_hz".to_string(), Kind::NumberValue(100.0)),
+        ]);
+        let conf_kind = Kind::StructValue(kind_map);
+        let conf_result = DataCollectorConfig::try_from(&conf_kind);
+        assert!(matches!(
+            conf_result,
+            Err(AttributeError::ConversionImpossibleError)
+        ));
+        Ok(())
+    }
+
+    #[test_log::test]
+    fn test_collect_data() -> Result<(), DataCollectionError> {
+        let sensor = Arc::new(Mutex::new(FakeSensor::new()));
+        let resource = ResourceType::Sensor(sensor);
+        let kind_map = HashMap::from([
+            (
+                "method".to_string(),
+                Kind::StringValue("Readings".to_string()),
+            ),
+            ("capture_frequency_hz".to_string(), Kind::NumberValue(100.0)),
+        ]);
+        let conf_kind = Kind::StructValue(kind_map);
+        let conf =
+            DataCollectorConfig::try_from(&conf_kind).expect("data collector config parse failed");
+        let mut coll = DataCollector::from_config("fake".to_string(), resource, conf)?;
+        let data = coll.call_method()?.data;
+        assert!(data.is_some());
+        let data = data.unwrap();
+        match data {
+            Data::Binary(_) => panic!("expected struct not binary data"),
+            Data::Struct(d) => {
+                let readings = d.fields.get("readings");
+                assert!(readings.is_some());
+                let readings = readings.unwrap();
+                let readings = &readings.kind;
+                assert!(readings.is_some());
+                let readings = readings.clone().unwrap();
+                let readings = match readings {
+                    google::protobuf::value::Kind::StructValue(s) => s,
+                    _ => panic!("readings was not a struct"),
+                };
+                let fake_reading = readings.fields.get("fake_sensor");
+                assert!(fake_reading.is_some());
+                let fake_reading = &fake_reading.clone().unwrap().kind;
+                assert!(fake_reading.is_some());
+                let fake_reading = fake_reading.clone().unwrap();
+                match fake_reading {
+                    google::protobuf::value::Kind::NumberValue(fake_reading) => {
+                        assert_eq!(fake_reading, 42.42);
+                    }
+                    _ => panic!("fake reading was not a number"),
+                };
+            }
+        };
+        Ok(())
+    }
+}

--- a/micro-rdk/src/common/math_utils.rs
+++ b/micro-rdk/src/common/math_utils.rs
@@ -6,6 +6,9 @@ use crate::{
 use std::{collections::HashMap, time::Duration};
 use thiserror::Error;
 
+#[cfg(feature = "data")]
+use crate::proto::app::data_sync::v1::sensor_data::Data;
+
 #[derive(Error, Debug)]
 #[error("invalid argument")]
 pub struct UtilsInvalidArg;
@@ -24,6 +27,39 @@ impl Vector3 {
             y: 0.0,
             z: 0.0,
         }
+    }
+    #[cfg(feature = "data")]
+    pub fn to_data_struct(self, key: &str) -> Data {
+        let data_struct = Struct {
+            fields: HashMap::from([
+                (
+                    "x".to_string(),
+                    Value {
+                        kind: Some(Kind::NumberValue(self.x)),
+                    },
+                ),
+                (
+                    "y".to_string(),
+                    Value {
+                        kind: Some(Kind::NumberValue(self.y)),
+                    },
+                ),
+                (
+                    "z".to_string(),
+                    Value {
+                        kind: Some(Kind::NumberValue(self.z)),
+                    },
+                ),
+            ]),
+        };
+        Data::Struct(Struct {
+            fields: HashMap::from([(
+                key.to_string(),
+                Value {
+                    kind: Some(Kind::StructValue(data_struct)),
+                },
+            )]),
+        })
     }
 }
 

--- a/micro-rdk/src/common/mod.rs
+++ b/micro-rdk/src/common/mod.rs
@@ -81,3 +81,5 @@ pub mod conn {
     pub mod server;
     mod utils;
 }
+#[cfg(feature = "data")]
+pub mod data_collector;

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -64,6 +64,23 @@ pub enum ResourceType {
 pub type Resource = ResourceType;
 pub type ResourceMap = HashMap<ResourceName, Resource>;
 
+impl ResourceType {
+    pub fn component_type(&self) -> String {
+        match self {
+            Self::Base(_) => "rdk:component:base",
+            Self::Board(_) => "rdk:component:board",
+            Self::Encoder(_) => "rdk:component:encoder",
+            Self::Generic(_) => "rdk:component:generic",
+            Self::Motor(_) => "rdk:component:motor",
+            Self::MovementSensor(_) => "rdk:component:movement_sensor",
+            Self::PowerSensor(_) => "rdk:component:power_sensor",
+            Self::Sensor(_) => "rdk:component:sensor",
+            Self::Servo(_) => "rdk:component:servo",
+        }
+        .to_string()
+    }
+}
+
 #[derive(Default)]
 pub struct LocalRobot {
     resources: ResourceMap,

--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -49,6 +49,14 @@ pub mod proto {
                 include!("gen/viam.app.packages.v1.rs");
             }
         }
+        #[cfg(feature = "data")]
+        pub mod data_sync {
+            pub mod v1 {
+                #![allow(clippy::derive_partial_eq_without_eq)]
+                #![allow(clippy::large_enum_variant)]
+                include!("gen/viam.app.datasync.v1.rs");
+            }
+        }
     }
 
     pub mod rpc {


### PR DESCRIPTION
Part 1 of 2 PRs

The TODO comments are there to provide a sense of the direction of the architecture moving forward and will be removed before merge

For now, to run the tests introduced in the PR, add "data" to the default features in micro-rdk/Cargo.toml before calling `make test`