### PR TITLE
chore: decouple template manifest from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,3 @@ trackable = "1.2.0"
 viam = { version = ">=0.0.17", git = "https://github.com/viamrobotics/viam-rust-sdk.git" }
 viam-rust-utils = "0.1.2"
 webpki-roots = "0.22.6"
-
-[template]
-sub_templates = ["templates/project", "templates/module"]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,0 +1,2 @@
+[template]
+sub_templates = ["templates/project", "templates/module"]


### PR DESCRIPTION
According to the [Cargo Generate Book](https://cargo-generate.github.io/cargo-generate/usage.html#templates-in-subfolders), 
subfolders can be specified with a root-level `cargo-generate.toml`. 

Currently, when running `make build-esp32-bin`, the following warning will appear
```sh
➜ make build-esp32-bin
$ cargo +esp espflash save-image --package examples --merge --chip esp32 target/xtensa-esp32-espidf/esp32-server.bin -T examples/esp32/partitions.csv -s 4mb  --bin esp32-server --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release

warning: /home/mperez/viam/micro-rdk/Cargo.toml: unused manifest key: template
   Compiling proc-macro2 v1.0.78
   Compiling unicode-ident v1.0.12
   ...
```

This change quites that warning.