### PR TITLE
[issue] template/project Makefile should use micro-rdk-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Table of Contents
-=================
+
 
 - [Table of Contents](#table-of-contents)
 - [Micro-RDK (Robot Development Kit for Microcontrollers)](#micro-rdk-robot-development-kit-for-microcontrollers)


### PR DESCRIPTION
This is a roundabout way to create a github issue because I am on my personal laptop and don't have access to the JIRA

template/project/Makefile has:
```
flash-esp32-bin:
ifneq (,$(wildcard target/esp32-server.bin))
	espflash write-bin 0x0 target/esp32-server.bin -b 460800  && sleep 2 && espflash monitor
else
	$(error esp32-server.bin not found, run build-esp32-bin first)
endif
```

It would be great if this ran the nifty micro-rdk-installer instead (either through cargo or some other distribution mechanism). I had some trouble getting espflash set up but the micro-rdk-installer worked (mostly) out of the box.