### PR TITLE
Installer write flash prompt

### DIFF
--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -171,13 +171,15 @@ fn validate_version(version: &str) -> Result<String, String> {
     // With 0.1.9+ release the installer will not be backward compatible
     // with prior version, therefore we return an error letting the user know they should
     // use an older installer
-    let version_019 = version_compare::Version::from("0.1.9").unwrap();
+    if version != "latest" {
+        let version_019 = version_compare::Version::from("0.1.9").unwrap();
 
-    let requested_version = version_compare::Version::from(version)
-        .ok_or(format!("{} is not a valid version string", version))?;
+        let requested_version = version_compare::Version::from(version)
+            .ok_or(format!("{} is not a valid version string", version))?;
 
-    if requested_version < version_019 {
-        return Err(format!("this version of the installer does not support version of micro-rdk < 0.1.9. If you want to install micro-rdk {} please downgrade the installer to v0.1.8 first",version));
+        if requested_version < version_019 {
+            return Err(format!("this version of the installer does not support version of micro-rdk < 0.1.9. If you want to install micro-rdk {} please downgrade the installer to v0.1.8 first",version));
+        }
     }
     Ok(version.to_owned())
 }
@@ -356,16 +358,19 @@ fn main() -> Result<(), Error> {
             let app_path = match &args.binary_path {
                 Some(path) => PathBuf::from(path),
                 None => {
-                    let use_latest = dialoguer::Confirm::new()
-                        .with_prompt("Download and flash the latest Micro-RDK release?")
-                        .interact()
-                        .unwrap();
-                    if use_latest {
-                        let rt = Runtime::new().map_err(Error::AsyncError)?;
-                        rt.block_on(download_micro_rdk_release(&tmp_path, args.version.clone()))?
-                    } else {
-                        return Ok(());
+                    if args.version.is_none() {
+                        let use_latest = dialoguer::Confirm::new()
+                            .with_prompt("Download and flash the latest Micro-RDK release?")
+                            .default(false)
+                            .interact()
+                            .unwrap();
+                        if !use_latest {
+                            return Ok(());
+                        }
                     }
+
+                    let rt = Runtime::new().map_err(Error::AsyncError)?;
+                    rt.block_on(download_micro_rdk_release(&tmp_path, args.version.clone()))?
                 }
             };
             let config = Config::load().map_err(|err| Error::SerialConfigError(err.to_string()))?;

--- a/micro-rdk-installer/src/main.rs
+++ b/micro-rdk-installer/src/main.rs
@@ -120,8 +120,8 @@ struct WriteFlashArgs {
     /// File path to the JSON config of the robot, downloaded from app.viam.com
     #[arg(long = "app-config")]
     config: Option<String>,
-    /// Version of the compiled micro-RDK server to download.
-    /// See https://github.com/viamrobotics/micro-rdk/releases for the version options
+    /// Version of the compiled micro-RDK server to download (ex. v0.2.3, latest).
+    /// See https://github.com/viamrobotics/micro-rdk/releases for available versions
     #[arg(long = "version", value_parser = validate_version)]
     version: Option<String>,
     /// Wi-Fi SSID to write to NVS partition of binary. If not provided, user will be

--- a/micro-rdk-installer/src/nvs/request.rs
+++ b/micro-rdk-installer/src/nvs/request.rs
@@ -22,7 +22,16 @@ pub async fn download_micro_rdk_release(
                 RELEASES_BASE_URL, "latest/download", BINARY_NAME
             )
         },
-        |version| format!("{}/download/{}/{}", RELEASES_BASE_URL, version, BINARY_NAME),
+        |version| {
+            if version == "latest" {
+                format!(
+                    "{}/{}/{}",
+                    RELEASES_BASE_URL, "latest/download", BINARY_NAME
+                )
+            } else {
+                format!("{}/download/{}/{}", RELEASES_BASE_URL, version, BINARY_NAME)
+            }
+        },
     );
 
     log::info!("Downloading micro-RDK release from {:?}", release_url);

--- a/micro-rdk-installer/src/nvs/request.rs
+++ b/micro-rdk-installer/src/nvs/request.rs
@@ -15,24 +15,19 @@ pub async fn download_micro_rdk_release(
     path: &Path,
     version: Option<String>,
 ) -> Result<PathBuf, Error> {
-    let release_url = version.map_or_else(
-        || {
-            format!(
-                "{}/{}/{}",
-                RELEASES_BASE_URL, "latest/download", BINARY_NAME
-            )
-        },
-        |version| {
-            if version == "latest" {
-                format!(
-                    "{}/{}/{}",
-                    RELEASES_BASE_URL, "latest/download", BINARY_NAME
-                )
-            } else {
-                format!("{}/download/{}/{}", RELEASES_BASE_URL, version, BINARY_NAME)
-            }
-        },
-    );
+    let release_url = if version.is_none() || version.clone().unwrap() == "latest" {
+        format!(
+            "{}/{}/{}",
+            RELEASES_BASE_URL, "latest/download", BINARY_NAME
+        )
+    } else {
+        format!(
+            "{}/download/{}/{}",
+            RELEASES_BASE_URL,
+            version.unwrap(),
+            BINARY_NAME
+        )
+    };
 
     log::info!("Downloading micro-RDK release from {:?}", release_url);
     let fname = path.to_path_buf();


### PR DESCRIPTION
as `micro-rdk-installer write-flash` doesn't require a path or version to run, it will flash the device completely with the latest build immediately, overwriting stored configs.

During development, whether by poor naming of the options or me misremembering, I've had to quickly cancel so my configs don't get wiped. This prompt will give a user a chance to decline if this (or flashing with latest) is not the desired outcome.

For scripts where flashing latest is the desired behavior, `micro-rdk-installer write-flash --version latest` will work.  
