### PR TITLE
templates/project/src/main.rs does not compile

### DIFF
--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -88,12 +88,14 @@ fn main() -> anyhow::Result<()> {
         let key = ROBOT_SRV_DER_KEY;
         Esp32TlsServerConfig::new(cert, key.as_ptr(), key.len() as u32)
     };
+    
+    let max_connection = 3;
 
     let mut registry = Box::<ComponentRegistry>::default();
     register_modules(&mut registry)?;
     let repr = RobotRepresentation::WithRegistry(registry);
 
-    serve_web(cfg, tls_cfg, repr, ip, webrtc_certificate);
+    serve_web(cfg, tls_cfg, repr, ip, webrtc_certificate, max_connection);
     Ok(())
 }
 

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -88,8 +88,15 @@ fn main() -> anyhow::Result<()> {
         let key = ROBOT_SRV_DER_KEY;
         Esp32TlsServerConfig::new(cert, key.as_ptr(), key.len() as u32)
     };
-    
-    let max_connection = 3;
+
+    let mut max_connection = 3;
+    unsafe {
+        if !g_spiram_ok {
+            log::info!("spiram not initialized disabling cache feature of the wifi driver");
+            g_wifi_feature_caps &= !(CONFIG_FEATURE_CACHE_TX_BUF_BIT as u64);
+            max_connection = 1;
+        }
+    }
 
     let mut registry = Box::<ComponentRegistry>::default();
     register_modules(&mut registry)?;


### PR DESCRIPTION
```
error[E0061]: this function takes 6 arguments but 5 arguments were supplied
   --> src/main.rs:96:5
    |
96  |     serve_web(cfg, tls_cfg, repr, ip, webrtc_certificate);
    |     ^^^^^^^^^-------------------------------------------- an argument of type `usize` is missing
    |
note: function defined here
   --> /host/.micro-rdk-docker-caches/cargo-registry/git/checkouts/micro-rdk-5c871d18509c9d7e/21ddb22/micro-rdk/src/esp32/entry.rs:135:8
    |
135 | pub fn serve_web(
    |        ^^^^^^^^^
help: provide the argument
    |
96  |     serve_web(cfg, tls_cfg, repr, ip, webrtc_certificate, /* usize */);
```