### PR TITLE
connect to best AP

### DIFF
--- a/micro-rdk/src/esp32/conn/network.rs
+++ b/micro-rdk/src/esp32/conn/network.rs
@@ -109,7 +109,7 @@ impl Esp32WifiNetwork {
                 if let Err(e) = esp_idf_svc::sys::esp!(unsafe {
                     esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_STA, &mut sta_config as *mut _)
                 }) {
-                    log::warn!("couldn't update wifi station config {:?}", e);
+                    log::warn!("couldn't update wifi station scan/sort config {:?}", e);
                 }
             }
             Err(e) => {

--- a/micro-rdk/src/esp32/conn/network.rs
+++ b/micro-rdk/src/esp32/conn/network.rs
@@ -22,7 +22,15 @@ use {
     },
 };
 
-use esp_idf_svc::{hal::modem::WifiModem, timer::EspTaskTimerService, wifi::AsyncWifi};
+use esp_idf_svc::{
+    hal::modem::WifiModem,
+    sys::{
+        esp_interface_t_ESP_IF_WIFI_STA, esp_wifi_get_config, esp_wifi_set_config, wifi_config_t,
+        wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN, wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL,
+    },
+    timer::EspTaskTimerService,
+    wifi::AsyncWifi,
+};
 use futures_util::lock::Mutex;
 use once_cell::sync::OnceCell;
 
@@ -85,6 +93,29 @@ impl Esp32WifiNetwork {
 
         wifi.stop().await?;
         wifi.set_configuration(&config)?;
+
+        let mut sta_config = wifi_config_t::default();
+
+        // Change the connection behavior to do a full scan and selecting the AP with the
+        // strongest signal, instead of connecting to the first found AP which may not be the best
+        // AP.
+        match esp_idf_svc::sys::esp!(unsafe {
+            esp_wifi_get_config(esp_interface_t_ESP_IF_WIFI_STA, &mut sta_config as *mut _)
+        }) {
+            Ok(_) => {
+                sta_config.sta.scan_method = wifi_scan_method_t_WIFI_ALL_CHANNEL_SCAN;
+                sta_config.sta.sort_method = wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL;
+
+                if let Err(e) = esp_idf_svc::sys::esp!(unsafe {
+                    esp_wifi_set_config(esp_interface_t_ESP_IF_WIFI_STA, &mut sta_config as *mut _)
+                }) {
+                    log::warn!("couldn't update wifi station config {:?}", e);
+                }
+            }
+            Err(e) => {
+                log::warn!("couldn't get wifi station config {:?}", e);
+            }
+        }
 
         Ok(Self {
             _subscription: None,


### PR DESCRIPTION
Change the connection behavior to do a full scan and selecting the AP with the strongest signal, instead of connecting to the first found AP which may not be the best AP.