### PR TITLE
[RSDK-7386] bump espflash deps to v3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,26 +4,17 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
-dependencies = [
- "cpp_demangle",
- "fallible-iterator",
- "gimli 0.27.3",
- "memmap2",
- "object 0.31.1",
- "rustc-demangle",
- "smallvec",
-]
-
-[[package]]
-name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli 0.28.1",
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli",
+ "memmap2",
+ "object",
+ "rustc-demangle",
+ "smallvec",
 ]
 
 [[package]]
@@ -178,16 +169,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -217,12 +208,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -607,15 +598,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,12 +660,12 @@ version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
- "addr2line 0.21.0",
+ "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
- "object 0.32.2",
+ "object",
  "rustc-demangle",
 ]
 
@@ -713,6 +695,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -749,28 +737,6 @@ dependencies = [
  "shlex",
  "syn 1.0.109",
  "which",
-]
-
-[[package]]
-name = "binread"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
-dependencies = [
- "binread_derive",
- "rustversion",
-]
-
-[[package]]
-name = "binread_derive"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
-dependencies = [
- "either",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1055,26 +1021,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
- "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
- "terminal_size 0.2.6",
+ "strsim 0.11.1",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1088,11 +1053,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -1100,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cmake"
@@ -1120,12 +1085,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "colored"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b34115915337defe99b2aff5c2ce6771e5fbc4079f4b506301f5cf394c8452f7"
 dependencies = [
- "crossterm 0.27.0",
+ "crossterm",
  "strum 0.26.2",
  "strum_macros 0.26.2",
  "unicode-width",
@@ -1271,22 +1246,6 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
@@ -1294,7 +1253,10 @@ dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
  "libc",
+ "mio",
  "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -1468,7 +1430,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
@@ -1534,6 +1496,38 @@ checksum = "3939552907426de152b3c2c6f51ed53f98f448babd26f28694c95f5906194595"
 dependencies = [
  "bitflags 1.3.2",
  "defmt-macros",
+]
+
+[[package]]
+name = "defmt-decoder"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfd9e4fb2a0ad57aac44194390825607592bee871dbee99188b8287e601dffa"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "colored",
+ "defmt-json-schema",
+ "defmt-parser",
+ "dissimilar",
+ "gimli",
+ "log",
+ "nom",
+ "object",
+ "ryu",
+ "serde",
+ "serde_json",
+ "time",
+]
+
+[[package]]
+name = "defmt-json-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b04d228e57a61cf385d86bc8980bb41b47c6fc0eace90592668df97b2dad6a"
+dependencies = [
+ "log",
+ "serde",
 ]
 
 [[package]]
@@ -1682,6 +1676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "destructure_traitobject"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1701,19 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "zeroize",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror",
  "zeroize",
 ]
 
@@ -1750,6 +1768,12 @@ dependencies = [
  "quote",
  "syn 2.0.52",
 ]
+
+[[package]]
+name = "dissimilar"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440d59c0c6d96354061909b4769b2ca03868dbaee203e7b779d9021ebbde3058"
 
 [[package]]
 name = "dns-parser"
@@ -1817,7 +1841,7 @@ dependencies = [
  "critical-section",
  "embedded-io-async",
  "futures-util",
- "heapless 0.8.0",
+ "heapless",
 ]
 
 [[package]]
