### PR TITLE
[RSDK-7801] Update sensorerr with esperr

### DIFF
--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -19,13 +19,11 @@ use super::i2c::I2CErrors;
 
 use thiserror::Error;
 
-
 #[cfg(feature = "data")]
 use crate::{
     google::protobuf::Timestamp,
     proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata},
 };
-
 
 pub static COMPONENT_NAME: &str = "sensor";
 

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -25,6 +25,9 @@ use crate::{
     proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata},
 };
 
+#[cfg(feature = "esp32")]
+use crate::esp32::esp_idf_svc::sys::EspError as SysEspError;
+
 pub static COMPONENT_NAME: &str = "sensor";
 
 #[derive(Debug, Error)]
@@ -33,9 +36,8 @@ pub enum SensorError {
     AnalogError(#[from] AnalogError),
     #[error("sensor config error: {0}")]
     ConfigError(&'static str),
-    #[cfg(feature = "esp32")]
     #[error(transparent)]
-    EspError(#[from] crate::esp32::esp_idf_svc::sys::EspError),
+    EspError(#[from] SysEspError),
     #[error(transparent)]
     SensorI2CError(#[from] I2CErrors),
     #[error("{0}")]

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 #[cfg(feature = "esp32")]
-use crate::esp32::esp_idf_svc::sys::EspError as SysEspError;
+use crate::esp32::esp_idf_svc::sys::EspError;
 
 pub static COMPONENT_NAME: &str = "sensor";
 
@@ -37,7 +37,8 @@ pub enum SensorError {
     #[error("sensor config error: {0}")]
     ConfigError(&'static str),
     #[error(transparent)]
-    EspError(#[from] SysEspError),
+    #[cfg(feature = "esp32")]
+    EspError(#[from] EspError),
     #[error(transparent)]
     SensorI2CError(#[from] I2CErrors),
     #[error("{0}")]

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -19,11 +19,13 @@ use super::i2c::I2CErrors;
 
 use thiserror::Error;
 
+
 #[cfg(feature = "data")]
 use crate::{
     google::protobuf::Timestamp,
     proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata},
 };
+
 
 pub static COMPONENT_NAME: &str = "sensor";
 
@@ -33,6 +35,9 @@ pub enum SensorError {
     AnalogError(#[from] AnalogError),
     #[error("sensor config error: {0}")]
     ConfigError(&'static str),
+    #[cfg(feature = "esp32")]
+    #[error(transparent)]
+    EspError(#[from] crate::esp32::esp_idf_svc::sys::EspError),
     #[error(transparent)]
     SensorI2CError(#[from] I2CErrors),
     #[error("{0}")]


### PR DESCRIPTION
- this change is in conjuction with updating the micro-rdk-esp32-sensor-examples pr 
- Support #from EspError for SensorError