### PR TITLE
RSDK-7582 Robot configuration caching

### DIFF
--- a/micro-rdk/src/common/app_client.rs
+++ b/micro-rdk/src/common/app_client.rs
@@ -254,9 +254,9 @@ impl AppClient {
     // taken from its header for the purposes of timestamping configuration logs and returning
     // `last_reconfigured` values for resource statuses.
     pub async fn get_config(
-        &self,
+        &mut self,
         ip: Ipv4Addr,
-    ) -> Result<(Box<ConfigResponse>, Option<DateTime<FixedOffset>>), AppClientError> {
+    ) -> Result<(AppClientConfig, Box<ConfigResponse>, Option<DateTime<FixedOffset>>), AppClientError> {
         let agent = AgentInfo {
             os: "esp32".to_string(),
             host: "esp32".to_string(),
@@ -293,9 +293,14 @@ impl AppClient {
             None
         };
 
-        let r = r.split_off(5);
+        let cfg_response = ConfigResponse::decode(r.split_off(5))?;
+        if let Some(robot_config) = cfg_response.config.as_ref() {
+            if let Some(cloud_config) = robot_config.cloud.as_ref() {
+                self.config.set_rpc_host(cloud_config.fqdn.clone());
+            }
+        }
 
-        Ok((Box::new(ConfigResponse::decode(r)?), datetime))
+        Ok((self.config.clone(), Box::new(cfg_response), datetime))
     }
 
     pub async fn push_logs(&self, logs: Vec<LogEntry>) -> Result<(), AppClientError> {

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -363,7 +363,7 @@ where
 
         // Let the robot register any periodic app client tasks it may
         // have based on its configuration.
-        self.app_client_tasks.append(&mut robot.lock().unwrap().generate_periodic_app_client_tasks());
+        self.app_client_tasks.append(&mut robot.lock().unwrap().get_periodic_app_client_tasks());
 
         // Convert each `PeriodicAppClientTask` implementer into an async task spawned on the
         // executor, and collect them all into `_app_client_tasks` so we don't lose track of them.

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -361,6 +361,10 @@ where
             self.app_client.write().await.replace(app_client);
         }
 
+        // Let the robot register any periodic app client tasks it may
+        // have based on its configuration.
+        self.app_client_tasks.append(&mut robot.lock().unwrap().generate_periodic_app_client_tasks());
+
         // Convert each `PeriodicAppClientTask` implementer into an async task spawned on the
         // executor, and collect them all into `_app_client_tasks` so we don't lose track of them.
         let _app_client_tasks: Vec<_> = self

--- a/micro-rdk/src/common/conn/server.rs
+++ b/micro-rdk/src/common/conn/server.rs
@@ -223,8 +223,6 @@ where
             .unwrap()
             .into();
 
-        self.app_config.set_rpc_host(cfg.fqdn.clone());
-
         self.mdns
             .set_hostname(&cfg.name)
             .map_err(|e| ServerError::Other(e.into()))?;
@@ -356,8 +354,12 @@ where
             network,
         }
     }
