### PR TITLE
Fix esp32's HTTP2 server

### DIFF
--- a/examples/build.rs
+++ b/examples/build.rs
@@ -103,20 +103,8 @@ fn main() -> anyhow::Result<()> {
     let local_fqdn = cloud_cfg.local_fqdn.replace('.', "-");
     let fqdn = cloud_cfg.fqdn.replace('.', "-");
 
-    let mut certs = cfg
-        .cloud
-        .tls_certificate
-        .split_inclusive("----END CERTIFICATE-----");
-    let mut srv_cert = (&mut certs).take(2).collect::<String>();
-    srv_cert.push('\0');
-    let ca_cert = certs
-        .take(1)
-        .map(der::Document::from_pem)
-        .filter(|s| s.is_ok())
-        .map(|s| s.unwrap().1.to_vec())
-        .collect::<Vec<Vec<u8>>>()
-        .pop()
-        .unwrap_or_default();
+    let srv_cert = format!("{}\0", cfg.cloud.tls_certificate);
+
     let key = der::Document::from_pem(&cfg.cloud.tls_private_key)
         .map_or(vec![], |k| k.1.as_bytes().to_vec());
 
@@ -158,10 +146,6 @@ fn main() -> anyhow::Result<()> {
         const_declaration!(
             #[allow(clippy::redundant_static_lifetimes, dead_code)]
             ROBOT_SRV_PEM_CHAIN = srv_cert.as_bytes()
-        ),
-        const_declaration!(
-            #[allow(clippy::redundant_static_lifetimes, dead_code)]
-            ROBOT_SRV_PEM_CA = ca_cert
         ),
         const_declaration!(
             #[allow(clippy::redundant_static_lifetimes, dead_code)]

--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -92,7 +92,6 @@ mod esp32 {
         robot_dtls_key_pair: Vec<u8>,
         robot_dtls_cert_fp: String,
         robot_srv_pem_chain: Vec<u8>,
-        robot_srv_pem_ca: Vec<u8>,
         robot_srv_der_key: Vec<u8>,
     }
 
@@ -113,7 +112,6 @@ mod esp32 {
                 robot_dtls_key_pair: get_blob_from_nvs(&viam_nvs, "DTLS_KEY_PAIR")?,
                 robot_dtls_cert_fp: get_str_from_nvs(&viam_nvs, "DTLS_CERT_FP")?,
                 robot_srv_pem_chain: get_blob_from_nvs(&viam_nvs, "SRV_PEM_CHAIN")?,
-                robot_srv_pem_ca: get_blob_from_nvs(&viam_nvs, "CA_CRT")?,
                 robot_srv_der_key: get_blob_from_nvs(&viam_nvs, "SRV_DER_KEY")?,
             })
         }
@@ -216,7 +214,7 @@ mod esp32 {
             &nvs_vars.robot_dtls_cert_fp,
         );
 
-        let cert: [Vec<u8>; 2] = [nvs_vars.robot_srv_pem_chain, nvs_vars.robot_srv_pem_ca];
+        let cert: Vec<u8> = nvs_vars.robot_srv_pem_chain;
         let key = nvs_vars.robot_srv_der_key;
         let tls_cfg = Esp32TLSServerConfig::new(cert, key.as_ptr(), key.len() as u32);
 

--- a/examples/esp32/esp32-server.rs
+++ b/examples/esp32/esp32-server.rs
@@ -113,7 +113,7 @@ mod esp32 {
         );
 
         let tls_cfg = {
-            let cert = [ROBOT_SRV_PEM_CHAIN.to_vec(), ROBOT_SRV_PEM_CA.to_vec()];
+            let cert = ROBOT_SRV_PEM_CHAIN.to_vec();
             let key = ROBOT_SRV_DER_KEY;
             Esp32TLSServerConfig::new(cert, key.as_ptr(), key.len() as u32)
         };

--- a/micro-rdk-installer/src/nvs/data.rs
+++ b/micro-rdk-installer/src/nvs/data.rs
@@ -26,7 +26,6 @@ pub struct RobotCredentials {
     pub app_address: Option<String>,
     pub local_fqdn: Option<String>,
     pub fqdn: Option<String>,
-    pub ca_crt: Option<Vec<u8>>,
     pub der_key: Option<Vec<u8>>,
     pub robot_dtls_certificate: Option<Vec<u8>>,
     pub robot_dtls_key_pair: Option<Vec<u8>>,
@@ -41,7 +40,7 @@ pub struct ViamFlashStorageData {
 }
 
 impl ViamFlashStorageData {
-    fn to_nvs_key_value_pairs(&self, namespace_idx: u8) -> Result<[NVSKeyValuePair; 14], Error> {
+    fn to_nvs_key_value_pairs(&self, namespace_idx: u8) -> Result<[NVSKeyValuePair; 13], Error> {
         let wifi_cred = self
             .wifi
             .clone()
@@ -129,16 +128,6 @@ impl ViamFlashStorageData {
                 value: NVSValue::Bytes(self.robot_credentials.pem_chain.clone().ok_or(
                     Error::NVSDataProcessingError("pem_chain missing".to_string()),
                 )?),
-                namespace_idx,
-            },
-            NVSKeyValuePair {
-                key: "CA_CRT".to_string(),
-                value: NVSValue::Bytes(
-                    self.robot_credentials
-                        .ca_crt
-                        .clone()
-                        .ok_or(Error::NVSDataProcessingError("ca_crt missing".to_string()))?,
-                ),
                 namespace_idx,
             },
             NVSKeyValuePair {

--- a/micro-rdk/src/esp32/tcp.rs
+++ b/micro-rdk/src/esp32/tcp.rs
@@ -28,7 +28,7 @@ impl Esp32Listener {
         let socket = TcpListener::bind(addr)?;
         socket.set_nonblocking(true)?;
         Ok(Self {
-            listener: Arc::new(socket.into()),
+            listener: Arc::new(socket),
             addr,
             _marker: PhantomData,
             tls,

--- a/micro-rdk/src/esp32/tcp.rs
+++ b/micro-rdk/src/esp32/tcp.rs
@@ -3,9 +3,9 @@ use crate::esp32::tls::{Esp32TLS, Esp32TLSStream};
 use async_io::Async;
 use futures_lite::{io, ready, AsyncRead, AsyncWrite, Future};
 use hyper::rt;
-use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use std::fmt::Debug;
 use std::mem::MaybeUninit;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{
     marker::PhantomData,
@@ -17,19 +17,15 @@ use std::{
 pub struct Esp32Listener {
     listener: Arc<TcpListener>,
     #[allow(dead_code)]
-    addr: SockAddr,
+    addr: SocketAddr,
     _marker: PhantomData<*const ()>,
     tls: Option<Box<Esp32TLS>>,
 }
 
 impl Esp32Listener {
     /// Creates a new Tcplistener
-    pub fn new(addr: SockAddr, tls: Option<Box<Esp32TLS>>) -> Result<Self, std::io::Error> {
-        let socket = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP))?;
-        socket.set_reuse_address(true)?;
-        socket.set_nodelay(true)?;
-        socket.bind(&addr)?;
-        socket.listen(128)?;
+    pub fn new(addr: SocketAddr, tls: Option<Box<Esp32TLS>>) -> Result<Self, std::io::Error> {
+        let socket = TcpListener::bind(addr)?;
         socket.set_nonblocking(true)?;
         Ok(Self {
             listener: Arc::new(socket.into()),

--- a/micro-rdk/src/esp32/tls.rs
+++ b/micro-rdk/src/esp32/tls.rs
@@ -146,7 +146,7 @@ impl Esp32TLS {
         let tls_cfg_srv = Box::new(esp_tls_cfg_server {
             alpn_protos: alpn_ptr.as_mut_ptr(),
             __bindgen_anon_1: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_1 {
-                // This is the root LE certificate in the DER format
+                // The CA root is not need when a client is connecting as it's available
                 cacert_buf: std::ptr::null(),
             },
             __bindgen_anon_2: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_2 {

--- a/micro-rdk/src/esp32/tls.rs
+++ b/micro-rdk/src/esp32/tls.rs
@@ -54,7 +54,7 @@ pub struct Esp32TLSStream {
 }
 
 pub struct Esp32TLSServerConfig {
-    srv_cert: [Vec<u8>; 2],
+    srv_cert: Vec<u8>,
     srv_key: *const u8,
     srv_key_len: u32,
 }
@@ -63,7 +63,7 @@ impl Esp32TLSServerConfig {
     // An Esp32TlsServerConfig takes a certificate and key bytearray (in the form of a pointer and length)
     // The PEM certificate has two parts: the first is the certificate chain and the second is the
     // certificate authority.
-    pub fn new(srv_cert: [Vec<u8>; 2], srv_key: *const u8, srv_key_len: u32) -> Self {
+    pub fn new(srv_cert: Vec<u8>, srv_key: *const u8, srv_key_len: u32) -> Self {
         Esp32TLSServerConfig {
             srv_cert,
             srv_key,
@@ -147,17 +147,17 @@ impl Esp32TLS {
             alpn_protos: alpn_ptr.as_mut_ptr(),
             __bindgen_anon_1: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_1 {
                 // This is the root LE certificate in the DER format
-                cacert_buf: cfg.srv_cert[1].as_ptr(),
+                cacert_buf: std::ptr::null(),
             },
             __bindgen_anon_2: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_2 {
-                cacert_bytes: cfg.srv_cert[1].len() as u32,
+                cacert_bytes: 0,
             },
             __bindgen_anon_3: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_3 {
                 // This is the server certificates in the PEM format
-                servercert_buf: cfg.srv_cert[0].as_ptr(),
+                servercert_buf: cfg.srv_cert.as_ptr(),
             },
             __bindgen_anon_4: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_4 {
-                servercert_bytes: cfg.srv_cert[0].len() as u32,
+                servercert_bytes: cfg.srv_cert.len() as u32,
             },
             __bindgen_anon_5: crate::esp32::esp_idf_svc::sys::esp_tls_cfg_server__bindgen_ty_5 {
                 serverkey_buf: cfg.srv_key,


### PR DESCRIPTION
Essentially remove support for setting a CA cert in  the TLS config and use a TcpListener instead of a raw socket