### PR TITLE
micro-rdk-installer readme says rustc > 1.68 but doesn't work on 1.70

### DIFF
--- a/micro-rdk-installer/README.md
+++ b/micro-rdk-installer/README.md
@@ -14,7 +14,7 @@ These download links are for the latest release of the installer by architecture
 
 Only necessary as an alternative to the previous Download step
 
-Requirements: rust (1.67.0 or higher), Cargo (1.67.0 or higher)
+Requirements: rust (1.71.0 or higher), Cargo (1.71.0 or higher)
 
 1. `git clone https://github.com/viamrobotics/micro-rdk.git`
 2. cd micro-rdk/micro-rdk-installer


### PR DESCRIPTION
```
➜  micro-rdk-installer git:(7403b39) rustc --version
rustc 1.70.0 (90c541806 2023-05-31)
➜  micro-rdk-installer git:(7403b39) cargo build
warning: /home/zack/work/micro-rdk/Cargo.toml: unused manifest key: template
    Updating crates.io index
error: Package `micro-rdk v0.1.7 (/home/zack/work/micro-rdk/micro-rdk)` does not have feature `esp-idf-svc`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
```

(but builds on 1.76 I assume its 1.71+?)