-    pub async fn serve(&mut self, robot: Arc<Mutex<LocalRobot>>) {
+    pub async fn serve(&mut self, robot: Arc<Mutex<LocalRobot>>, app_client: Option<AppClient>) {
         let cloned_robot = robot.clone();
+
+        if let Some(app_client) = app_client {
+            self.app_client.write().await.replace(app_client);
+        }
 
         // Convert each `PeriodicAppClientTask` implementer into an async task spawned on the
         // executor, and collect them all into `_app_client_tasks` so we don't lose track of them.

--- a/micro-rdk/src/common/data_manager.rs
+++ b/micro-rdk/src/common/data_manager.rs
@@ -1,6 +1,5 @@
 use std::pin::Pin;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use crate::common::data_collector::{DataCollectionError, DataCollector};
@@ -11,7 +10,7 @@ use crate::proto::app::data_sync::v1::{
 };
 use crate::proto::app::v1::ConfigResponse;
 
-use super::app_client::{AppClient, AppClientConfig, AppClientError, PeriodicAppClientTask};
+use super::app_client::{AppClient, AppClientError, PeriodicAppClientTask};
 use super::data_collector::ResourceMethodKey;
 use super::data_store::{DataStoreError, DataStoreReader, WriteMode};
 use super::robot::{LocalRobot, RobotError};
@@ -85,7 +84,7 @@ pub struct DataManager<StoreType> {
     store: Rc<AsyncMutex<StoreType>>,
     sync_interval: Duration,
     min_interval: Duration,
-    part_id: String,
+    robot_part_id: String,
 }
 
 impl<StoreType> DataManager<StoreType>
@@ -96,7 +95,7 @@ where
         collectors: Vec<DataCollector>,
         store: StoreType,
         sync_interval: Duration,
-        part_id: String,
+        robot_part_id: String,
     ) -> Result<Self, DataManagerError> {
         let intervals = collectors.iter().map(|x| x.time_interval());
         let min_interval = intervals.min().ok_or(DataManagerError::NoCollectors)?;
@@ -105,23 +104,21 @@ where
             store: Rc::new(AsyncMutex::new(store)),
             sync_interval,
             min_interval,
-            part_id,
+            robot_part_id,
         })
     }
 
     pub fn from_robot_and_config(
+        robot: &LocalRobot,
         cfg: &ConfigResponse,
-        app_config: &AppClientConfig,
-        robot: Arc<Mutex<LocalRobot>>,
     ) -> Result<Option<Self>, DataManagerError> {
-        let part_id = app_config.get_robot_id();
         let sync_interval = get_data_sync_interval(cfg)?;
         if let Some(sync_interval) = sync_interval {
-            let collectors = robot.lock().unwrap().data_collectors()?;
+            let collectors = robot.data_collectors()?;
             let collector_keys: Vec<ResourceMethodKey> =
                 collectors.iter().map(|c| c.resource_method_key()).collect();
             let store = StoreType::from_resource_method_keys(collector_keys)?;
-            let data_manager_svc = DataManager::new(collectors, store, sync_interval, part_id)?;
+            let data_manager_svc = DataManager::new(collectors, store, sync_interval, robot.part_id.clone())?;
             Ok(Some(data_manager_svc))
         } else {
             Ok(None)
@@ -137,7 +134,7 @@ where
     }
 
     pub fn part_id(&self) -> String {
-        self.part_id.clone()
+        self.robot_part_id.clone()
     }
 
     pub(crate) fn collection_intervals(&self) -> Vec<u64> {

--- a/micro-rdk/src/common/entry.rs
+++ b/micro-rdk/src/common/entry.rs
@@ -1,7 +1,36 @@
+#[cfg(feature = "esp32")]
+use crate::esp32::exec::Esp32Executor;
+#[cfg(feature = "native")]
+use crate::native::exec::NativeExecutor;
+
+use super::app_client::{AppClient, AppClientBuilder, AppClientConfig};
+use super::conn::server::TlsClientConnector;
+use super::grpc_client::GrpcClient;
+use super::provisioning::storage::RobotCredentials;
 use super::registry::ComponentRegistry;
 use super::robot::LocalRobot;
 
 pub enum RobotRepresentation {
     WithRobot(LocalRobot),
     WithRegistry(Box<ComponentRegistry>),
+}
+
+#[cfg(feature = "native")]
+type Executor = NativeExecutor;
+#[cfg(feature = "esp32")]
+type Executor = Esp32Executor;
+pub async fn validate_robot_credentials(
+    exec: Executor,
+    robot_creds: &RobotCredentials,
+    client_connector: &mut impl TlsClientConnector,
+) -> Result<AppClient, Box<dyn std::error::Error>> {
+    let app_config = AppClientConfig::new(
+        robot_creds.robot_secret().to_owned(),
+        robot_creds.robot_id().to_owned(),
+        "".to_owned(),
+    );
+    let client = GrpcClient::new(client_connector.connect().await?, exec.clone(), "https://app.viam.com:443").await?;
+    let builder = AppClientBuilder::new(Box::new(client), app_config.clone());
+
+    builder.build().await.map_err(|e| e.into())
 }

--- a/micro-rdk/src/common/provisioning/storage.rs
+++ b/micro-rdk/src/common/provisioning/storage.rs
@@ -3,7 +3,10 @@ use std::{convert::Infallible, error::Error, fmt::Debug, rc::Rc, sync::Mutex};
 
 use crate::{
     common::grpc::ServerError,
-    proto::provisioning::v1::{CloudConfig, SetNetworkCredentialsRequest},
+    proto::{
+        app::v1::RobotConfig,
+        provisioning::v1::{CloudConfig, SetNetworkCredentialsRequest},
+    },
 };
 
 #[derive(Clone, Default, Debug)]
@@ -63,17 +66,23 @@ pub trait WifiCredentialStorage {
     fn reset_wifi_credentials(&self) -> Result<(), Self::Error>;
 }
 
-pub trait RobotCredentialStorage {
+pub trait RobotConfigurationStorage {
     type Error: Error + Debug + Into<ServerError>;
-    fn has_stored_credentials(&self) -> bool;
+    fn has_robot_credentials(&self) -> bool;
     fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error>;
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error>;
     fn reset_robot_credentials(&self) -> Result<(), Self::Error>;
+
+    fn has_robot_configuration(&self) -> bool;
+    fn store_robot_configuration(&self, cfg: RobotConfig) -> Result<(), Self::Error>;
+    fn get_robot_configuration(&self) -> Result<RobotConfig, Self::Error>;
+    fn reset_robot_configuration(&self) -> Result<(), Self::Error>;
 }
 
 #[derive(Default)]
 struct RAMCredentialStorageInner {
-    config: Option<RobotCredentials>,
+    robot_creds: Option<RobotCredentials>,
+    robot_config: Option<RobotConfig>,
     wifi_creds: Option<WifiCredentials>,
 }
 
@@ -83,7 +92,7 @@ pub struct RAMStorage(Rc<Mutex<RAMCredentialStorageInner>>);
 
 impl RAMStorage {
     pub fn new(ssid: &str, pass: &str, robot_id: &str, robot_secret: &str) -> Self {
-        let config = RobotCredentials {
+        let robot_creds = RobotCredentials {
             robot_id: robot_id.to_owned(),
             robot_secret: robot_secret.to_owned(),
         };
@@ -92,32 +101,55 @@ impl RAMStorage {
             pwd: pass.to_owned(),
         };
         Self(Rc::new(Mutex::new(RAMCredentialStorageInner {
-            config: Some(config),
+            robot_creds: Some(robot_creds),
+            robot_config: None,
             wifi_creds: Some(wifi_creds),
         })))
     }
 }
 
-impl RobotCredentialStorage for RAMStorage {
+impl RobotConfigurationStorage for RAMStorage {
     type Error = Infallible;
-    fn has_stored_credentials(&self) -> bool {
+    fn has_robot_credentials(&self) -> bool {
         let inner_ref = self.0.lock().unwrap();
-        inner_ref.config.is_some()
+        inner_ref.robot_config.is_some()
     }
     fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error> {
         let creds: RobotCredentials = cfg.into();
         let mut inner_ref = self.0.lock().unwrap();
-        let _ = inner_ref.config.insert(creds);
+        let _ = inner_ref.robot_creds.insert(creds);
         Ok(())
     }
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
         let inner_ref = self.0.lock().unwrap();
-        let cfg = inner_ref.config.clone().unwrap_or_default().clone();
+        let cfg = inner_ref.robot_creds.clone().unwrap_or_default().clone();
         Ok(cfg)
     }
     fn reset_robot_credentials(&self) -> Result<(), Self::Error> {
         let mut inner_ref = self.0.lock().unwrap();
-        let _ = inner_ref.config.take();
+        let _ = inner_ref.robot_creds.take();
+        Ok(())
+    }
+
+    fn has_robot_configuration(&self) -> bool {
+        self.0.lock().unwrap().robot_config.is_some()
+    }
+    fn store_robot_configuration(&self, cfg: RobotConfig) -> Result<(), Self::Error> {
+        let _ = self.0.lock().unwrap().robot_config.insert(cfg);
+        Ok(())
+    }
+    fn get_robot_configuration(&self) -> Result<RobotConfig, Self::Error> {
+        Ok(self
+            .0
+            .lock()
+            .unwrap()
+            .robot_config
+            .clone()
+            .unwrap_or_default()
+            .clone())
+    }
+    fn reset_robot_configuration(&self) -> Result<(), Self::Error> {
+        let _ = self.0.lock().unwrap().robot_config.take();
         Ok(())
     }
 }

--- a/micro-rdk/src/common/provisioning/storage.rs
+++ b/micro-rdk/src/common/provisioning/storage.rs
@@ -112,7 +112,7 @@ impl RobotConfigurationStorage for RAMStorage {
     type Error = Infallible;
     fn has_robot_credentials(&self) -> bool {
         let inner_ref = self.0.lock().unwrap();
-        inner_ref.robot_config.is_some()
+        inner_ref.robot_creds.is_some()
     }
     fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error> {
         let creds: RobotCredentials = cfg.into();

--- a/micro-rdk/src/common/provisioning/storage.rs
+++ b/micro-rdk/src/common/provisioning/storage.rs
@@ -11,16 +11,21 @@ use crate::{
 
 #[derive(Clone, Default, Debug)]
 pub struct RobotCredentials {
-    pub(crate) robot_secret: String,
     pub(crate) robot_id: String,
+    pub(crate) robot_secret: String,
 }
 
 impl RobotCredentials {
-    pub(crate) fn robot_secret(&self) -> &str {
-        &self.robot_secret
+    pub fn new(robot_id: String, robot_secret: String) -> Self{
+        Self { robot_secret, robot_id }
     }
+
     pub(crate) fn robot_id(&self) -> &str {
         &self.robot_id
+    }
+
+    pub(crate) fn robot_secret(&self) -> &str {
+        &self.robot_secret
     }
 }
 
@@ -33,21 +38,6 @@ impl From<SetNetworkCredentialsRequest> for WifiCredentials {
     }
 }
 
-#[derive(Clone, Default)]
-pub struct WifiCredentials {
-    pub(crate) ssid: String,
-    pub(crate) pwd: String,
-}
-
-impl WifiCredentials {
-    pub(crate) fn wifi_ssid(&self) -> &str {
-        &self.ssid
-    }
-    pub(crate) fn wifi_pwd(&self) -> &str {
-        &self.pwd
-    }
-}
-
 impl From<CloudConfig> for RobotCredentials {
     fn from(value: CloudConfig) -> Self {
         // TODO: make ticket : ignore app_address for now but need to add it later
@@ -55,6 +45,36 @@ impl From<CloudConfig> for RobotCredentials {
             robot_id: value.id,
             robot_secret: value.secret,
         }
+    }
+}
+
+impl From<RobotCredentials> for CloudConfig {
+    fn from(value: RobotCredentials) -> Self {
+        Self {
+            app_address: "".to_string(),
+            id: value.robot_id,
+            secret: value.robot_secret,
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct WifiCredentials {
+    pub(crate) ssid: String,
+    pub(crate) pwd: String,
+}
+
+impl WifiCredentials {
+    pub fn new(ssid: String, pwd: String) -> Self {
+        Self {
+            ssid, pwd
+        }
+    }
+    pub(crate) fn wifi_ssid(&self) -> &str {
+        &self.ssid
+    }
+    pub(crate) fn wifi_pwd(&self) -> &str {
+        &self.pwd
     }
 }
 

--- a/micro-rdk/src/common/registry.rs
+++ b/micro-rdk/src/common/registry.rs
@@ -133,6 +133,7 @@ type GenericComponentConstructor =
 
 type DependenciesFromConfig = dyn Fn(ConfigType) -> Vec<ResourceKey>;
 
+#[derive(Clone)]
 pub struct ComponentRegistry {
     motors: Map<&'static str, &'static MotorConstructor>,
     board: Map<&'static str, &'static BoardConstructor>,

--- a/micro-rdk/src/common/registry.rs
+++ b/micro-rdk/src/common/registry.rs
@@ -169,7 +169,7 @@ impl Default for ComponentRegistry {
             #[cfg(feature = "camera")]
             crate::common::camera::register_models(&mut r);
         }
-        #[cfg(esp32)]
+        #[cfg(feature = "esp32")]
         {
             crate::esp32::board::register_models(&mut r);
             #[cfg(feature = "builtin-components")]

--- a/micro-rdk/src/esp32/entry.rs
+++ b/micro-rdk/src/esp32/entry.rs
@@ -103,6 +103,7 @@ pub async fn serve_web_inner<S>(
         RobotRepresentation::WithRegistry(registry) => {
             log::info!("building robot from config");
             let r = match LocalRobot::from_cloud_config(
+                exec.clone(),
                 app_config.get_robot_id(),
                 &cfg_response,
                 registry,
@@ -210,6 +211,7 @@ where
                 if let RobotRepresentation::WithRegistry(ref registry) = repr {
                     log::info!("Found cached robot configuration; speculatively building robot from config");
                     match LocalRobot::from_cloud_config(
+                        exec.clone(),
                         storage.get_robot_credentials().unwrap().robot_id,
                         &ConfigResponse {
                             config: Some(storage.get_robot_configuration().unwrap()),
@@ -393,6 +395,7 @@ where
                 if let RobotRepresentation::WithRegistry(ref registry) = repr {
                     log::info!("Found cached robot configuration; speculatively building robot from config");
                     match LocalRobot::from_cloud_config(
+                        exec.clone(),
                         storage.get_robot_credentials().unwrap().robot_id,
                         &ConfigResponse {
                             config: Some(storage.get_robot_configuration().unwrap()),

--- a/micro-rdk/src/esp32/entry.rs
+++ b/micro-rdk/src/esp32/entry.rs
@@ -41,7 +41,7 @@ use esp_idf_svc::sys::{settimeofday, timeval};
 use crate::common::{
     grpc::ServerError,
     provisioning::server::ProvisioningInfo,
-    provisioning::storage::{RobotCredentialStorage, WifiCredentialStorage},
+    provisioning::storage::{RobotConfigurationStorage, WifiCredentialStorage},
 };
 
 pub async fn serve_web_inner(
@@ -251,9 +251,9 @@ async fn serve_async<S>(
     max_webrtc_connection: usize,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     use crate::{
@@ -271,7 +271,7 @@ where
 
     let network = loop {
         // Credentials are present let's check we can connect
-        if storage.has_stored_credentials() && storage.has_wifi_credentials() {
+        if storage.has_robot_credentials() && storage.has_wifi_credentials() {
             let mut network =
                 Esp32WifiNetwork::new(storage.get_wifi_credentials().unwrap()).await?;
             let validated = loop {
@@ -342,9 +342,9 @@ async fn serve_async_with_external_network<S>(
     max_webrtc_connection: usize,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     use crate::common::provisioning::server::serve_provisioning_async;
@@ -356,7 +356,7 @@ where
 
     loop {
         // Credentials are present let's check we can connect
-        if storage.has_stored_credentials() {
+        if storage.has_robot_credentials() {
             let validated = loop {
                 // should check internet when implementing Cached Config
                 if let Err(error) = network.is_connected() {
@@ -417,9 +417,9 @@ pub fn serve_web<S>(
     max_webrtc_connection: usize,
     storage: S,
 ) where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     // set the TWDT to expire after 5 minutes
@@ -466,9 +466,9 @@ pub fn serve_web_with_external_network<S>(
     storage: S,
     network: impl Network,
 ) where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     // set the TWDT to expire after 5 minutes

--- a/micro-rdk/src/esp32/entry.rs
+++ b/micro-rdk/src/esp32/entry.rs
@@ -225,6 +225,11 @@ pub async fn serve_web_inner<S>(
         builder.build(&cfg_response).unwrap()
     };
 
+    // Attempt to cache the config for the machine we are about to `serve`.
+    if let Err(e) = storage.store_robot_configuration(cfg_response.config.unwrap()) {
+        log::warn!("Failed to store robot configuration: {}", e);
+    }
+
     futures_lite::future::zip(Box::pin(srv.serve(robot)), data_future).await;
 }
 

--- a/micro-rdk/src/esp32/entry.rs
+++ b/micro-rdk/src/esp32/entry.rs
@@ -134,18 +134,6 @@ pub async fn serve_web_inner<S>(
         }
     };
 
-
-    // #[cfg(feature = "data")]
-    // let data_future = Box::pin(async move {
-    //     if let Some(mut data_manager_svc) = data_manager_svc {
-    //         if let Err(err) = data_manager_svc.data_collection_task().await {
-    //             log::error!("error running data manager: {:?}", err)
-    //         }
-    //     }
-    // });
-    // #[cfg(not(feature = "data"))]
-    // let data_future = async move {};
-
     let webrtc_certificate = Rc::new(webrtc_certificate);
     let dtls = Esp32DtlsBuilder::new(webrtc_certificate.clone());
 

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -1,17 +1,21 @@
 #![allow(dead_code)]
+use bytes::Bytes;
+use prost::{DecodeError, Message};
 use std::{cell::RefCell, rc::Rc};
-
-use esp_idf_svc::{
-    nvs::{EspCustomNvs, EspCustomNvsPartition, EspNvs},
-    sys::EspError,
-};
 use thiserror::Error;
 
-use crate::common::{
-    grpc::{GrpcError, ServerError},
-    provisioning::storage::{
-        RobotCredentialStorage, RobotCredentials, WifiCredentialStorage, WifiCredentials,
+use crate::{
+    common::{
+        grpc::{GrpcError, ServerError},
+        provisioning::storage::{
+            RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage, WifiCredentials,
+        },
     },
+    esp32::esp_idf_svc::{
+        nvs::{EspCustomNvs, EspCustomNvsPartition, EspNvs},
+        sys::EspError,
+    },
+    proto::{app::v1::RobotConfig, provisioning::v1::CloudConfig},
 };
 
 #[derive(Error, Debug)]
@@ -20,6 +24,8 @@ pub enum NVSStorageError {
     EspError(#[from] EspError),
     #[error("nvs key {0} is absent")]
     NVSKeyAbsent(&'static str),
+    #[error(transparent)]
+    NVSValueDecodeError(#[from] DecodeError),
 }
 
 #[derive(Clone)]
@@ -58,9 +64,23 @@ impl NVSStorage {
         let nvs = self.nvs.borrow();
         Ok(nvs.str_len(key)?.is_some())
     }
+    fn get_blob(&self, key: &'static str) -> Result<Vec<u8>, NVSStorageError> {
+        let nvs = self.nvs.borrow_mut();
+        let len = nvs
+            .blob_len(key)?
+            .ok_or(NVSStorageError::NVSKeyAbsent(key))?;
+        let mut buf = vec![0_u8; len];
+        nvs.get_blob(key, buf.as_mut_slice())?
+            .ok_or(NVSStorageError::NVSKeyAbsent(key))?;
+        Ok(buf)
+    }
+    fn set_blob(&self, key: &str, bytes: Bytes) -> Result<(), NVSStorageError> {
+        let mut nvs = self.nvs.borrow_mut();
+        Ok(nvs.set_blob(key, bytes.as_ref())?)
+    }
+
     fn has_key(&self, key: &str) -> Result<bool, NVSStorageError> {
         let nvs = self.nvs.borrow();
-
         Ok(nvs.contains(key)?)
     }
     fn erase_key(&self, key: &str) -> Result<(), NVSStorageError> {
@@ -69,9 +89,10 @@ impl NVSStorage {
         Ok(())
     }
 }
-impl RobotCredentialStorage for NVSStorage {
+
+impl RobotConfigurationStorage for NVSStorage {
     type Error = NVSStorageError;
-    fn has_stored_credentials(&self) -> bool {
+    fn has_robot_credentials(&self) -> bool {
         self.has_str("ROBOT_SECRET").unwrap_or(false) && self.has_str("ROBOT_ID").unwrap_or(false)
     }
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
@@ -82,10 +103,7 @@ impl RobotCredentialStorage for NVSStorage {
             robot_id,
         })
     }
-    fn store_robot_credentials(
-        &self,
-        cfg: crate::proto::provisioning::v1::CloudConfig,
-    ) -> Result<(), Self::Error> {
+    fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error> {
         self.set_string("ROBOT_SECRET", &cfg.secret)?;
         self.set_string("ROBOT_ID", &cfg.id)?;
         Ok(())
@@ -93,6 +111,22 @@ impl RobotCredentialStorage for NVSStorage {
     fn reset_robot_credentials(&self) -> Result<(), Self::Error> {
         self.erase_key("ROBOT_SECRET")?;
         self.erase_key("ROBOT_ID")?;
+        Ok(())
+    }
+
+    fn has_robot_configuration(&self) -> bool {
+        self.has_str("ROBOT_CONFIG").unwrap_or(false)
+    }
+    fn store_robot_configuration(&self, cfg: RobotConfig) -> Result<(), Self::Error> {
+        self.set_blob("ROBOT_CONFIG", cfg.encode_to_vec().into())?;
+        Ok(())
+    }
+    fn get_robot_configuration(&self) -> Result<RobotConfig, Self::Error> {
+        let robot_config = self.get_blob("ROBOT_CONFIG")?;
+        RobotConfig::decode(&robot_config[..]).map_err(|e| NVSStorageError::NVSValueDecodeError(e))
+    }
+    fn reset_robot_configuration(&self) -> Result<(), Self::Error> {
+        self.erase_key("ROBOT_CONFIG")?;
         Ok(())
     }
 }

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -136,7 +136,7 @@ impl RobotConfigurationStorage for NVSStorage {
     }
 
     fn has_robot_configuration(&self) -> bool {
-        self.has_string(NVS_ROBOT_CONFIG_KEY).unwrap_or(false)
+        self.has_blob(NVS_ROBOT_CONFIG_KEY).unwrap_or(false)
     }
 
     fn store_robot_configuration(&self, cfg: RobotConfig) -> Result<(), Self::Error> {

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -187,6 +187,11 @@ pub async fn serve_web_inner<S>(
         builder.build(&cfg_response).unwrap()
     };
 
+    // Attempt to cache the config for the machine we are about to `serve`.
+    if let Err(e) = storage.store_robot_configuration(cfg_response.config.unwrap()) {
+        log::warn!("Failed to store robot configuration: {}", e);
+    }
+
     futures_lite::future::zip(Box::pin(srv.serve(robot)), data_future).await;
 }
 

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -27,7 +27,7 @@ use crate::common::{
     grpc::ServerError,
     provisioning::{
         server::ProvisioningInfo,
-        storage::{RobotCredentialStorage, WifiCredentialStorage},
+        storage::{RobotConfigurationStorage, WifiCredentialStorage},
     },
 };
 
@@ -210,9 +210,9 @@ async fn serve_async_with_external_network<S>(
     max_webrtc_connection: usize,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     use std::time::Duration;
@@ -230,7 +230,7 @@ where
         // if so we can move ahead and confirm the robot exists
         // Since the network is not managed by us we should just check if robot
         // credentials are stored
-        if storage.has_stored_credentials() {
+        if storage.has_robot_credentials() {
             let validated = loop {
                 // When we have cached config we should still continue in the event the network
                 // fails
@@ -293,9 +293,9 @@ pub fn serve_web_with_external_network<S>(
     storage: S,
     network: impl Network,
 ) where
-    S: RobotCredentialStorage + WifiCredentialStorage + Clone + 'static,
-    <S as RobotCredentialStorage>::Error: Debug,
-    ServerError: From<<S as RobotCredentialStorage>::Error>,
+    S: RobotConfigurationStorage + WifiCredentialStorage + Clone + 'static,
+    <S as RobotConfigurationStorage>::Error: Debug,
+    ServerError: From<<S as RobotConfigurationStorage>::Error>,
     <S as WifiCredentialStorage>::Error: Sync + Send + 'static,
 {
     let exec = NativeExecutor::new();

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -72,6 +72,7 @@ pub async fn serve_web_inner<S>(
         RobotRepresentation::WithRegistry(registry) => {
             log::info!("building robot from config");
             let r = match LocalRobot::from_cloud_config(
+                exec.clone(),
                 app_config.get_robot_id(),
                 &cfg_response,
                 registry,
@@ -102,18 +103,6 @@ pub async fn serve_web_inner<S>(
             Arc::new(Mutex::new(r))
         }
     };
-
-
-    // #[cfg(feature = "data")]
-    // let data_future = Box::pin(async move {
-    //     if let Some(mut data_manager_svc) = data_manager_svc {
-    //         if let Err(err) = data_manager_svc.data_collection_task().await {
-    //             log::error!("error running data manager: {:?}", err)
-    //         }
-    //     }
-    // });
-    // #[cfg(not(feature = "data"))]
-    // let data_future = async move {};
 
     let address: SocketAddr = "0.0.0.0:12346".parse().unwrap();
     let tls = Box::new(NativeTls::new_server(tls_server_config));
@@ -179,6 +168,7 @@ where
                 if let RobotRepresentation::WithRegistry(ref registry) = repr {
                     log::info!("Found cached robot configuration; speculatively building robot from config");
                     match LocalRobot::from_cloud_config(
+                        exec.clone(),
                         storage.get_robot_credentials().unwrap().robot_id,
                         &ConfigResponse {
                             config: Some(storage.get_robot_configuration().unwrap()),

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     common::{
-        app_client::{AppClient, AppClientConfig, AppClientError},
+        app_client::{AppClient, AppClientError},
         conn::{
             network::Network,
             server::{TlsClientConnector, ViamServerBuilder, WebRtcConfiguration},
@@ -22,12 +22,15 @@ use std::{
 };
 
 #[cfg(feature = "provisioning")]
-use crate::common::{
-    grpc::ServerError,
-    provisioning::{
-        server::ProvisioningInfo,
-        storage::{RobotConfigurationStorage, WifiCredentialStorage},
+use crate::{
+    common::{
+        grpc::ServerError,
+        provisioning::{
+            server::ProvisioningInfo,
+            storage::{RobotConfigurationStorage, WifiCredentialStorage},
+        },
     },
+    proto::app::v1::ConfigResponse,
 };
 
 #[cfg(feature = "provisioning")]
@@ -175,7 +178,7 @@ async fn serve_async_with_external_network<S>(
     exec: NativeExecutor,
     info: Option<ProvisioningInfo>,
     storage: S,
-    repr: RobotRepresentation,
+    mut repr: RobotRepresentation,
     network: impl Network,
     max_webrtc_connection: usize,
 ) -> Result<(), Box<dyn std::error::Error>>
@@ -195,14 +198,23 @@ where
     let info = info.unwrap_or_default();
     let mut last_error: Option<Box<dyn std::error::Error>> = None;
 
-    let (_robot, app_client) = 'provisioned: loop {
+    let app_client = 'provisioned: loop {
         if storage.has_robot_credentials() {
             log::info!("Found cached robot credentials; attempting to serve");
 
-            let mut robot = None;
             if storage.has_robot_configuration() {
-                log::info!("Found cached robot configuration; speculatively building robot");
-                let _ = robot.insert(());
+                if let RobotRepresentation::WithRegistry(ref registry) = repr {
+                    log::info!("Found cached robot configuration; speculatively building robot from config");
+                    match LocalRobot::from_cloud_config(&ConfigResponse { config : Some(storage.get_robot_configuration().unwrap()) }, registry.clone(), None) {
+                        Ok(robot) => {
+                            repr = RobotRepresentation::WithRobot(robot);
+                        }
+                        Err(e) => {
+                            log::warn!("Failed building robot from cached robot configuration: {}; dropping and ignoring cached config", e);
+                            let _ = storage.reset_robot_configuration();
+                        }
+                    };
+                }
             }
 
             let mut duration = None;
@@ -224,7 +236,7 @@ where
                 {
                     Ok(app_client) => {
                         log::info!("Robot credentials validated OK");
-                        break 'provisioned (robot, app_client);
+                        break 'provisioned app_client;
                     }
                     Err(e) => {
                         if let Some(app_client_error) = e.downcast_ref::<AppClientError>() {

--- a/micro-rdk/src/native/entry.rs
+++ b/micro-rdk/src/native/entry.rs
@@ -41,9 +41,6 @@ use super::{
     tls::NativeTlsServerConfig,
 };
 
-#[cfg(feature = "data")]
-use crate::common::{data_manager::DataManager, data_store::StaticMemoryDataStore};
-
 pub async fn serve_web_inner<S>(
     storage: S,
     repr: RobotRepresentation,
@@ -74,64 +71,49 @@ pub async fn serve_web_inner<S>(
         RobotRepresentation::WithRobot(robot) => Arc::new(Mutex::new(robot)),
         RobotRepresentation::WithRegistry(registry) => {
             log::info!("building robot from config");
-            let r =
-                match LocalRobot::from_cloud_config(&cfg_response, registry, cfg_received_datetime)
-                {
-                    Ok(robot) => {
-                        if let Some(datetime) = cfg_received_datetime {
-                            let logs = vec![config_log_entry(datetime, None)];
-                            app_client
-                                .push_logs(logs)
-                                .await
-                                .expect("could not push logs to app");
-                        }
-                        robot
+            let r = match LocalRobot::from_cloud_config(
+                app_config.get_robot_id(),
+                &cfg_response,
+                registry,
+                cfg_received_datetime,
+            ) {
+                Ok(robot) => {
+                    if let Some(datetime) = cfg_received_datetime {
+                        let logs = vec![config_log_entry(datetime, None)];
+                        app_client
+                            .push_logs(logs)
+                            .await
+                            .expect("could not push logs to app");
                     }
-                    Err(err) => {
-                        if let Some(datetime) = cfg_received_datetime {
-                            let logs = vec![config_log_entry(datetime, Some(err))];
-                            app_client
-                                .push_logs(logs)
-                                .await
-                                .expect("could not push logs to app");
-                        }
-                        //TODO shouldn't panic here, when we support offline mode and reloading configuration this should be removed
-                        panic!("couldn't build robot");
+                    robot
+                }
+                Err(err) => {
+                    if let Some(datetime) = cfg_received_datetime {
+                        let logs = vec![config_log_entry(datetime, Some(err))];
+                        app_client
+                            .push_logs(logs)
+                            .await
+                            .expect("could not push logs to app");
                     }
-                };
+                    //TODO shouldn't panic here, when we support offline mode and reloading configuration this should be removed
+                    panic!("couldn't build robot");
+                }
+            };
             Arc::new(Mutex::new(r))
         }
     };
 
-    #[cfg(feature = "data")]
-    // TODO: Support implementers of the DataStore trait other than StaticMemoryDataStore in a way that is configurable
-    let data_manager_svc = match DataManager::<StaticMemoryDataStore>::from_robot_and_config(
-        &cfg_response,
-        &app_config,
-        robot.clone(),
-    ) {
-        Ok(svc) => svc,
-        Err(err) => {
-            log::error!("error configuring data management: {:?}", err);
-            None
-        }
-    };
 
-    #[cfg(feature = "data")]
-    let data_sync_task = data_manager_svc
-        .as_ref()
-        .map(|data_manager_svc| data_manager_svc.get_sync_task());
-
-    #[cfg(feature = "data")]
-    let data_future = Box::pin(async move {
-        if let Some(mut data_manager_svc) = data_manager_svc {
-            if let Err(err) = data_manager_svc.data_collection_task().await {
-                log::error!("error running data manager: {:?}", err)
-            }
-        }
-    });
-    #[cfg(not(feature = "data"))]
-    let data_future = async move {};
+    // #[cfg(feature = "data")]
+    // let data_future = Box::pin(async move {
+    //     if let Some(mut data_manager_svc) = data_manager_svc {
+    //         if let Err(err) = data_manager_svc.data_collection_task().await {
+    //             log::error!("error running data manager: {:?}", err)
+    //         }
+    //     }
+    // });
+    // #[cfg(not(feature = "data"))]
+    // let data_future = async move {};
 
     let address: SocketAddr = "0.0.0.0:12346".parse().unwrap();
     let tls = Box::new(NativeTls::new_server(tls_server_config));
@@ -148,29 +130,20 @@ pub async fn serve_web_inner<S>(
         exec.clone(),
     ));
 
-    let mut srv = {
-        let builder =
-            ViamServerBuilder::new(mdns, cloned_exec, client_connector, app_config, 3, network)
-                .with_http2(tls_listener, 12346)
-                .with_webrtc(webrtc)
-                .with_periodic_app_client_task(Box::new(RestartMonitor::new(|| {
-                    std::process::exit(0)
-                })));
-        #[cfg(feature = "data")]
-        let builder = if let Some(task) = data_sync_task {
-            builder.with_periodic_app_client_task(Box::new(task))
-        } else {
-            builder
-        };
-        builder.build(&cfg_response).unwrap()
-    };
+    let mut srv =
+        ViamServerBuilder::new(mdns, cloned_exec, client_connector, app_config, 3, network)
+            .with_http2(tls_listener, 12346)
+            .with_webrtc(webrtc)
+            .with_periodic_app_client_task(Box::new(RestartMonitor::new(|| std::process::exit(0))))
+            .build(&cfg_response)
+            .unwrap();
 
     // Attempt to cache the config for the machine we are about to `serve`.
     if let Err(e) = storage.store_robot_configuration(cfg_response.config.unwrap()) {
         log::warn!("Failed to store robot configuration: {}", e);
     }
 
-    futures_lite::future::zip(Box::pin(srv.serve(robot, Some(app_client))), data_future).await;
+    srv.serve(robot, Some(app_client)).await;
 }
 
 #[cfg(feature = "provisioning")]
@@ -205,7 +178,14 @@ where
             if storage.has_robot_configuration() {
                 if let RobotRepresentation::WithRegistry(ref registry) = repr {
                     log::info!("Found cached robot configuration; speculatively building robot from config");
-                    match LocalRobot::from_cloud_config(&ConfigResponse { config : Some(storage.get_robot_configuration().unwrap()) }, registry.clone(), None) {
+                    match LocalRobot::from_cloud_config(
+                        storage.get_robot_credentials().unwrap().robot_id,
+                        &ConfigResponse {
+                            config: Some(storage.get_robot_configuration().unwrap()),
+                        },
+                        registry.clone(),
+                        None,
+                    ) {
                         Ok(robot) => {
                             repr = RobotRepresentation::WithRobot(robot);
                         }


### PR DESCRIPTION
This adds support for caching robot configurations.

- Support for storing a robot configuration is added to the NVS and RAM storage infra
- The `serve_web_async` family of functions will create a robot from the cached config during startup.
- The created robot will be live while the startup code attempts to connect to a network and validate credentials.
- Once the network is available, if the credentials validate, the already created robot is used. If not, it is discarded.
- The app client used to validate credentials is re-used all the way down into ViamServer::serve.

Overall, there are several things about this code that leave me less than happy. I'll note them as review comments. However, it does seem to work with the testing I've done so far. I intend to do more, but I'd like to get feedback on the overall approach here before I invest further in any testing in case a redesign or a different approach is desired.

Due to the fairly large changes required to some of the initialization code this may unfortunately be somewhat hard to review.