### PR TITLE
stabilize server behavior on network interruptions

### DIFF
--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -177,14 +177,20 @@ mod esp32 {
         #[allow(clippy::redundant_clone)]
         #[cfg(not(feature = "qemu"))]
         let network = {
-            let mut wifi =
-                Esp32WifiNetwork::new(sys_loop_stack.clone(), SSID.to_string(), PASS.to_string())
-                    .unwrap();
+            let mut wifi = Esp32WifiNetwork::new(
+                sys_loop_stack.clone(),
+                nvs_vars.wifi_ssid.clone(),
+                nvs_vars.wifi_pwd.clone(),
+            )
+            .unwrap();
             loop {
                 match wifi.connect() {
                     Ok(()) => break,
                     Err(_) => {
-                        log::info!("wifi could not connect to SSID: {:?}, retrying...", SSID);
+                        log::info!(
+                            "wifi could not connect to SSID: {:?}, retrying...",
+                            nvs_vars.wifi_ssid
+                        );
                         std::thread::sleep(std::time::Duration::from_millis(300));
                     }
                 }

--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -182,7 +182,7 @@ mod esp32 {
                 nvs_vars.wifi_ssid.clone(),
                 nvs_vars.wifi_pwd.clone(),
             )
-            .unwrap();
+            .expect("could not configure wifi");
             loop {
                 match wifi.connect() {
                     Ok(()) => break,

--- a/examples/esp32-with-cred/esp32-server-with-cred.rs
+++ b/examples/esp32-with-cred/esp32-server-with-cred.rs
@@ -25,6 +25,7 @@ mod esp32 {
                 board::FakeBoard,
                 robot::{LocalRobot, ResourceMap, ResourceType},
             },
+            esp32::conn::network::eth_configure,
             proto::common::v1::ResourceName,
         },
         std::{
@@ -36,14 +37,8 @@ mod esp32 {
 
     #[cfg(not(feature = "qemu"))]
     use {
-        embedded_svc::wifi::{
-            AuthMethod, ClientConfiguration as WifiClientConfiguration,
-            Configuration as WifiConfiguration,
-        },
         micro_rdk::common::registry::ComponentRegistry,
-        micro_rdk::esp32::esp_idf_svc::hal::{peripheral::Peripheral, prelude::Peripherals},
-        micro_rdk::esp32::esp_idf_svc::sys::esp_wifi_set_ps,
-        micro_rdk::esp32::esp_idf_svc::wifi::{BlockingWifi, EspWifi},
+        micro_rdk::esp32::conn::network::Esp32WifiNetwork,
     };
 
     #[derive(Debug, Error)]
@@ -52,8 +47,6 @@ mod esp32 {
         NVSKeyError(String),
         #[error("{0}")]
         EspError(EspError),
-        #[error("Error obtaining peripherals")]
-        PeripheralsError,
     }
 
     impl From<EspError> for ServerError {
@@ -123,11 +116,6 @@ mod esp32 {
         micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
         let sys_loop_stack = EspSystemEventLoop::take().unwrap();
 
-        #[cfg(not(feature = "qemu"))]
-        let periph = Peripherals::take()
-            .map_err(|_| ServerError::PeripheralsError)
-            .unwrap();
-
         #[cfg(feature = "qemu")]
         let repr = {
             let board = Arc::new(Mutex::new(FakeBoard::new(vec![])));
@@ -157,7 +145,7 @@ mod esp32 {
         let nvs_vars = NvsStaticVars::new().unwrap();
 
         #[cfg(feature = "qemu")]
-        let (ip, _block_eth) = {
+        let network = {
             use micro_rdk::esp32::esp_idf_svc::hal::prelude::Peripherals;
             info!("creating eth object");
             let mut eth = Box::new(
@@ -173,9 +161,7 @@ mod esp32 {
                 )
                 .unwrap(),
             );
-            let _ = eth_configure(&sys_loop_stack, &mut eth).unwrap();
-            let ip = Ipv4Addr::new(10, 1, 12, 187);
-            (ip, eth)
+            eth_configure(&sys_loop_stack, &mut eth).unwrap()
         };
 
         let mut max_connection = 3;
@@ -190,22 +176,20 @@ mod esp32 {
         info!("starting wifi...");
         #[allow(clippy::redundant_clone)]
         #[cfg(not(feature = "qemu"))]
-        let (ip, _wifi) = {
-            let wifi = start_wifi(
-                periph.modem,
-                sys_loop_stack,
-                &nvs_vars.wifi_ssid,
-                &nvs_vars.wifi_pwd,
-            )
-            .expect("failed to start wifi");
-            (
-                wifi.wifi()
-                    .sta_netif()
-                    .get_ip_info()
-                    .expect("failed to get ip info")
-                    .ip,
-                wifi,
-            )
+        let network = {
+            let mut wifi =
+                Esp32WifiNetwork::new(sys_loop_stack.clone(), SSID.to_string(), PASS.to_string())
+                    .unwrap();
+            loop {
+                match wifi.connect() {
+                    Ok(()) => break,
+                    Err(_) => {
+                        log::info!("wifi could not connect to SSID: {:?}, retrying...", SSID);
+                        std::thread::sleep(std::time::Duration::from_millis(300));
+                    }
+                }
+            }
+            wifi
         };
 
         let webrtc_certificate = WebRtcCertificate::new(
@@ -218,59 +202,16 @@ mod esp32 {
         let key = nvs_vars.robot_srv_der_key;
         let tls_cfg = Esp32TLSServerConfig::new(cert, key.as_ptr(), key.len() as u32);
 
-        let cfg = AppClientConfig::new(nvs_vars.robot_secret, nvs_vars.robot_id, ip, "".to_owned());
+        let cfg = AppClientConfig::new(nvs_vars.robot_secret, nvs_vars.robot_id, "".to_owned());
 
-        serve_web(cfg, tls_cfg, repr, ip, webrtc_certificate, max_connection);
-    }
-
-    #[cfg(feature = "qemu")]
-    fn eth_configure<'d, T>(
-        sl_stack: &EspSystemEventLoop,
-        eth: &mut micro_rdk::esp32::esp_idf_svc::eth::EspEth<'d, T>,
-    ) -> Result<Ipv4Addr, ServerError> {
-        let mut eth = micro_rdk::esp32::esp_idf_svc::eth::BlockingEth::wrap(eth, sl_stack.clone())?;
-        eth.start()?;
-        let ip_info = eth.eth().netif().get_ip_info()?;
-
-        info!("ETH IP {:?}", ip_info.ip);
-        Ok(ip_info.ip)
-    }
-
-    #[cfg(not(feature = "qemu"))]
-    fn start_wifi(
-        modem: impl Peripheral<P = micro_rdk::esp32::esp_idf_svc::hal::modem::Modem> + 'static,
-        sl_stack: EspSystemEventLoop,
-        ssid: &str,
-        password: &str,
-    ) -> Result<Box<BlockingWifi<EspWifi<'static>>>, ServerError> {
-        let nvs = EspDefaultNvsPartition::take()?;
-        let mut wifi = BlockingWifi::wrap(
-            EspWifi::new(modem, sl_stack.clone(), Some(nvs.clone()))?,
-            sl_stack,
-        )?;
-        let wifi_configuration = WifiConfiguration::Client(WifiClientConfiguration {
-            ssid: ssid.try_into().unwrap(),
-            bssid: None,
-            auth_method: AuthMethod::WPA2Personal,
-            password: password.try_into().unwrap(),
-            channel: None,
-        });
-        debug!("setting wifi configuration...");
-        wifi.set_configuration(&wifi_configuration)?;
-
-        wifi.start()?;
-        info!("Wifi started");
-
-        wifi.connect()?;
-        info!("Wifi connected");
-
-        wifi.wait_netif_up()?;
-        info!("Wifi netif up");
-
-        micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {
-            esp_wifi_set_ps(micro_rdk::esp32::esp_idf_svc::sys::wifi_ps_type_t_WIFI_PS_NONE)
-        })?;
-        Ok(Box::new(wifi))
+        serve_web(
+            cfg,
+            tls_cfg,
+            repr,
+            webrtc_certificate,
+            max_connection,
+            network,
+        );
     }
 }
 fn main() {

--- a/examples/esp32/esp32-server.rs
+++ b/examples/esp32/esp32-server.rs
@@ -70,7 +70,7 @@ mod esp32 {
         let network = {
             let mut wifi =
                 Esp32WifiNetwork::new(sys_loop_stack.clone(), SSID.to_string(), PASS.to_string())
-                    .unwrap();
+                    .expect("could not configure wifi");
             loop {
                 match wifi.connect() {
                     Ok(()) => break,

--- a/examples/esp32/esp32-server.rs
+++ b/examples/esp32/esp32-server.rs
@@ -9,43 +9,30 @@ mod esp32 {
 
     include!(concat!(env!("OUT_DIR"), "/robot_secret.rs"));
 
-    use log::*;
     use micro_rdk::common::entry::RobotRepresentation;
     #[cfg(feature = "qemu")]
-    use micro_rdk::esp32::esp_idf_svc::eth::EspEth;
+    use micro_rdk::esp32::conn::network::eth_configure;
+    #[cfg(feature = "qemu")]
+    use micro_rdk::esp32::esp_idf_svc::eth::{EspEth, EthDriver};
     use micro_rdk::esp32::esp_idf_svc::eventloop::EspSystemEventLoop;
     use micro_rdk::esp32::esp_idf_svc::sys::{
         g_wifi_feature_caps, CONFIG_FEATURE_CACHE_TX_BUF_BIT,
     };
-    #[cfg(feature = "qemu")]
-    use std::net::Ipv4Addr;
 
     extern "C" {
         pub static g_spiram_ok: bool;
     }
 
     use micro_rdk::common::registry::ComponentRegistry;
-    use micro_rdk::esp32::esp_idf_svc::sys::EspError;
 
     #[cfg(not(feature = "qemu"))]
-    use {
-        embedded_svc::wifi::{
-            AuthMethod, ClientConfiguration as WifiClientConfiguration,
-            Configuration as WifiConfiguration,
-        },
-        micro_rdk::esp32::esp_idf_svc::hal::{peripheral::Peripheral, prelude::Peripherals},
-        micro_rdk::esp32::esp_idf_svc::sys::esp_wifi_set_ps,
-        micro_rdk::esp32::esp_idf_svc::wifi::{BlockingWifi, EspWifi},
-    };
+    use micro_rdk::esp32::conn::network::Esp32WifiNetwork;
 
     pub(crate) fn main_esp32() {
         micro_rdk::esp32::esp_idf_svc::sys::link_patches();
 
         micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
         let sys_loop_stack = EspSystemEventLoop::take().unwrap();
-
-        #[cfg(not(feature = "qemu"))]
-        let periph = Peripherals::take().unwrap();
 
         let repr = RobotRepresentation::WithRegistry(Box::<ComponentRegistry>::default());
 
@@ -59,20 +46,15 @@ mod esp32 {
         }
 
         #[cfg(feature = "qemu")]
-        let (ip, _block_eth) = {
+        let network = {
             use micro_rdk::esp32::esp_idf_svc::hal::prelude::Peripherals;
-            info!("creating eth object");
-            let eth = micro_rdk::esp32::esp_idf_svc::eth::EspEth::wrap(
-                micro_rdk::esp32::esp_idf_svc::eth::EthDriver::new_openeth(
-                    Peripherals::take().unwrap().mac,
-                    sys_loop_stack.clone(),
-                )
-                .unwrap(),
+            log::info!("creating eth object");
+            let eth = EspEth::wrap(
+                EthDriver::new_openeth(Peripherals::take().unwrap().mac, sys_loop_stack.clone())
+                    .unwrap(),
             )
             .unwrap();
-            let (_, eth) = eth_configure(&sys_loop_stack, eth).unwrap();
-            let ip = Ipv4Addr::new(10, 1, 12, 187);
-            (ip, eth)
+            eth_configure(&sys_loop_stack, eth).unwrap()
         };
 
         let mut max_connection = 3;
@@ -85,16 +67,20 @@ mod esp32 {
         }
         #[allow(clippy::redundant_clone)]
         #[cfg(not(feature = "qemu"))]
-        let (ip, _wifi) = {
-            let wifi = start_wifi(periph.modem, sys_loop_stack).expect("failed to start wifi");
-            (
-                wifi.wifi()
-                    .sta_netif()
-                    .get_ip_info()
-                    .expect("failed to get ip info")
-                    .ip,
-                wifi,
-            )
+        let network = {
+            let mut wifi =
+                Esp32WifiNetwork::new(sys_loop_stack.clone(), SSID.to_string(), PASS.to_string())
+                    .unwrap();
+            loop {
+                match wifi.connect() {
+                    Ok(()) => break,
+                    Err(_) => {
+                        log::info!("wifi could not connect to SSID: {:?}, retrying...", SSID);
+                        std::thread::sleep(std::time::Duration::from_millis(300));
+                    }
+                }
+            }
+            wifi
         };
 
         #[cfg(not(feature = "provisioning"))]
@@ -103,12 +89,8 @@ mod esp32 {
                 common::app_client::AppClientConfig,
                 esp32::{certificate::WebRtcCertificate, tls::Esp32TLSServerConfig},
             };
-            let cfg = AppClientConfig::new(
-                ROBOT_SECRET.to_owned(),
-                ROBOT_ID.to_owned(),
-                ip,
-                "".to_owned(),
-            );
+            let cfg =
+                AppClientConfig::new(ROBOT_SECRET.to_owned(), ROBOT_ID.to_owned(), "".to_owned());
             let webrtc_certificate = WebRtcCertificate::new(
                 ROBOT_DTLS_CERT.to_vec(),
                 ROBOT_DTLS_KEY_PAIR.to_vec(),
@@ -125,9 +107,9 @@ mod esp32 {
                 cfg,
                 tls_cfg,
                 repr,
-                ip,
                 webrtc_certificate,
                 max_connection,
+                network,
             );
         }
         #[cfg(feature = "provisioning")]
@@ -142,60 +124,10 @@ mod esp32 {
                 storage,
                 info,
                 repr,
-                ip,
+                network,
                 max_connection,
             );
         }
-    }
-
-    #[cfg(feature = "qemu")]
-    use micro_rdk::esp32::esp_idf_svc::eth::BlockingEth;
-    #[cfg(feature = "qemu")]
-    fn eth_configure<'d, T>(
-        sl_stack: &EspSystemEventLoop,
-        eth: micro_rdk::esp32::esp_idf_svc::eth::EspEth<'d, T>,
-    ) -> Result<(Ipv4Addr, Box<BlockingEth<EspEth<'d, T>>>), EspError> {
-        let mut eth = micro_rdk::esp32::esp_idf_svc::eth::BlockingEth::wrap(eth, sl_stack.clone())?;
-        eth.start()?;
-        eth.wait_netif_up()?;
-
-        let ip_info = eth.eth().netif().get_ip_info()?;
-
-        info!("ETH IP {:?}", ip_info.ip);
-        Ok((ip_info.ip, Box::new(eth)))
-    }
-
-    #[cfg(not(feature = "qemu"))]
-    fn start_wifi(
-        modem: impl Peripheral<P = micro_rdk::esp32::esp_idf_svc::hal::modem::Modem> + 'static,
-        sl_stack: EspSystemEventLoop,
-    ) -> Result<Box<BlockingWifi<EspWifi<'static>>>, EspError> {
-        let nvs = micro_rdk::esp32::esp_idf_svc::nvs::EspDefaultNvsPartition::take()?;
-        let mut wifi =
-            BlockingWifi::wrap(EspWifi::new(modem, sl_stack.clone(), Some(nvs))?, sl_stack)?;
-        let wifi_configuration = WifiConfiguration::Client(WifiClientConfiguration {
-            ssid: SSID.try_into().unwrap(),
-            bssid: None,
-            auth_method: AuthMethod::WPA2Personal,
-            password: PASS.try_into().unwrap(),
-            channel: None,
-        });
-
-        wifi.set_configuration(&wifi_configuration)?;
-
-        wifi.start()?;
-        info!("Wifi started");
-
-        wifi.connect()?;
-        info!("Wifi connected");
-
-        wifi.wait_netif_up()?;
-        info!("Wifi netif up");
-
-        micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {
-            esp_wifi_set_ps(micro_rdk::esp32::esp_idf_svc::sys::wifi_ps_type_t_WIFI_PS_NONE)
-        })?;
-        Ok(Box::new(wifi))
     }
 }
 

--- a/examples/native/native-server.rs
+++ b/examples/native/native-server.rs
@@ -12,7 +12,7 @@ mod native {
 
         let repr = RobotRepresentation::WithRegistry(Box::default());
 
-        let network = match local_ip_address::local_ip().unwrap() {
+        let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
             _ => panic!("oops expected ipv4"),
         };

--- a/examples/native/native-server.rs
+++ b/examples/native/native-server.rs
@@ -3,10 +3,7 @@ mod native {
     // Generated robot config during build process
     include!(concat!(env!("OUT_DIR"), "/robot_secret.rs"));
 
-    use micro_rdk::common::{
-        entry::RobotRepresentation,
-        network::{ExternallyManagedNetwork, Network},
-    };
+    use micro_rdk::common::{conn::network::ExternallyManagedNetwork, entry::RobotRepresentation};
 
     pub(crate) fn main_native() {
         env_logger::builder()

--- a/examples/native/native-server.rs
+++ b/examples/native/native-server.rs
@@ -3,7 +3,10 @@ mod native {
     // Generated robot config during build process
     include!(concat!(env!("OUT_DIR"), "/robot_secret.rs"));
 
-    use micro_rdk::common::entry::RobotRepresentation;
+    use micro_rdk::common::{
+        entry::RobotRepresentation,
+        network::{ExternallyManagedNetwork, Network},
+    };
 
     pub(crate) fn main_native() {
         env_logger::builder()
@@ -12,9 +15,9 @@ mod native {
 
         let repr = RobotRepresentation::WithRegistry(Box::default());
 
-        let ip = match local_ip_address::local_ip().unwrap() {
-            std::net::IpAddr::V4(ip) => ip,
-            _ => panic!("ouups expected ipv4"),
+        let network = match local_ip_address::local_ip().unwrap() {
+            std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
+            _ => panic!("oops expected ipv4"),
         };
         #[cfg(not(feature = "provisioning"))]
         {
@@ -26,14 +29,10 @@ mod native {
                 NativeTlsServerConfig::new(cert.to_vec(), key.to_vec())
             };
 
-            let app_config = AppClientConfig::new(
-                ROBOT_SECRET.to_owned(),
-                ROBOT_ID.to_owned(),
-                ip,
-                "".to_owned(),
-            );
+            let app_config =
+                AppClientConfig::new(ROBOT_SECRET.to_owned(), ROBOT_ID.to_owned(), "".to_owned());
 
-            micro_rdk::native::entry::serve_web(app_config, cfg, repr, ip);
+            micro_rdk::native::entry::serve_web(app_config, cfg, repr, network);
         }
         #[cfg(feature = "provisioning")]
         {

--- a/micro-rdk/src/common/conn/network.rs
+++ b/micro-rdk/src/common/conn/network.rs
@@ -1,0 +1,47 @@
+use std::net::Ipv4Addr;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum NetworkError {
+    #[error("error connecting to network")]
+    ConnectionError,
+    #[cfg(feature = "esp32")]
+    #[error(transparent)]
+    Esp32ConnectionError(#[from] crate::esp32::esp_idf_svc::sys::EspError),
+}
+
+/// Reflects the representation of a network's status.
+pub trait Network {
+    /// Get the current IP address of the network interface.
+    fn get_ip(&self) -> Ipv4Addr;
+
+    /// Returns whether the underlying network interface is connected, *not* if
+    /// internet access is available
+    fn is_connected(&self) -> Result<bool, NetworkError>;
+}
+
+/// For networks managed outside of micro-rdk (for example, using micro-rdk as an ESP-IDF
+/// component in a separate project), this struct is meant to simply communicate the IP
+/// address statically. It will trivially always appear as connected because connectivity
+/// management is external
+#[repr(C)]
+pub struct ExternallyManagedNetwork {
+    ip: Ipv4Addr,
+}
+
+impl ExternallyManagedNetwork {
+    pub fn new(ip: Ipv4Addr) -> Self {
+        Self { ip }
+    }
+}
+
+impl Network for ExternallyManagedNetwork {
+    // TODO: provide a way for an external managed network to communicate a change in IP
+    // address
+    fn get_ip(&self) -> Ipv4Addr {
+        self.ip
+    }
+    fn is_connected(&self) -> Result<bool, NetworkError> {
+        Ok(true)
+    }
+}

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -426,14 +426,10 @@ where
                             .await
                             .unwrap(),
                     );
-                    let app_client = AppClientBuilder::new(
-                        grpc_client,
-                        self.app_config.clone(),
-                        self.network.get_ip(),
-                    )
-                    .build()
-                    .await
-                    .unwrap();
+                    let app_client = AppClientBuilder::new(grpc_client, self.app_config.clone())
+                        .build()
+                        .await
+                        .unwrap();
                     let _ = AsyncRwLockUpgradableReadGuard::upgrade(urguard)
                         .await
                         .insert(app_client);

--- a/micro-rdk/src/common/mod.rs
+++ b/micro-rdk/src/common/mod.rs
@@ -80,6 +80,7 @@ pub mod webrtc {
 pub mod conn {
     pub mod errors;
     pub mod mdns;
+    pub mod network;
     pub mod server;
     mod utils;
 }

--- a/micro-rdk/src/esp32/conn/network.rs
+++ b/micro-rdk/src/esp32/conn/network.rs
@@ -1,0 +1,129 @@
+use std::{
+    net::Ipv4Addr,
+    sync::{Arc, Mutex},
+};
+
+use {
+    crate::common::conn::network::{Network, NetworkError},
+    crate::esp32::esp_idf_svc::{
+        eventloop::{EspSubscription, EspSystemEventLoop, System},
+        hal::modem::Modem,
+        sys::esp_wifi_set_ps,
+        wifi::{BlockingWifi, EspWifi, WifiEvent},
+    },
+    embedded_svc::wifi::{
+        AuthMethod, ClientConfiguration as WifiClientConfiguration,
+        Configuration as WifiConfiguration,
+    },
+};
+
+use crate::esp32::esp_idf_svc::{
+    eth::{BlockingEth, EspEth, OpenEth},
+    sys::EspError,
+};
+
+/// A wrapper around the wifi structure available in esp-idf-svc with and adjustment to support
+/// reconnection
+pub struct Esp32WifiNetwork {
+    inner: Arc<Mutex<Box<BlockingWifi<EspWifi<'static>>>>>,
+    sl_stack: EspSystemEventLoop,
+    _subscription: Option<EspSubscription<'static, System>>,
+}
+
+impl Esp32WifiNetwork {
+    pub fn new(
+        sl_stack: EspSystemEventLoop,
+        ssid: String,
+        password: String,
+    ) -> Result<Self, NetworkError> {
+        let config = WifiConfiguration::Client(WifiClientConfiguration {
+            ssid: ssid.as_str().try_into().unwrap(),
+            bssid: None,
+            auth_method: AuthMethod::WPA2Personal,
+            password: password.as_str().try_into().unwrap(),
+            channel: None,
+        });
+        let modem = unsafe { Modem::new() };
+        let mut wifi = BlockingWifi::wrap(
+            EspWifi::new(modem, sl_stack.clone(), None)?,
+            sl_stack.clone(),
+        )?;
+        wifi.set_configuration(&config)?;
+        let inner = Arc::new(Mutex::new(Box::new(wifi)));
+        Ok(Self {
+            inner,
+            sl_stack,
+            _subscription: None,
+        })
+    }
+}
+
+impl Esp32WifiNetwork {
+    pub fn connect(&mut self) -> Result<(), NetworkError> {
+        let inner_clone = self.inner.clone();
+        let mut wifi = self.inner.lock().unwrap();
+        wifi.start()?;
+        log::info!("Wifi started");
+
+        wifi.connect()?;
+        log::info!("Wifi connected");
+
+        wifi.wait_netif_up()?;
+        log::info!("Wifi netif up");
+
+        crate::esp32::esp_idf_svc::sys::esp!(unsafe {
+            esp_wifi_set_ps(crate::esp32::esp_idf_svc::sys::wifi_ps_type_t_WIFI_PS_NONE)
+        })?;
+
+        let subscription = self
+            .sl_stack
+            .subscribe::<WifiEvent, _>(move |event: WifiEvent| {
+                if matches!(event, WifiEvent::StaDisconnected) {
+                    let mut wifi_guard = inner_clone.lock().unwrap();
+                    log::info!("wifi connecting...");
+                    if let Err(err) = wifi_guard.wifi_mut().connect() {
+                        log::error!("could not connect to wifi: {:?}", err);
+                    }
+                } else if matches!(event, WifiEvent::StaConnected) {
+                    log::info!("wifi connected event received");
+                }
+            })?;
+        let _ = self._subscription.replace(subscription);
+        Ok(())
+    }
+}
+
+impl Network for Esp32WifiNetwork {
+    fn get_ip(&self) -> Ipv4Addr {
+        self.inner
+            .lock()
+            .unwrap()
+            .wifi()
+            .sta_netif()
+            .get_ip_info()
+            .unwrap()
+            .ip
+    }
+    fn is_connected(&self) -> Result<bool, NetworkError> {
+        Ok(self.inner.lock().unwrap().is_connected()?)
+    }
+}
+
+pub fn eth_configure<'d, T>(
+    sl_stack: &EspSystemEventLoop,
+    eth: EspEth<'d, T>,
+) -> Result<Box<BlockingEth<EspEth<'d, T>>>, EspError> {
+    let mut eth = BlockingEth::wrap(eth, sl_stack.clone())?;
+    eth.start()?;
+    eth.wait_netif_up()?;
+    Ok(Box::new(eth))
+}
+
+impl Network for Box<BlockingEth<EspEth<'static, OpenEth>>> {
+    fn get_ip(&self) -> Ipv4Addr {
+        self.eth().netif().get_ip_info().unwrap().ip
+    }
+    fn is_connected(&self) -> Result<bool, NetworkError> {
+        Ok(BlockingEth::is_connected(self)?)
+    }
+}

--- a/micro-rdk/src/esp32/conn/network.rs
+++ b/micro-rdk/src/esp32/conn/network.rs
@@ -37,10 +37,16 @@ impl Esp32WifiNetwork {
         password: String,
     ) -> Result<Self, NetworkError> {
         let config = WifiConfiguration::Client(WifiClientConfiguration {
-            ssid: ssid.as_str().try_into().unwrap(),
+            ssid: ssid
+                .as_str()
+                .try_into()
+                .expect("SSID to C string conversion failed"),
             bssid: None,
             auth_method: AuthMethod::WPA2Personal,
-            password: password.as_str().try_into().unwrap(),
+            password: password
+                .as_str()
+                .try_into()
+                .expect("WiFi password to C string conversion failed"),
             channel: None,
         });
         let modem = unsafe { Modem::new() };
@@ -101,7 +107,7 @@ impl Network for Esp32WifiNetwork {
             .wifi()
             .sta_netif()
             .get_ip_info()
-            .unwrap()
+            .expect("could not get IP info")
             .ip
     }
     fn is_connected(&self) -> Result<bool, NetworkError> {
@@ -121,7 +127,11 @@ pub fn eth_configure<'d, T>(
 
 impl Network for Box<BlockingEth<EspEth<'static, OpenEth>>> {
     fn get_ip(&self) -> Ipv4Addr {
-        self.eth().netif().get_ip_info().unwrap().ip
+        self.eth()
+            .netif()
+            .get_ip_info()
+            .expect("could not get IP info")
+            .ip
     }
     fn is_connected(&self) -> Result<bool, NetworkError> {
         Ok(BlockingEth::is_connected(self)?)

--- a/micro-rdk/src/esp32/entry.rs
+++ b/micro-rdk/src/esp32/entry.rs
@@ -75,11 +75,12 @@ pub async fn serve_web_inner(
                 .unwrap(),
         );
 
-        let builder = AppClientBuilder::new(grpc_client, app_config.clone(), network.get_ip());
+        let builder = AppClientBuilder::new(grpc_client, app_config.clone());
 
         let client = builder.build().await.unwrap();
 
-        let (cfg_response, cfg_received_datetime) = client.get_config().await.unwrap();
+        let (cfg_response, cfg_received_datetime) =
+            client.get_config(network.get_ip()).await.unwrap();
 
         let robot = match repr {
             RobotRepresentation::WithRobot(robot) => Arc::new(Mutex::new(robot)),
@@ -223,7 +224,7 @@ where
             let conn =
                 Esp32Stream::TLSStream(Box::new(Esp32TLS::new_client().open_ssl_context(None)?));
             let client = GrpcClient::new(conn, exec.clone(), "https://app.viam.com:443").await?;
-            let builder = AppClientBuilder::new(Box::new(client), app_config.clone(), ip);
+            let builder = AppClientBuilder::new(Box::new(client), app_config.clone());
 
             let mut client = builder.build().await?;
             let certs = client.get_certificates().await?;

--- a/micro-rdk/src/esp32/mod.rs
+++ b/micro-rdk/src/esp32/mod.rs
@@ -27,6 +27,7 @@ pub mod tls;
 pub mod utils;
 pub mod conn {
     pub mod mdns;
+    pub mod network;
 }
 #[cfg(feature = "provisioning")]
 pub mod nvs_storage;

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -63,12 +63,12 @@ pub async fn serve_web_inner(
         let grpc_client = GrpcClient::new(conn, cloned_exec, "https://app.viam.com:443")
             .await
             .unwrap();
-        let builder =
-            AppClientBuilder::new(Box::new(grpc_client), app_config.clone(), network.get_ip());
+        let builder = AppClientBuilder::new(Box::new(grpc_client), app_config.clone());
         log::info!("build client start");
         let client = builder.build().await.unwrap();
 
-        let (cfg_response, cfg_received_datetime) = client.get_config().await.unwrap();
+        let (cfg_response, cfg_received_datetime) =
+            client.get_config(network.get_ip()).await.unwrap();
 
         let robot = match repr {
             RobotRepresentation::WithRobot(robot) => Arc::new(Mutex::new(robot)),
@@ -208,7 +208,7 @@ where
                 NativeTls::new_client().open_ssl_context(None).await?,
             ));
             let client = GrpcClient::new(conn, exec.clone(), "https://app.viam.com:443").await?;
-            let builder = AppClientBuilder::new(Box::new(client), app_config.clone(), ip);
+            let builder = AppClientBuilder::new(Box::new(client), app_config.clone());
 
             let mut client = builder.build().await?;
             let certs = client.get_certificates().await?;
@@ -321,7 +321,7 @@ mod tests {
 
         let config = AppClientConfig::new("".to_string(), "".to_string(), "".to_owned());
 
-        let builder = AppClientBuilder::new(grpc_client, config, Ipv4Addr::UNSPECIFIED);
+        let builder = AppClientBuilder::new(grpc_client, config);
 
         let client = builder.build().await;
 

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -33,7 +33,10 @@ use crate::common::{
 #[cfg(feature = "provisioning")]
 use async_io::Async;
 #[cfg(feature = "provisioning")]
-use std::{fmt::Debug, net::{TcpListener, Ipv4Addr}};
+use std::{
+    fmt::Debug,
+    net::{Ipv4Addr, TcpListener},
+};
 
 use super::{
     certificate::WebRtcCertificate, conn::mdns::NativeMdns, dtls::NativeDtls, tcp::NativeListener,

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
     let cfg = AppClientConfig::new(
         ROBOT_SECRET.to_owned(),
         ROBOT_ID.to_owned(),
-        ip,
+        wifi,
         "".to_owned(),
     );
     let webrtc_certificate = WebRtcCertificate::new(


### PR DESCRIPTION
Introduces the following behavioral changes:
- at the beginning of `main_esp32` in `esp32-server.rs` and `esp32-server-with-cred`, there is now a continuous loop for connecting to Wi-Fi rather than simply panicking when unsuccessful
- in `ViamServer::serve`, if the base station remains connected but there is not internet access, the loop now continues without attempting to connect signaling
- in `ViamServer::serve`, if the base station is disconnected, the `app_client` is dropped until network connection has been re-established
- we now attempt reconnection upon receipt of a station disconnected event (while the station is disconnected, the event is repeatedly fired on what seems to be a safe interval)

**NOTE: The templates have not been adjusted because they point to the last released version. There should be a ticket to adjust them accordingly upon the next major version release.** It will be linked here when created