### PR TITLE
[RSDK-7387] Drop lifetime from GrpcClient, AppClient, and ViamServer

### DIFF
--- a/micro-rdk/src/common/app_client.rs
+++ b/micro-rdk/src/common/app_client.rs
@@ -88,8 +88,8 @@ impl AppClientConfig {
     }
 }
 
-pub struct AppClientBuilder<'a> {
-    grpc_client: Box<GrpcClient<'a>>,
+pub struct AppClientBuilder {
+    grpc_client: Box<GrpcClient>,
     config: AppClientConfig,
 }
 
@@ -109,9 +109,9 @@ where
     Ok(buf.into())
 }
 
-impl<'a> AppClientBuilder<'a> {
+impl AppClientBuilder {
     /// Create a new AppClientBuilder
-    pub fn new(grpc_client: Box<GrpcClient<'a>>, config: AppClientConfig) -> Self {
+    pub fn new(grpc_client: Box<GrpcClient>, config: AppClientConfig) -> Self {
         Self {
             grpc_client,
             config,
@@ -119,7 +119,7 @@ impl<'a> AppClientBuilder<'a> {
     }
     /// Consume the AppClientBuilder and returns an AppClient. This function will panic if
     /// the received config doesn't contain an fqdn field.
-    pub async fn build(mut self) -> Result<AppClient<'a>, AppClientError> {
+    pub async fn build(mut self) -> Result<AppClient, AppClientError> {
         let jwt = self.get_jwt_token().await?;
 
         Ok(AppClient {
@@ -163,10 +163,10 @@ impl<'a> AppClientBuilder<'a> {
     }
 }
 
-pub struct AppClient<'a> {
+pub struct AppClient {
     config: AppClientConfig,
     jwt: String,
-    grpc_client: Box<GrpcClient<'a>>,
+    grpc_client: Box<GrpcClient>,
     ip: Ipv4Addr,
 }
 
@@ -175,7 +175,7 @@ pub(crate) struct AppSignaling(
     pub(crate) GrpcMessageStream<AnswerRequest>,
 );
 
-impl<'a> AppClient<'a> {
+impl AppClient {
     pub(crate) async fn connect_signaling(&mut self) -> Result<AppSignaling, AppClientError> {
         let (sender, receiver) = async_channel::bounded::<Bytes>(1);
         let r = self
@@ -265,7 +265,7 @@ impl<'a> AppClient<'a> {
     }
 }
 
-impl<'a> Drop for AppClient<'a> {
+impl Drop for AppClient {
     fn drop(&mut self) {
         log::debug!("dropping AppClient")
     }

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -270,16 +270,16 @@ where
     }
 }
 
-pub struct ViamServer<'a, C, T, CC, D, L> {
+pub struct ViamServer<C, T, CC, D, L> {
     http_listener: HttpListener<L, T>,
     webrtc_config: Option<Box<WebRtcConfiguration<D, CC>>>,
     exec: Executor,
     app_connector: C,
     app_config: AppClientConfig,
-    app_client: Option<AppClient<'a>>,
+    app_client: Option<AppClient>,
     incoming_connection_manager: IncomingConnectionManager,
 }
-impl<'a, C, T, CC, D, L> ViamServer<'a, C, T, CC, D, L>
+impl<C, T, CC, D, L> ViamServer<C, T, CC, D, L>
 where
     C: TlsClientConnector,
     T: rt::Read + rt::Write + Unpin + 'static,

--- a/micro-rdk/src/common/grpc_client.rs
+++ b/micro-rdk/src/common/grpc_client.rs
@@ -170,20 +170,20 @@ where
 type Executor = NativeExecutor;
 #[cfg(feature = "esp32")]
 type Executor = Esp32Executor;
-pub struct GrpcClient<'a> {
+pub struct GrpcClient {
     executor: Executor,
     http2_connection: SendRequest<BoxBody<Bytes, hyper::Error>>,
     #[allow(dead_code)]
     http2_task: Option<Task<()>>,
-    uri: &'a str,
+    uri: String,
 }
 
-impl<'a> GrpcClient<'a> {
+impl GrpcClient {
     pub async fn new<T>(
         io: T,
         executor: Executor,
-        uri: &'a str,
-    ) -> Result<GrpcClient<'a>, GrpcClientError>
+        uri: &str
+    ) -> Result<GrpcClient, GrpcClientError>
     where
         T: rt::Read + rt::Write + Unpin + 'static,
     {
@@ -208,7 +208,7 @@ impl<'a> GrpcClient<'a> {
             executor,
             http2_connection,
             http2_task: Some(http2_task),
-            uri,
+            uri: uri.to_string()
         })
     }
 

--- a/micro-rdk/src/common/grpc_client.rs
+++ b/micro-rdk/src/common/grpc_client.rs
@@ -179,11 +179,7 @@ pub struct GrpcClient {
 }
 
 impl GrpcClient {
-    pub async fn new<T>(
-        io: T,
-        executor: Executor,
-        uri: &str
-    ) -> Result<GrpcClient, GrpcClientError>
+    pub async fn new<T>(io: T, executor: Executor, uri: &str) -> Result<GrpcClient, GrpcClientError>
     where
         T: rt::Read + rt::Write + Unpin + 'static,
     {
@@ -208,7 +204,7 @@ impl GrpcClient {
             executor,
             http2_connection,
             http2_task: Some(http2_task),
-            uri: uri.to_string()
+            uri: uri.to_string(),
         })
     }
 


### PR DESCRIPTION
A small simplification: drops a lifetime out of three important structs, so it seems worthwhile for the small memory cost of holding the URI in an owned string.