### PR TITLE
[RSDK-7439] chore: better wifi errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ Cargo.lock
 /canary/.venv/*
 .vscode
 components_esp32.lock
-.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 /canary/.venv/*
 .vscode
 components_esp32.lock
+.envrc

--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -199,8 +199,15 @@ mod esp32 {
                 &nvs_vars.wifi_ssid,
                 &nvs_vars.wifi_pwd,
             )
-            .unwrap();
-            (wifi.wifi().sta_netif().get_ip_info().unwrap().ip, wifi)
+            .expect("failed to start wifi");
+            (
+                wifi.wifi()
+                    .sta_netif()
+                    .get_ip_info()
+                    .expect("failed to get ip info")
+                    .ip,
+                wifi,
+            )
         };
 
         let webrtc_certificate = WebRtcCertificate::new(

--- a/examples/esp32/esp32-server.rs
+++ b/examples/esp32/esp32-server.rs
@@ -89,8 +89,15 @@ mod esp32 {
         #[allow(clippy::redundant_clone)]
         #[cfg(not(feature = "qemu"))]
         let (ip, _wifi) = {
-            let wifi = start_wifi(periph.modem, sys_loop_stack).unwrap();
-            (wifi.wifi().sta_netif().get_ip_info().unwrap().ip, wifi)
+            let wifi = start_wifi(periph.modem, sys_loop_stack).expect("failed to start wifi");
+            (
+                wifi.wifi()
+                    .sta_netif()
+                    .get_ip_info()
+                    .expect("failed to get ip info")
+                    .ip,
+                wifi,
+            )
         };
 
         let cfg = AppClientConfig::new(
@@ -149,13 +156,13 @@ mod esp32 {
 
         wifi.set_configuration(&wifi_configuration)?;
 
-        wifi.start().unwrap();
+        wifi.start()?;
         info!("Wifi started");
 
-        wifi.connect().unwrap();
+        wifi.connect()?;
         info!("Wifi connected");
 
-        wifi.wait_netif_up().unwrap();
+        wifi.wait_netif_up()?;
         info!("Wifi netif up");
 
         micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -70,8 +70,15 @@ fn main() {
     }
 
     let (ip, _wifi) = {
-        let wifi = start_wifi(periph.modem, sys_loop_stack).unwrap();
-        (wifi.wifi().sta_netif().get_ip_info().unwrap().ip, wifi)
+        let wifi = start_wifi(periph.modem, sys_loop_stack).expect("failed to start wifi");
+        (
+            wifi.wifi()
+                .sta_netif()
+                .get_ip_info()
+                .expect("failed to get ip info'")
+                .ip,
+            wifi,
+        )
     };
     let cfg = AppClientConfig::new(
         ROBOT_SECRET.to_owned(),
@@ -114,13 +121,13 @@ fn start_wifi(
 
     wifi.set_configuration(&wifi_configuration)?;
 
-    wifi.start().unwrap();
+    wifi.start()?;
     info!("Wifi started");
 
-    wifi.connect().unwrap();
+    wifi.connect()?;
     info!("Wifi connected");
 
-    wifi.wait_netif_up().unwrap();
+    wifi.wait_netif_up()?;
 
     micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {
         esp_wifi_set_ps(micro_rdk::esp32::esp_idf_svc::sys::wifi_ps_type_t_WIFI_PS_NONE)


### PR DESCRIPTION
Previously, micro-rdk would just throw a panic with a line number when failing to start wifi (ssid/pass misconfiguration, etc).

This change gives slightly better error messages and includes the `EspError` value, ex. `failed to start wifi: EspError(263)`.

Adding these changes highlighted a couple code smells. The changes were repeated in three separate areas in almost the same way. Would be great if we could move the wifi setup code into the micrordk for users to pull and initialize with a couple lines instead of the boilerplate. It also enables us to provide better error messaging; the current error outputs are esp specific and need to be looked up [here](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/error-codes.html)