### PR TITLE
Add link to JIRA in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ the ESP32.
 - Discord: <https://discord.gg/viam>
 - Support: <https://support.viam.com>
 
+If you have a bug or an idea, please open an issue in our [JIRA project](https://viam.atlassian.net/).
+
 ## (In)stability Notice
 
 > **Warning**


### PR DESCRIPTION
Wanted to submit a bug / help request this weekend but there was no link to JIRA on the README.

This is a copy-over from the RDK.

I'd **much rather** submit a github issue so enabling issues would also work.