### PR TITLE
[RSDK-8131] Avoid killing the collector task on any error

### DIFF
--- a/micro-rdk/src/common/data_manager.rs
+++ b/micro-rdk/src/common/data_manager.rs
@@ -154,7 +154,7 @@ where
         intervals
     }
 
-    pub async fn data_collection_task(&mut self) {
+    pub async fn data_collection_task(&mut self) -> ! {
         let mut loop_counter: u64 = 0;
         loop {
             if let Err(e) = self.collect_data_inner(loop_counter).await {
@@ -192,7 +192,15 @@ where
                     e
                 ),
                 Ok(data) => {
-                    store_guard.write_message(&collector_key, data, WriteMode::OverwriteOldest)?
+                    if let Err(e) =
+                        store_guard.write_message(&collector_key, data, WriteMode::OverwriteOldest)
+                    {
+                        log::error!(
+                            "couldn't store data for collector {:?} error : {:?}",
+                            collector_key,
+                            e
+                        );
+                    }
                 }
             }
         }

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -287,7 +287,7 @@ impl LocalRobot {
                     let _ = robot
                         .data_manager_collection_task
                         .replace(robot.executor.spawn(async move {
-                            data_manager_svc.data_collection_task().await;
+                            data_manager.data_collection_task().await;
                             unreachable!()
                         }));
                 }

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -287,9 +287,8 @@ impl LocalRobot {
                     let _ = robot
                         .data_manager_collection_task
                         .replace(robot.executor.spawn(async move {
-                            if let Err(err) = data_manager.data_collection_task().await {
-                                log::error!("error running data manager: {:?}", err)
-                            }
+                            data_manager_svc.data_collection_task().await;
+                            unreachable!()
                         }));
                 }
                 Ok(None) => {}

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -288,7 +288,6 @@ impl LocalRobot {
                         .data_manager_collection_task
                         .replace(robot.executor.spawn(async move {
                             data_manager.data_collection_task().await;
-                            unreachable!()
                         }));
                 }
                 Ok(None) => {}


### PR DESCRIPTION
This fixes two issues : 
1) on any errors the collector task will not terminate and continue to attempt collecting
2) If any collector fails forever or transiently it will not  prevent collecting other records 