### PR TITLE
log ssid to output

### DIFF
--- a/micro-rdk/src/esp32/provisioning/wifi_provisioning.rs
+++ b/micro-rdk/src/esp32/provisioning/wifi_provisioning.rs
@@ -32,11 +32,16 @@ impl Default for Esp32WifiProvisioningBuilder {
         unsafe {
             sys::esp!(sys::esp_efuse_mac_get_default(mac_address.as_mut_ptr())).unwrap();
         };
+
+        let ssid = format!(
+            "esp32-micrordk-{:02X}{:02X}",
+            mac_address[4], mac_address[5]
+        );
+
+        log::info!("Provisioning SSID: {}", ssid);
+
         Self {
-            ssid: format!(
-                "esp32-micrordk-{:02X}{:02X}",
-                mac_address[4], mac_address[5]
-            ),
+            ssid,
             password: "viamsetup".to_owned(),
             ap_ip_addr: Ipv4Addr::new(10, 42, 0, 1),
         }

--- a/micro-rdk/src/esp32/provisioning/wifi_provisioning.rs
+++ b/micro-rdk/src/esp32/provisioning/wifi_provisioning.rs
@@ -38,11 +38,13 @@ impl Default for Esp32WifiProvisioningBuilder {
             mac_address[4], mac_address[5]
         );
 
-        log::info!("Provisioning SSID: {}", ssid);
+        let password = "viamsetup".to_string();
+
+        log::info!("Provisioning SSID: {} - Password: {}", ssid, password);
 
         Self {
             ssid,
-            password: "viamsetup".to_owned(),
+            password,
             ap_ip_addr: Ipv4Addr::new(10, 42, 0, 1),
         }
     }


### PR DESCRIPTION
while going through provisioning with @EshaMaharishi, we couldn't find device mac address in monitor output; tries to print MAC in monitor before MAC is set with FUSE at L33 here. This just makes things clear. should we also log the default provisioning password while we're at it?