### PR TITLE
refactor store to return a reader that only consumes on flush

### DIFF
--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -16,6 +16,10 @@ pub extern crate micro_rdk_macros;
 #[macro_use(defer)]
 extern crate scopeguard;
 
+#[cfg(all(feature = "data", not(feature = "builtin-components")))]
+#[macro_use(defer)]
+extern crate scopeguard;
+
 pub use micro_rdk_macros::DoCommand;
 pub use micro_rdk_macros::MovementSensorReadings;
 pub use micro_rdk_macros::PowerSensorReadings;


### PR DESCRIPTION
This refactor was necessary to enable the `DataManager` to preserve data when it fails to upload (upload logic still not included)