### PR TITLE
[RSDK-7221] relax pinned versions of rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,13 +2502,12 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d383f0425d991a05e564c2f3ec150bd6dde863179c131dd60d8aa73a05434461"
+checksum = "35bd3cf68c183738046838e300353e4716c674dc5e56890de4826801a6622a28"
 dependencies = [
  "futures-io",
- "rustls 0.20.9",
- "webpki 0.22.4",
+ "rustls 0.21.10",
 ]
 
 [[package]]
@@ -3461,7 +3460,7 @@ dependencies = [
  "rand",
  "rcgen 0.11.3",
  "ringbuf",
- "rustls 0.20.9",
+ "rustls 0.21.10",
  "rustls-pemfile",
  "scopeguard",
  "sctp-proto",
@@ -6299,9 +6298,9 @@ dependencies = [
 
 [[package]]
 name = "viam-rust-utils"
-version = "0.1.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cb9d4f394db2caecdc509d107b7581ee5da93b3b68c65dd5fab6f9f251912a"
+checksum = "bf2b3fe240bf733e27559974d5a5b10b1ce89bc89aefe981df080c4a9f60b992"
 dependencies = [
  "anyhow",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ esp-idf-svc = { version = "=0.48.1", default-features = false }
 espflash = { git = "https://github.com/viamrobotics/espflash.git", branch = "monitor-output" }
 futures = "0.3.28"
 futures-lite = "1"
-futures-rustls = "=0.22.0"
+futures-rustls = "0.24"
 futures-util = "0.3.30"
 gethostname = "0.4.3"
 http-body-util = "0.1.1"
@@ -86,7 +86,7 @@ reqwest = "0.11.20"
 reqwless = "0.5.0"
 ring = "0.16.20"
 ringbuf = "0.3.3"
-rustls = { version = "0.20.7", features = ["logging", "tls12"] }
+rustls = { version = "0.21", features = ["logging", "tls12"] }
 rustls-pemfile = { version = "1.0.2" }
 scopeguard = "1.2.0"
 sctp-proto = "0.1.4"
@@ -104,5 +104,5 @@ thiserror = "1.0.47"
 tokio = { version = "1.29.1", default-features = false }
 trackable = "1.2.0"
 viam = { version = ">=0.0.17", git = "https://github.com/viamrobotics/viam-rust-sdk.git" }
-viam-rust-utils = "0.1.2"
+viam-rust-utils = "0.2"
 webpki-roots = "0.22.6"

--- a/micro-rdk/src/native/tls.rs
+++ b/micro-rdk/src/native/tls.rs
@@ -107,15 +107,13 @@ impl NativeTlsStream {
             futures_rustls::TlsStream::Server(stream)
         } else {
             let mut root_certs = RootCertStore::empty();
-            root_certs.add_server_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(
-                |ta| {
-                    OwnedTrustAnchor::from_subject_spki_name_constraints(
-                        ta.subject,
-                        ta.spki,
-                        ta.name_constraints,
-                    )
-                },
-            ));
+            root_certs.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+                OwnedTrustAnchor::from_subject_spki_name_constraints(
+                    ta.subject,
+                    ta.spki,
+                    ta.name_constraints,
+                )
+            }));
             let log = Arc::new(KeyLogFile::new());
             let mut cfg = ClientConfig::builder()
                 .with_safe_defaults()


### PR DESCRIPTION
This PR updates rustls and viam-rust-utils allowing to relax the pinned version of futures-rustls