### PR TITLE
RSDK-7387 Handle incoming http2 connections in a coroutine

### DIFF
--- a/examples/native/native-server.rs
+++ b/examples/native/native-server.rs
@@ -9,7 +9,9 @@ mod native {
     };
 
     pub(crate) fn main_native() {
-        env_logger::init();
+        env_logger::builder()
+            .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+            .init();
 
         let repr = RobotRepresentation::WithRegistry(Box::default());
 

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -400,9 +400,13 @@ where
                     Ok(c) => {
                         let robot = robot.clone();
                         let exec = self.exec.clone();
-                        let t = self.exec.spawn(async move { Self::serve_http2(c, exec, robot).await });
+                        let t = self
+                            .exec
+                            .spawn(async move { Self::serve_http2(c, exec, robot).await });
                         // Incoming direct HTTP2 connections take top priority.
-                        self.incoming_connection_manager.insert_new_conn(t, u32::MAX).await;
+                        self.incoming_connection_manager
+                            .insert_new_conn(t, u32::MAX)
+                            .await;
                         Ok(())
                     }
                 },
@@ -411,7 +415,9 @@ where
                     Ok(_) => {
                         let prio = c.prio;
                         let t = self.exec.spawn(async move { c.run().await });
-                        self.incoming_connection_manager.insert_new_conn(t, prio).await;
+                        self.incoming_connection_manager
+                            .insert_new_conn(t, prio)
+                            .await;
                         Ok(())
                     }
                 },
@@ -424,8 +430,7 @@ where
         connection: T,
         exec: Executor,
         robot: Arc<Mutex<LocalRobot>>,
-    ) -> Result<(), ServerError>
-    {
+    ) -> Result<(), ServerError> {
         let srv = GrpcServer::new(robot.clone(), GrpcBody::new());
         Box::new(
             http2::Builder::new(exec)

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -26,7 +26,7 @@ use crate::{
 
 use async_io::Timer;
 use futures_lite::prelude::*;
-use futures_lite::{future::Boxed, ready, Future};
+use futures_lite::{future::Boxed, ready};
 use hyper::{rt, server::conn::http2};
 
 use async_executor::Task;
@@ -277,7 +277,7 @@ pub struct ViamServer<'a, C, T, CC, D, L> {
     app_connector: C,
     app_config: AppClientConfig,
     app_client: Option<AppClient<'a>>,
-    webrtc_manager: WebRTCConnectionManager,
+    incoming_connection_manager: IncomingConnectionManager,
 }
 impl<'a, C, T, CC, D, L> ViamServer<'a, C, T, CC, D, L>
 where
@@ -304,7 +304,7 @@ where
             app_connector,
             app_config,
             app_client: None,
-            webrtc_manager: WebRTCConnectionManager::new(max_concurent_connections),
+            incoming_connection_manager: IncomingConnectionManager::new(max_concurent_connections),
         }
     }
     pub async fn serve(&mut self, robot: Arc<Mutex<LocalRobot>>) {
@@ -357,7 +357,7 @@ where
                 async {
                     let mut api = sig.await?;
 
-                    let prio = self.webrtc_manager.get_lowest_prio();
+                    let prio = self.incoming_connection_manager.get_lowest_prio();
 
                     let sdp = api
                         .answer(prio)
@@ -395,14 +395,23 @@ where
             };
 
             if let Err(e) = match connection {
-                IncomingConnection::Http2Connection(c) => self.serve_http2(c, robot.clone()).await,
-
+                IncomingConnection::Http2Connection(mut c) => match c.accept().await {
+                    Err(e) => Err(ServerError::Other(e.into())),
+                    Ok(c) => {
+                        let robot = robot.clone();
+                        let exec = self.exec.clone();
+                        let t = self.exec.spawn(async move { Self::serve_http2(c, exec, robot).await });
+                        // Incoming direct HTTP2 connections take top priority.
+                        self.incoming_connection_manager.insert_new_conn(t, u32::MAX).await;
+                        Ok(())
+                    }
+                },
                 IncomingConnection::WebRtcConnection(mut c) => match c.open_data_channel().await {
                     Err(e) => Err(e),
                     Ok(_) => {
                         let prio = c.prio;
                         let t = self.exec.spawn(async move { c.run().await });
-                        self.webrtc_manager.insert_new_conn(t, prio).await;
+                        self.incoming_connection_manager.insert_new_conn(t, prio).await;
                         Ok(())
                     }
                 },
@@ -411,19 +420,15 @@ where
             }
         }
     }
-    async fn serve_http2<U>(
-        &self,
-        mut c: U,
+    async fn serve_http2(
+        connection: T,
+        exec: Executor,
         robot: Arc<Mutex<LocalRobot>>,
     ) -> Result<(), ServerError>
-    where
-        U: Http2Connector<Stream = T>,
     {
         let srv = GrpcServer::new(robot.clone(), GrpcBody::new());
-        let connection = c.accept().await.map_err(|e| ServerError::Other(e.into()))?;
-
         Box::new(
-            http2::Builder::new(self.exec.clone())
+            http2::Builder::new(exec)
                 .initial_connection_window_size(2048)
                 .initial_stream_window_size(2048)
                 .max_send_buf_size(4096)
@@ -570,12 +575,12 @@ where
 }
 
 #[derive(Default)]
-struct WebRTCTask {
+struct IncomingConnectionTask {
     task: Option<Task<Result<(), ServerError>>>,
     prio: Option<u32>,
 }
 
-impl WebRTCTask {
+impl IncomingConnectionTask {
     fn replace(&mut self, task: Task<Result<(), ServerError>>, prio: u32) {
         let _ = self.task.replace(task);
         let _ = self.prio.replace(prio);
@@ -600,11 +605,11 @@ impl WebRTCTask {
     }
 }
 
-struct WebRTCConnectionManager {
-    connections: Vec<WebRTCTask>,
+struct IncomingConnectionManager {
+    connections: Vec<IncomingConnectionTask>,
 }
 
-impl WebRTCConnectionManager {
+impl IncomingConnectionManager {
     fn new(size: usize) -> Self {
         let mut connections = Vec::with_capacity(size);
         connections.resize_with(size, Default::default);

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -437,7 +437,7 @@ where
                 .initial_connection_window_size(2048)
                 .initial_stream_window_size(2048)
                 .max_send_buf_size(4096)
-                .max_concurrent_streams(1)
+                .max_concurrent_streams(2)
                 .serve_connection(connection, srv),
         )
         .await


### PR DESCRIPTION
Per discussions, `ViamServer::serve` is going to need to be decomposed into co-routines which can run concurrently.

The current implementation only does that for incoming WebRTC connections. Incoming HTTP2 connections simply took over service until complete. This PR changes handling for HTTP2 connections to work similarly to how WebRTC connections work.

HTTP2 connections are afforded the highest priority, since this seemed closest in spirit to the existing behavior, where established inbound HTTP2 connection would simply block new connection handling.

Creating this as draft for now while I do some more testing, but please feel free to provide any feedback you may have now.