@@ -1889,7 +1913,7 @@ dependencies = [
  "embedded-io",
  "embedded-io-async",
  "enumset",
- "heapless 0.8.0",
+ "heapless",
  "log",
  "no-std-net",
  "num_enum",
@@ -1966,6 +1990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
@@ -1987,7 +2012,10 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
 dependencies = [
+ "anstream",
+ "anstyle",
  "env_filter",
+ "humantime",
  "log",
 ]
 
@@ -2048,7 +2076,7 @@ dependencies = [
  "embuild",
  "enumset",
  "esp-idf-sys",
- "heapless 0.8.0",
+ "heapless",
  "log",
  "nb 1.1.0",
  "num_enum",
@@ -2056,19 +2084,19 @@ dependencies = [
 
 [[package]]
 name = "esp-idf-part"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28192549b6c3d0bfd3be8ff694802b8d92ff7e1b12a6fd0285ca96c66e97bed3"
+checksum = "59f50b6c32370067087b46087cd5333f2dfe678f0b01223fa70fde6f15449844"
 dependencies = [
  "csv",
  "deku",
- "heapless 0.7.17",
+ "heapless",
  "md5",
  "parse_int",
  "regex",
  "serde",
  "serde_plain",
- "strum 0.24.1",
+ "strum 0.26.2",
  "thiserror",
 ]
 
@@ -2084,7 +2112,7 @@ dependencies = [
  "embuild",
  "enumset",
  "esp-idf-hal",
- "heapless 0.8.0",
+ "heapless",
  "log",
  "num_enum",
  "uncased",
@@ -2112,28 +2140,31 @@ dependencies = [
 
 [[package]]
 name = "espflash"
-version = "2.0.1"
-source = "git+https://github.com/viamrobotics/espflash.git?branch=monitor_changes#73c86ebec4decf443594bb4e6585b44c4743d0b8"
+version = "3.0.1-dev"
+source = "git+https://github.com/viamrobotics/espflash.git?branch=monitor-output#c4daf4bf6dd0f34151d81e3a9b93d892a7febd23"
 dependencies = [
- "addr2line 0.20.0",
- "base64 0.21.7",
- "binread",
+ "addr2line",
+ "base64 0.22.1",
  "bytemuck",
  "chrono",
  "clap",
  "clap_complete",
  "comfy-table",
- "crossterm 0.25.0",
+ "crossterm",
  "ctrlc",
- "dialoguer",
+ "defmt-decoder",
+ "defmt-parser",
+ "dialoguer 0.11.0",
  "directories",
- "env_logger 0.10.2",
+ "env_logger 0.11.3",
  "esp-idf-part",
  "flate2",
  "hex",
  "indicatif",
  "lazy_static",
+ "libc",
  "log",
+ "md-5",
  "miette",
  "parse_int",
  "regex",
@@ -2141,7 +2172,7 @@ dependencies = [
  "serialport",
  "sha2",
  "slip-codec",
- "strum 0.25.0",
+ "strum 0.26.2",
  "thiserror",
  "toml",
  "update-informer",
@@ -2237,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -2583,19 +2614,13 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -2690,15 +2715,6 @@ dependencies = [
 
 [[package]]
 name = "hash32"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
-name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
@@ -2720,25 +2736,11 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapless"
-version = "0.7.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
-dependencies = [
- "atomic-polyfill",
- "hash32 0.2.1",
- "rustc_version",
- "serde",
- "spin 0.9.8",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32 0.3.1",
+ "hash32",
  "serde",
  "stable_deref_trait",
 ]
@@ -2748,6 +2750,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -3153,6 +3161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3471,7 +3485,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "der 0.7.8",
- "dialoguer",
+ "dialoguer 0.10.4",
  "env_logger 0.10.2",
  "espflash",
  "gethostname",
@@ -3505,20 +3519,19 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "5.10.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
 dependencies = [
  "backtrace",
  "backtrace-ext",
- "is-terminal",
+ "cfg-if 1.0.0",
  "miette-derive",
- "once_cell",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.1.17",
+ "terminal_size",
  "textwrap",
  "thiserror",
  "unicode-width",
@@ -3526,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "5.10.0"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3837,22 +3850,13 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
-
-[[package]]
-name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
+ "flate2",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -3952,9 +3956,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "p256"
@@ -4331,7 +4335,7 @@ dependencies = [
  "bytes",
  "cfg-if 1.0.0",
  "cmake",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -4351,7 +4355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools",
  "lazy_static",
  "log",
@@ -4857,12 +4861,12 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
- "thiserror",
+ "derive_more",
  "twox-hash",
 ]
 
@@ -5237,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "slip-codec"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399892aa22101014dcebb84944dc950f6d02695e91ea5f7e11baf02998fc59e2"
+checksum = "e794b692443f8d9b677cd41c867347df2902844d7b7f5775f47fcb37b9e7965b"
 
 [[package]]
 name = "smallvec"
@@ -5317,6 +5321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5339,6 +5349,9 @@ name = "strum"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+dependencies = [
+ "strum_macros 0.26.2",
+]
 
 [[package]]
 name = "strum_macros"
@@ -5346,7 +5359,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5359,7 +5372,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5372,7 +5385,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5428,31 +5441,24 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "supports-color"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+checksum = "9829b314621dfc575df4e409e79f9d6a66a3bd707ab73f23cb4aa3a854ac854f"
 dependencies = [
- "is-terminal",
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
+checksum = "2c0a1e5168041f5f3ff68ff7d95dcb9c8749df29f6e7e89ada40dd4c9de404ee"
 
 [[package]]
 name = "supports-unicode"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
-dependencies = [
- "is-terminal",
-]
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
@@ -5544,21 +5550,11 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
-dependencies = [
- "rustix 0.37.27",
+ "rustix 0.38.31",
  "windows-sys 0.48.0",
 ]
 
@@ -5585,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -5778,14 +5774,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.19.15",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -5804,10 +5800,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.2.5",
- "serde",
- "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -5818,7 +5812,20 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap 2.2.5",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.7",
 ]
 
 [[package]]
@@ -6991,6 +6998,15 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,11 +2141,12 @@ dependencies = [
 [[package]]
 name = "espflash"
 version = "3.0.1-dev"
-source = "git+https://github.com/viamrobotics/espflash.git#15991b5c1184b06d2f243dad7479b3de661fe4d2"
+source = "git+https://github.com/viamrobotics/espflash.git?branch=monitor-output#a8c2e3c4149ac67e599db24929fe13d0a8bd98bc"
 dependencies = [
  "addr2line",
  "base64 0.22.1",
  "bytemuck",
+ "chrono",
  "clap",
  "clap_complete",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,11 +2141,11 @@ dependencies = [
 [[package]]
 name = "espflash"
 version = "3.0.1-dev"
+source = "git+https://github.com/viamrobotics/espflash.git#15991b5c1184b06d2f243dad7479b3de661fe4d2"
 dependencies = [
  "addr2line",
  "base64 0.22.1",
  "bytemuck",
- "chrono",
  "clap",
  "clap_complete",
  "comfy-table",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2141,7 +2141,6 @@ dependencies = [
 [[package]]
 name = "espflash"
 version = "3.0.1-dev"
-source = "git+https://github.com/viamrobotics/espflash.git?branch=monitor-output#c4daf4bf6dd0f34151d81e3a9b93d892a7febd23"
 dependencies = [
  "addr2line",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ embedded-svc = "0.27"
 embuild = "0.31.3"
 env_logger = "0.10.1"
 esp-idf-svc = { version = "=0.48.1", default-features = false }
-espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor-output" }
+espflash = { path = "../espflash/espflash" }
 futures = "0.3.28"
 futures-lite = "1"
 futures-rustls = "=0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ bitfield = "0.14.0"
 bytecodec = "0.4.15"
 bytes = "1.2.1"
 chrono = "0.4.31"
-clap = "=4.3.23"
+clap = "4.5.4"
 const-gen = "1.3.0"
 crc32fast = "1.3.2"
 der = { version = "0.7.7", features = ["pem", "alloc", "zeroize"] }
@@ -54,7 +54,7 @@ embedded-svc = "0.27"
 embuild = "0.31.3"
 env_logger = "0.10.1"
 esp-idf-svc = { version = "=0.48.1", default-features = false }
-espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor_changes" }
+espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor-output" }
 futures = "0.3.28"
 futures-lite = "1"
 futures-rustls = "=0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ embedded-svc = "0.27"
 embuild = "0.31.3"
 env_logger = "0.10.1"
 esp-idf-svc = { version = "=0.48.1", default-features = false }
-espflash = { path = "../espflash/espflash" }
+espflash = { git = "https://github.com/viamrobotics/espflash.git", commit = "a8c2e3c4149ac67" }
 futures = "0.3.28"
 futures-lite = "1"
 futures-rustls = "=0.22.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ embedded-svc = "0.27"
 embuild = "0.31.3"
 env_logger = "0.10.1"
 esp-idf-svc = { version = "=0.48.1", default-features = false }
-espflash = { git = "https://github.com/viamrobotics/espflash.git", commit = "a8c2e3c4149ac67" }
+espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor-output" }
 futures = "0.3.28"
 futures-lite = "1"
 futures-rustls = "=0.22.0"

--- a/micro-rdk-installer/src/error.rs
+++ b/micro-rdk-installer/src/error.rs
@@ -49,8 +49,8 @@ pub enum Error {
     SerialConfigError(String),
     #[error("No command received")]
     NoCommandError,
-    #[error("{0}")]
-    Other(String),
+    #[error("Uncategorized Error: {0}")]
+    Uncategorized(String),
 }
 
 impl From<RcgenError> for Error {

--- a/micro-rdk-installer/src/error.rs
+++ b/micro-rdk-installer/src/error.rs
@@ -49,8 +49,6 @@ pub enum Error {
     SerialConfigError(String),
     #[error("No command received")]
     NoCommandError,
-    #[error("Uncategorized Error: {0}")]
-    Uncategorized(String),
 }
 
 impl From<RcgenError> for Error {

--- a/micro-rdk-installer/src/error.rs
+++ b/micro-rdk-installer/src/error.rs
@@ -49,6 +49,8 @@ pub enum Error {
     SerialConfigError(String),
     #[error("No command received")]
     NoCommandError,
+    #[error("{0}")]
+    Other(String),
 }
 
 impl From<RcgenError> for Error {

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -1,3 +1,4 @@
+use espflash::cli::{serial_monitor, FlashArgs, MonitorArgs};
 use log::LevelFilter;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
@@ -35,7 +36,7 @@ enum Commands {
     WriteFlash(WriteFlash),
     WriteCredentials(WriteCredentials),
     CreateNvsPartition(CreateNVSPartition),
-    Monitor(Monitor),
+    Monitor(MonitorArgs),
 }
 
 /// Write Wi-Fi and robot credentials to the NVS storage portion of a pre-compiled
@@ -117,6 +118,7 @@ struct CreateNVSPartition {
     wifi_password: Option<Secret<String>>,
 }
 
+/*
 /// Monitor a currently connected ESP32
 #[derive(Args)]
 struct Monitor {
@@ -127,6 +129,7 @@ struct Monitor {
     #[arg(long = "log-file")]
     log_file_path: Option<String>,
 }
+*/
 
 #[derive(Parser)]
 #[command(
@@ -221,9 +224,15 @@ fn write_credentials_to_app_binary(
     app_file.write_all(nvs_data).map_err(Error::FileError)?;
     Ok(())
 }
+/*
+    binary_path: PathBuf,
+    should_monitor: bool,
+    baud_rate: Option<u32>,
+    log_file_path: Option<String>,
+*/
 
 fn flash(
-    binary_path: PathBuf,
+    flash_args: FlashArgs,
     should_monitor: bool,
     baud_rate: Option<u32>,
     log_file_path: Option<String>,
@@ -258,6 +267,7 @@ fn flash(
     Ok(())
 }
 
+/*
 fn monitor_esp32(baud_rate: Option<u32>, log_file_path: Option<String>) -> Result<(), Error> {
     let connect_args = ConnectArgs {
         baud: Some(baud_rate.unwrap_or(460800)),
@@ -274,6 +284,7 @@ fn monitor_esp32(baud_rate: Option<u32>, log_file_path: Option<String>) -> Resul
         .map_err(|err| Error::MonitorError(err.to_string()))?;
     Ok(())
 }
+*/
 
 fn init_logger() {
     env_logger::Builder::new()
@@ -350,7 +361,7 @@ fn main() -> Result<(), Error> {
             )?)
             .map_err(Error::FileError)?;
         }
-        Some(Commands::Monitor(args)) => monitor_esp32(args.baud_rate, args.log_file_path.clone())?,
+        Some(Commands::Monitor(args)) => serial_monitor(args, config).unwrap(),
         None => return Err(Error::NoCommandError),
     };
     Ok(())

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -6,17 +6,19 @@ use std::path::PathBuf;
 use clap::{arg, command, Args, Parser, Subcommand};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, Password};
-use espflash::cli::{config::Config, connect, serial_monitor, monitor::monitor, ConnectArgs, FlashArgs, MonitorArgs, EspflashProgress};
+use espflash::cli::{
+    config::Config, connect, monitor::monitor, serial_monitor, ConnectArgs, EspflashProgress,
+    FlashArgs, MonitorArgs,
+};
 use micro_rdk_installer::{
     error::Error,
     nvs::{
         data::{ViamFlashStorageData, WifiCredentials},
         metadata::read_nvs_metadata,
         partition::{NVSPartition, NVSPartitionData},
-        request::{
-            download_micro_rdk_release, populate_nvs_storage_from_app,
-        }
-    }};
+        request::{download_micro_rdk_release, populate_nvs_storage_from_app},
+    },
+};
 use secrecy::Secret;
 use serde::Deserialize;
 use tokio::runtime::Runtime;
@@ -213,12 +215,15 @@ fn write_credentials_to_app_binary(
     log_file_path: Option<String>,
 */
 
-fn flash(
-    args: WriteFlashArgs,
-    config: &Config,
-) -> Result<(), Error> {
+fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
     log::info!("Connecting...");
-    let mut flasher = connect(&args.connect_args, config, args.flash_args.no_verify, args.flash_args.no_skip).map_err(|_| Error::FlashConnect)?;
+    let mut flasher = connect(
+        &args.connect_args,
+        config,
+        args.flash_args.no_verify,
+        args.flash_args.no_skip,
+    )
+    .map_err(|_| Error::FlashConnect)?;
     // TODO rm unwrap
     let mut f = File::open(args.flash_args.bootloader.unwrap()).map_err(Error::FileError)?;
     let size = f.metadata().map_err(Error::FileError)?.len();
@@ -236,8 +241,16 @@ fn flash(
         log::info!("Starting monitor...");
         let pid = flasher.get_usb_pid().map_err(Error::EspFlashError)?;
         // monitor(flasher.into_interface(), None, pid, 115_200, flash_args.log_format, flash_args.log_output, !flash_args.non_interactive)
-        monitor(flasher.into_serial(), None, pid, 115_200, args.flash_args.log_format, args.flash_args.log_output, true)
-            .map_err(|err| Error::MonitorError(err.to_string()))?;
+        monitor(
+            flasher.into_serial(),
+            None,
+            pid,
+            115_200,
+            args.flash_args.log_format,
+            args.flash_args.log_output,
+            true,
+        )
+        .map_err(|err| Error::MonitorError(err.to_string()))?;
     }
     Ok(())
 }
@@ -320,10 +333,7 @@ fn main() -> Result<(), Error> {
                 nvs_metadata.size,
                 nvs_metadata.start_address,
             )?;
-            flash(
-                args.clone(),
-                &config,
-            )?;
+            flash(args.clone(), &config)?;
         }
         Some(Commands::CreateNvsPartition(args)) => {
             let mut file = File::create(&args.file_name).map_err(Error::FileError)?;

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -214,13 +214,13 @@ fn write_credentials_to_app_binary(
 */
 
 fn flash(
-    write_flash_args: WriteFlashArgs,
+    args: WriteFlashArgs,
     config: &Config,
 ) -> Result<(), Error> {
     log::info!("Connecting...");
-    let mut flasher = connect(&write_flash_args.connect_args, config, write_flash_args.flash_args.no_verify, write_flash_args.flash_args.no_skip).map_err(|_| Error::FlashConnect)?;
+    let mut flasher = connect(&args.connect_args, config, args.flash_args.no_verify, args.flash_args.no_skip).map_err(|_| Error::FlashConnect)?;
     // TODO rm unwrap
-    let mut f = File::open(write_flash_args.flash_args.bootloader.unwrap()).map_err(Error::FileError)?;
+    let mut f = File::open(args.flash_args.bootloader.unwrap()).map_err(Error::FileError)?;
     let size = f.metadata().map_err(Error::FileError)?.len();
     let mut buffer = Vec::with_capacity(
         size.try_into()
@@ -232,11 +232,11 @@ fn flash(
         .write_bin_to_flash(0x00, &buffer, Some(&mut EspflashProgress::default()))
         .map_err(Error::EspFlashError)?;
     log::info!("Flashing completed.");
-    if write_flash_args.flash_args.monitor {
+    if args.flash_args.monitor {
         log::info!("Starting monitor...");
         let pid = flasher.get_usb_pid().map_err(Error::EspFlashError)?;
         // monitor(flasher.into_interface(), None, pid, 115_200, flash_args.log_format, flash_args.log_output, !flash_args.non_interactive)
-        monitor(flasher.into_serial(), None, pid, 115_200, write_flash_args.flash_args.log_format, write_flash_args.flash_args.log_output, true)
+        monitor(flasher.into_serial(), None, pid, 115_200, args.flash_args.log_format, args.flash_args.log_output, true)
             .map_err(|err| Error::MonitorError(err.to_string()))?;
     }
     Ok(())

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -136,7 +136,7 @@ fn request_wifi(
         Input::with_theme(&ColorfulTheme::default())
             .with_prompt("Please enter WiFi SSID")
             .interact_text()
-            .map_err(Error::WifiCredentialsError)?
+            .unwrap()
     };
     let password: Secret<String> = if let Some(password) = wifi_password {
         password
@@ -183,7 +183,7 @@ fn create_nvs_partition_binary(
         storage_data
             .wifi
             .clone()
-            .ok_or_else(|| Error::Uncategorized("failed to get wifi data".to_string()))?
+            .ok_or(Error::NVSDataProcessingError("no wifi".to_string()))?
             .ssid
     );
     populate_nvs_storage_from_app(&mut storage_data)?;
@@ -223,12 +223,7 @@ fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
         args.flash_args.no_skip,
     )
     .map_err(|_| Error::FlashConnect)?;
-    let mut f = File::open(
-        args.flash_args
-            .bootloader
-            .ok_or_else(|| Error::Uncategorized("failed to resolve path to binary".to_string()))?,
-    )
-    .map_err(Error::FileError)?;
+    let mut f = File::open(args.flash_args.bootloader.unwrap()).map_err(Error::FileError)?;
     let size = f.metadata().map_err(Error::FileError)?.len();
     let mut buffer = Vec::with_capacity(
         size.try_into()

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -7,8 +7,8 @@ use clap::{arg, command, Args, Parser, Subcommand};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::{Input, Password};
 use espflash::cli::{
-    config::Config, connect, monitor::monitor, serial_monitor, ConnectArgs, EspflashProgress,
-    FlashArgs, MonitorArgs,
+    config::Config, connect, monitor::monitor, serial_monitor, EspflashProgress, FlashArgs,
+    MonitorArgs,
 };
 use micro_rdk_installer::{
     error::Error,
@@ -70,7 +70,7 @@ struct WriteCredentialsArgs {
 struct WriteFlashArgs {
     /// from espflash: baud, port
     #[clap(flatten)]
-    connect_args: ConnectArgs,
+    monitor_args: MonitorArgs,
     /// from espflash: bootloader, log_output, monitor
     #[clap(flatten)]
     flash_args: FlashArgs,
@@ -216,7 +216,7 @@ fn write_credentials_to_app_binary(
 fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
     log::info!("Connecting...");
     let mut flasher = connect(
-        &args.connect_args,
+        &args.monitor_args.connect_args,
         config,
         args.flash_args.no_verify,
         args.flash_args.no_skip,
@@ -242,7 +242,6 @@ fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
     if args.flash_args.monitor {
         log::info!("Starting monitor...");
         let pid = flasher.get_usb_pid().map_err(Error::EspFlashError)?;
-        // monitor(flasher.into_interface(), None, pid, 115_200, flash_args.log_format, flash_args.log_output, !flash_args.non_interactive)
         monitor(
             flasher.into_serial(),
             None,
@@ -250,7 +249,7 @@ fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
             115_200,
             args.flash_args.log_format,
             args.flash_args.log_output,
-            true,
+            !args.monitor_args.non_interactive,
         )
         .map_err(|err| Error::MonitorError(err.to_string()))?;
     }

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -214,7 +214,7 @@ fn write_credentials_to_app_binary(
     Ok(())
 }
 
-fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
+fn flash(args: WriteFlashArgs, config: &Config, app_path: PathBuf) -> Result<(), Error> {
     log::info!("Connecting...");
     let mut flasher = connect(
         &args.monitor_args.connect_args,
@@ -223,7 +223,7 @@ fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
         args.flash_args.no_skip,
     )
     .map_err(|_| Error::FlashConnect)?;
-    let mut f = File::open(args.flash_args.bootloader.unwrap()).map_err(Error::FileError)?;
+    let mut f = File::open(app_path).map_err(Error::FileError)?;
     let size = f.metadata().map_err(Error::FileError)?.len();
     let mut buffer = Vec::with_capacity(
         size.try_into()
@@ -311,7 +311,7 @@ fn main() -> Result<(), Error> {
                 nvs_metadata.size,
                 nvs_metadata.start_address,
             )?;
-            flash(*args.clone(), &config)?;
+            flash(*args.clone(), &config, app_path)?;
         }
         Some(Commands::CreateNvsPartition(args)) => {
             let mut file = File::create(&args.file_name).map_err(Error::FileError)?;

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -208,12 +208,6 @@ fn write_credentials_to_app_binary(
     app_file.write_all(nvs_data).map_err(Error::FileError)?;
     Ok(())
 }
-/*
-    binary_path: PathBuf,
-    should_monitor: bool,
-    baud_rate: Option<u32>,
-    log_file_path: Option<String>,
-*/
 
 fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
     log::info!("Connecting...");

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -4,8 +4,7 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 use clap::{arg, command, Args, Parser, Subcommand};
-use dialoguer::theme::ColorfulTheme;
-use dialoguer::{Input, Password};
+use dialoguer::{theme::ColorfulTheme, Input, Password};
 use espflash::cli::{
     config::Config, connect, monitor::monitor, serial_monitor, EspflashProgress, FlashArgs,
     MonitorArgs,
@@ -37,9 +36,9 @@ struct AppConfig {
 
 #[derive(Subcommand)]
 enum Commands {
-    WriteFlash(WriteFlashArgs),
+    WriteFlash(Box<WriteFlashArgs>),
     WriteCredentials(WriteCredentialsArgs),
-    CreateNvsPartition(CreateNVSPartitionArgs),
+    CreateNvsPartition(Box<CreateNVSPartitionArgs>),
     Monitor(MonitorArgs),
 }
 
@@ -315,7 +314,7 @@ fn main() -> Result<(), Error> {
                 nvs_metadata.size,
                 nvs_metadata.start_address,
             )?;
-            flash(args.clone(), &config)?;
+            flash(*args.clone(), &config)?;
         }
         Some(Commands::CreateNvsPartition(args)) => {
             let mut file = File::create(&args.file_name).map_err(Error::FileError)?;

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -1,7 +1,9 @@
 use log::LevelFilter;
-use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::PathBuf;
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{Read, Seek, SeekFrom, Write},
+    path::PathBuf,
+};
 
 use clap::{arg, command, Args, Parser, Subcommand};
 use dialoguer::{theme::ColorfulTheme, Input, Password};
@@ -181,7 +183,7 @@ fn create_nvs_partition_binary(
         storage_data
             .wifi
             .clone()
-            .ok_or_else(|| Error::Other("failed to get wifi data".to_string()))?
+            .ok_or_else(|| Error::Uncategorized("failed to get wifi data".to_string()))?
             .ssid
     );
     populate_nvs_storage_from_app(&mut storage_data)?;
@@ -224,7 +226,7 @@ fn flash(args: WriteFlashArgs, config: &Config) -> Result<(), Error> {
     let mut f = File::open(
         args.flash_args
             .bootloader
-            .ok_or_else(|| Error::Other("failed to resolve path to binary".to_string()))?,
+            .ok_or_else(|| Error::Uncategorized("failed to resolve path to binary".to_string()))?,
     )
     .map_err(Error::FileError)?;
     let size = f.metadata().map_err(Error::FileError)?.len();


### PR DESCRIPTION
Updates micro-rdk-installer to use latest espflash updates. 

[Our fork](https://github.com/viamrobotics/espflash/tree/monitor-output) makes some slight modifications to the underlying structs and adds additional logic to writing monitoring logs to an output file. 

The changes made to the installer mimics that of how `cargo-espflash` uses the `espflash` crate; we define our own wrapper `Command`s that hold the crate's flattened structs (ex `FlashArgs`, `MonitorArgs`).

This currently is just at the point of compiling. 
Still need to confirm the installer's before and after behavior (especially for commands in current docs)


**Breaking Changes**
- `WriteFlash.binary_path` -> `WriteFlashArgs.flash_args.bootloader`
- `WriteFlash.baud_rate` -> `WriteFlashArgs.monitor_args.baud`
- `WriteFlash.monitor` -> `WriteFlashArgs.monitor_args.monitor`
- `WriteFlash.log_file` -> `WriteFlashArgs.monitor_args.log_output`