### PR TITLE
[RSDK-8201] add heap sensor as builtin component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,6 +2602,7 @@ dependencies = [
  "local-ip-address",
  "log",
  "micro-rdk",
+ "micro-rdk-modular-driver-example",
  "serde",
  "serde_json",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ log = "0.4.20"
 mdns-sd = { version = "0.10.5", default-features = false, features = ["async"] }
 micro-rdk = { path = "./micro-rdk", default-features = false, features = [] }
 micro-rdk-macros = { path = "./micro-rdk-macros" }
+micro-rdk-modular-driver-example = {path = "./examples/modular-drivers" }
 once_cell = "1.18.0"
 openssl = { version = "0.10.50" }
 pin-project = "1.1.5"

--- a/examples/modular-drivers/src/wifi_rssi_sensor.rs
+++ b/examples/modular-drivers/src/wifi_rssi_sensor.rs
@@ -20,7 +20,7 @@ use micro_rdk::{
 #[derive(DoCommand)]
 pub struct WifiRSSISensor;
 
-pub(crate) fn register_models(registry: &mut ComponentRegistry) -> Result<(), RegistryError> {
+pub fn register_models(registry: &mut ComponentRegistry) -> Result<(), RegistryError> {
     registry.register_sensor("wifi-rssi", &WifiRSSISensor::from_config)?;
     log::debug!("wifi-rssi sensor registration ok");
     Ok(())

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -18,6 +18,7 @@ qemu = []
 env_logger.workspace = true
 local-ip-address.workspace = true
 micro-rdk = { workspace = true, features = ["native", "provisioning"], default-features = true }
+micro-rdk-modular-driver-example.workspace = true
 
 
 [target.'cfg(target_os="espidf")'.dependencies]
@@ -26,7 +27,7 @@ embedded-hal.workspace = true
 embedded-svc.workspace = true
 futures-lite.workspace = true
 micro-rdk = { workspace = true, features = ["esp32", "binstart", "provisioning"], default-features = true }
-micro-rdk-modular-driver-example = {path = "../examples/modular-drivers", features = ["esp32"]}
+micro-rdk-modular-driver-example = {workspace = true, features = ["esp32"]}
 
 
 [dependencies]

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -26,10 +26,10 @@ embedded-hal.workspace = true
 embedded-svc.workspace = true
 futures-lite.workspace = true
 micro-rdk = { workspace = true, features = ["esp32", "binstart", "provisioning"], default-features = true }
+micro-rdk-modular-driver-example = {path = "../examples/modular-drivers", features = ["esp32"]}
 
 
 [dependencies]
-micro-rdk-modular-driver-example = {path = "../examples/modular-drivers", features = ["esp32"]}
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -29,6 +29,7 @@ micro-rdk = { workspace = true, features = ["esp32", "binstart", "provisioning"]
 
 
 [dependencies]
+micro-rdk-modular-driver-example = {path = "../examples/modular-drivers", features = ["esp32"]}
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -18,7 +18,6 @@ qemu = []
 env_logger.workspace = true
 local-ip-address.workspace = true
 micro-rdk = { workspace = true, features = ["native", "provisioning"], default-features = true }
-micro-rdk-modular-driver-example.workspace = true
 
 
 [target.'cfg(target_os="espidf")'.dependencies]

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -34,7 +34,11 @@ mod esp32 {
 
         micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
 
-        let repr = RobotRepresentation::WithRegistry(Box::<ComponentRegistry>::default());
+        let mut r = Box::<ComponentRegistry>::default();
+        if let Err(e) = micro_rdk_modular_driver_example::register_models(&mut r) {
+            log::error!("failed to load example drivers: {}", e);
+        }
+        let repr = RobotRepresentation::WithRegistry(r);
 
         {
             micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -35,7 +35,8 @@ mod esp32 {
         micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
 
         let mut r = Box::<ComponentRegistry>::default();
-        if let Err(e) = micro_rdk_modular_driver_example::register_models(&mut r) {
+        if let Err(e) = micro_rdk_modular_driver_example::free_heap_sensor::register_models(&mut r)
+        {
             log::error!("failed to load example drivers: {}", e);
         }
         let repr = RobotRepresentation::WithRegistry(r);

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -29,16 +29,22 @@ mod esp32 {
     use micro_rdk::common::registry::ComponentRegistry;
     use micro_rdk::esp32::nvs_storage::NVSStorage;
 
+    fn register_examples(r: &mut ComponentRegistry) {
+        if let Err(e) = micro_rdk_modular_driver_example::free_heap_sensor::register_models(r) {
+            log::error!("failed to register `free_heap_sensor`: {}", e);
+        }
+        if let Err(e) = micro_rdk_modular_driver_example::wifi_rssi_sensor::register_models(r) {
+            log::error!("failed to register `wifi_rssi_sensor`: {}", e);
+        }
+    }
+
     pub(crate) fn main_esp32() {
         micro_rdk::esp32::esp_idf_svc::sys::link_patches();
 
         micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
 
         let mut r = Box::<ComponentRegistry>::default();
-        if let Err(e) = micro_rdk_modular_driver_example::free_heap_sensor::register_models(&mut r)
-        {
-            log::error!("failed to load example drivers: {}", e);
-        }
+        register_examples(&mut r);
         let repr = RobotRepresentation::WithRegistry(r);
 
         {


### PR DESCRIPTION
This PR is just to migrate the `free_heap_sensor` from examples to the main micro-rdk builtins with minimal modifications. 

A follow-up ticket [RSDK-8353](https://viam.atlassian.net/browse/RSDK-8353) has been made to migrate builtin-sensors to a separate crate in the workspace.

Currently, it's not feature-gated from builtins due to its utility, but it may be worthwhile to eventually feature-gate this and similar tools under a `debug` flag or something. I can gate it in this PR behind the builtin-components flag if that's the concensus.

[RSDK-8353]: https://viam.atlassian.net/browse/RSDK-8353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