### PR TITLE
STOPGAP MEASURE - panic when too many PeriodicAppClientTasks are hanging

### DIFF
--- a/micro-rdk/src/common/app_client.rs
+++ b/micro-rdk/src/common/app_client.rs
@@ -327,6 +327,13 @@ impl AppClient {
             },
         })
     }
+
+    /// Returns the strong count of the AppClient's internal
+    /// gRPC client, serving as a rough proxy for the number of
+    /// concurrent tasks using this app client.
+    pub(crate) fn get_grpc_client_count(&self) -> usize {
+        Rc::strong_count(&self.grpc_client)
+    }
 }
 
 impl Drop for AppClient {


### PR DESCRIPTION
There is currently an instability on ESP32s that we believe is being caused by a request to the Viam App properly resolving but hanging on dropping the TLS context. This causes signaling to hang and blocks all incoming requests rendering the machine inaccessible and unable to move forward with any of its other tasks. The purpose of this PR is two-fold: we want to collect more data around the frequency with which these tasks hang and when all the tasks are in such a state we want to prompt a restart that will start of all the tasks anew. 

This is intended to be temporary until the investigation resolves and a proper fix is scoped out.