### PR TITLE
[RSDK-8612] capture and cache logs, then upload to app.viam.com

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr_core"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd98742e4fdca832d40cab219dc2e3048de17d873248f83f17df47c1bea70956"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
 name = "csv"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,6 +927,12 @@ dependencies = [
  "nix 0.28.0",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cvt"
@@ -2274,6 +2290,15 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
@@ -2506,6 +2531,7 @@ dependencies = [
  "openssl",
  "pin-project",
  "pin-project-lite",
+ "printf-compat",
  "prost",
  "rand",
  "rcgen",
@@ -3145,6 +3171,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "printf-compat"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b002af28ffe3d3d67202ae717810a28125a494d5396debc43de01ee136ac404"
+dependencies = [
+ "bitflags 1.3.2",
+ "cstr_core",
+ "cty",
+ "itertools 0.9.0",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3222,7 +3260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ once_cell = "1.18.0"
 openssl = { version = "0.10.50" }
 pin-project = "1.1.5"
 pin-project-lite = "0.2.9"
+printf-compat = "0.1.1"
 proc-macro-crate = "2.0.0"
 proc-macro2 = "1.0.67"
 prost = "0.11.0"

--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -7,6 +7,7 @@ use std::{
 use micro_rdk::common::{
     config::ConfigType,
     entry::RobotRepresentation,
+    log::initialize_logger,
     provisioning::server::ProvisioningInfo,
     registry::{ComponentRegistry, Dependency},
     sensor::{SensorError, SensorType},
@@ -206,16 +207,12 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
 
     #[cfg(not(target_os = "espidf"))]
     {
-        use log::LevelFilter;
-        env_logger::builder()
-            .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
-            .filter_level(LevelFilter::Info)
-            .init()
+        initialize_logger::<env_logger::Logger>();
     }
     #[cfg(target_os = "espidf")]
     {
         micro_rdk::esp32::esp_idf_svc::sys::link_patches();
-        micro_rdk::esp32::esp_idf_svc::log::EspLogger::initialize_default();
+        initialize_logger::<micro_rdk::esp32::esp_idf_svc::log::EspLogger>();
         micro_rdk::esp32::esp_idf_svc::sys::esp!(unsafe {
             micro_rdk::esp32::esp_idf_svc::sys::esp_vfs_eventfd_register(
                 &micro_rdk::esp32::esp_idf_svc::sys::esp_vfs_eventfd_config_t { max_fds: 5 },

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -17,6 +17,7 @@ mod esp32 {
                 RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage, WifiCredentials,
             },
             entry::RobotRepresentation,
+            log::initialize_logger,
             provisioning::server::ProvisioningInfo,
             registry::ComponentRegistry,
         },
@@ -24,6 +25,7 @@ mod esp32 {
             entry::serve,
             esp_idf_svc::{
                 self,
+                log::EspLogger,
                 sys::{g_wifi_feature_caps, CONFIG_FEATURE_CACHE_TX_BUF_BIT},
             },
             nvs_storage::NVSStorage,
@@ -45,7 +47,7 @@ mod esp32 {
 
     pub(crate) fn main_esp32() {
         esp_idf_svc::sys::link_patches();
-        esp_idf_svc::log::EspLogger::initialize_default();
+        initialize_logger::<EspLogger>();
 
         esp_idf_svc::sys::esp!(unsafe {
             esp_idf_svc::sys::esp_vfs_eventfd_register(

--- a/micro-rdk-server/native/main.rs
+++ b/micro-rdk-server/native/main.rs
@@ -7,14 +7,13 @@ mod native {
         conn::network::ExternallyManagedNetwork,
         credentials_storage::{RAMStorage, RobotConfigurationStorage, RobotCredentials},
         entry::{serve_with_network, RobotRepresentation},
+        log::initialize_logger,
         provisioning::server::ProvisioningInfo,
         registry::ComponentRegistry,
     };
 
     pub(crate) fn main_native() {
-        env_logger::builder()
-            .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
-            .init();
+        initialize_logger::<env_logger::Logger>();
 
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -20,7 +20,7 @@ binstart = ["esp-idf-svc/binstart"]
 libstart = ["esp-idf-svc/libstart"]
 builtin-components = []
 camera = []
-esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal", "esp-idf-svc/std", "esp-idf-svc/alloc"]
+esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal", "esp-idf-svc/std", "esp-idf-svc/alloc", "dep:printf-compat"]
 native = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address", "dep:openssl", "dep:rcgen", "dep:async-std-openssl"]
 data-upload-hook-unstable = ["data", "esp32"]
 data = []
@@ -31,6 +31,7 @@ env_logger.workspace = true
 
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
 async-std-openssl = { workspace = true, optional = true }
+env_logger.workspace = true
 futures-rustls.workspace = true
 local-ip-address = { workspace = true, optional = true }
 mdns-sd = { workspace = true, optional = true }
@@ -81,6 +82,7 @@ ringbuf.workspace = true
 pin-project.workspace = true
 async-lock.workspace = true
 dns-message-parser.workspace = true
+printf-compat = { workspace = true, optional = true }
 
 [build-dependencies]
 embuild.workspace = true

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -24,6 +24,7 @@ esp32 = ["dep:esp-idf-svc", "dep:embedded-svc", "dep:embedded-hal", "esp-idf-svc
 native = ["dep:rustls", "dep:webpki-roots", "dep:rustls-pemfile", "dep:mdns-sd", "dep:local-ip-address", "dep:openssl", "dep:rcgen", "dep:async-std-openssl"]
 data-upload-hook-unstable = ["data", "esp32"]
 data = []
+esp-idf-logs = ["esp32"]
 
 [dev-dependencies]
 test-log.workspace = true

--- a/micro-rdk/src/common/entry.rs
+++ b/micro-rdk/src/common/entry.rs
@@ -145,10 +145,11 @@ pub async fn serve_inner<S>(
                 cfg_received_datetime,
             ) {
                 Ok(robot) => (robot, None),
-                Err(err) => (LocalRobot::new(), Some(err))
+                Err(err) => (LocalRobot::new(), Some(err)),
             };
             if let Some(err) = err {
-                log::error!("could not build robot from config due to {:?}, defaulting to empty robot until a valid config is accessible", err);            } else {
+                log::error!("could not build robot from config due to {:?}, defaulting to empty robot until a valid config is accessible", err);
+            } else {
                 log::info!("successfully created robot from config");
             };
             Arc::new(Mutex::new(r))

--- a/micro-rdk/src/common/entry.rs
+++ b/micro-rdk/src/common/entry.rs
@@ -21,7 +21,7 @@ use super::{
     exec::Executor,
     grpc::ServerError,
     grpc_client::GrpcClient,
-    log::config_log_entry,
+    log::LogUploadTask,
     provisioning::server::{serve_provisioning_async, ProvisioningInfo},
     registry::ComponentRegistry,
     restart_monitor::RestartMonitor,
@@ -150,10 +150,11 @@ pub async fn serve_inner<S>(
                     (LocalRobot::new(), Some(err))
                 }
             };
-            if let Some(datetime) = cfg_received_datetime {
-                let logs = vec![config_log_entry(datetime, err)];
-                let _ = app_client.push_logs(logs).await;
-            }
+            if let Some(err) = err {
+                log::error!("could not create robot from config: {:?}", err);
+            } else {
+                log::info!("successfully created robot from config");
+            };
             Arc::new(Mutex::new(r))
         }
     };
@@ -197,13 +198,16 @@ pub async fn serve_inner<S>(
         network,
         rpc_host,
     )
-    .with_webrtc(webrtc)
-    .with_periodic_app_client_task(Box::new(RestartMonitor::new(restart)))
-    .with_periodic_app_client_task(Box::new(ConfigMonitor::new(
-        *(cfg_response.clone()),
-        storage.clone(),
-        restart,
-    )));
+    .with_webrtc(webrtc);
+
+    let server_builder = server_builder
+        .with_periodic_app_client_task(Box::new(RestartMonitor::new(restart)))
+        .with_periodic_app_client_task(Box::new(ConfigMonitor::new(
+            *(cfg_response.clone()),
+            storage.clone(),
+            restart,
+        )))
+        .with_periodic_app_client_task(Box::new(LogUploadTask {}));
 
     #[cfg(feature = "native")]
     let server_builder = {

--- a/micro-rdk/src/common/entry.rs
+++ b/micro-rdk/src/common/entry.rs
@@ -145,14 +145,10 @@ pub async fn serve_inner<S>(
                 cfg_received_datetime,
             ) {
                 Ok(robot) => (robot, None),
-                Err(err) => {
-                    log::error!("could not build robot from config due to {:?}, defaulting to empty robot until a valid config is accessible", err);
-                    (LocalRobot::new(), Some(err))
-                }
+                Err(err) => (LocalRobot::new(), Some(err))
             };
             if let Some(err) = err {
-                log::error!("could not create robot from config: {:?}", err);
-            } else {
+                log::error!("could not build robot from config due to {:?}, defaulting to empty robot until a valid config is accessible", err);            } else {
                 log::info!("successfully created robot from config");
             };
             Arc::new(Mutex::new(r))

--- a/micro-rdk/src/common/log.rs
+++ b/micro-rdk/src/common/log.rs
@@ -2,40 +2,207 @@ use crate::{
     google::protobuf::{value::Kind, Struct, Timestamp, Value},
     proto::common::v1::LogEntry,
 };
-use chrono::{DateTime, FixedOffset};
-use std::collections::HashMap;
+use async_lock::Mutex as AsyncMutex;
+use chrono::Local;
+use ringbuf::{LocalRb, Rb};
+use std::{
+    collections::HashMap,
+    mem::MaybeUninit,
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
 
-use super::robot::RobotError;
+use super::app_client::PeriodicAppClientTask;
 
-pub fn config_log_entry(time: DateTime<FixedOffset>, err: Option<RobotError>) -> LogEntry {
-    let secs = time.timestamp();
-    let nanos = time.timestamp_subsec_nanos();
-    let level = match err {
-        Some(_) => "error".to_string(),
-        None => "info".to_string(),
-    };
-    let message = match err {
-        Some(err) => format!("could not create robot from config: {err}"),
-        None => "successfully created robot from config".to_string(),
-    };
-    LogEntry {
-        host: "esp32".to_string(),
-        level,
-        time: Some(Timestamp {
+// We need a static buffer of logs on the heap, but because we cannot guarantee that the current time has been set
+// at every instance of logging, so we store each log alongside an instance of Instant. We assume that current time
+// has been set on the system by the time an AppClient is available for uploading the logs and so use the Instant
+// to correct the timestamp on the LogEntry.
+pub(crate) struct ViamLogEntry {
+    entry: LogEntry,
+    time: Instant,
+}
+
+impl ViamLogEntry {
+    pub(crate) fn from_record(record: &::log::Record<'_>) -> Self {
+        Self {
+            entry: record.into(),
+            time: Instant::now(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn new(entry: LogEntry) -> Self {
+        Self {
+            entry,
+            time: Instant::now(),
+        }
+    }
+
+    fn get_time_corrected_entry(mut self) -> LogEntry {
+        let time = Local::now().fixed_offset();
+        let corrected_time = time - (Instant::now().duration_since(self.time));
+        let secs = corrected_time.timestamp();
+        let nanos = corrected_time.timestamp_subsec_nanos();
+        let timestamp = Timestamp {
             seconds: secs,
             nanos: nanos as i32,
-        }),
-        logger_name: "robot_server".to_string(),
-        message,
-        caller: Some(Struct {
-            fields: HashMap::from([(
-                "Defined".to_string(),
-                Value {
-                    kind: Some(Kind::BoolValue(false)),
-                },
-            )]),
-        }),
-        stack: "".to_string(),
-        fields: vec![],
+        };
+        self.entry.time = Some(timestamp);
+        self.entry
+    }
+}
+
+impl From<&::log::Record<'_>> for LogEntry {
+    fn from(value: &::log::Record) -> Self {
+        LogEntry {
+            host: "esp32".to_string(),
+            level: value.level().as_str().to_string().to_lowercase(),
+            time: None,
+            logger_name: "viam-micro-server".to_string(),
+            message: format!("{}", value.args()),
+            caller: Some(Struct {
+                fields: HashMap::from([
+                    (
+                        "Defined".to_string(),
+                        Value {
+                            kind: Some(Kind::BoolValue(true)),
+                        },
+                    ),
+                    (
+                        "File".to_string(),
+                        Value {
+                            kind: value.file().map(|f| Kind::StringValue(f.to_string())),
+                        },
+                    ),
+                    (
+                        "Line".to_string(),
+                        Value {
+                            kind: value.line().map(|l| Kind::NumberValue(l as f64)),
+                        },
+                    ),
+                ]),
+            }),
+            stack: "".to_string(),
+            fields: vec![],
+        }
+    }
+}
+
+type LogBufferType = LocalRb<ViamLogEntry, Vec<MaybeUninit<ViamLogEntry>>>;
+
+// We've chosen a size of 150 for the buffer due to a roughly observed maximum of 200 bytes per log message and
+// a desire to restrict the total amount of space for the cache to 30KB without losing logs to overwriting
+// overwriting the ring buffer between uploads. The consequence is that, when the device is offline, we will
+// cache the last 150 logs.
+pub(crate) fn get_log_buffer() -> &'static AsyncMutex<LogBufferType> {
+    static LOG_BUFFER: OnceLock<AsyncMutex<LogBufferType>> = OnceLock::new();
+    LOG_BUFFER.get_or_init(|| AsyncMutex::new(LocalRb::new(150)))
+}
+
+pub(crate) struct LogUploadTask {}
+
+impl PeriodicAppClientTask for LogUploadTask {
+    fn get_default_period(&self) -> std::time::Duration {
+        Duration::from_secs(1)
+    }
+    fn name(&self) -> &str {
+        "LogUpload"
+    }
+    fn invoke<'b, 'a: 'b>(
+        &'a mut self,
+        app_client: &'b super::app_client::AppClient,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = Result<Option<Duration>, super::app_client::AppClientError>,
+                > + 'b,
+        >,
+    > {
+        Box::pin(async move {
+            let mut logs = get_log_buffer().lock().await;
+            if logs.len() > 0 {
+                let entries: Vec<LogEntry> = logs
+                    .pop_iter()
+                    .map(|log_entry| log_entry.get_time_corrected_entry())
+                    .collect();
+                // don't hold on to the buffer lock over the outgoing request to app.viam.com
+                std::mem::drop(logs);
+                app_client.push_logs(entries).await.map(|_| None)
+            } else {
+                Ok(None)
+            }
+        })
+    }
+}
+
+pub trait ViamLogAdapter {
+    fn before_log_setup(&self);
+    fn get_level_filter(&self) -> ::log::LevelFilter;
+    fn new() -> Self;
+}
+
+#[cfg(not(feature = "esp32"))]
+impl ViamLogAdapter for env_logger::Logger {
+    fn before_log_setup(&self) {}
+    fn get_level_filter(&self) -> ::log::LevelFilter {
+        self.filter()
+    }
+    fn new() -> Self {
+        env_logger::builder()
+            .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+            .build()
+    }
+}
+
+// ViamLogger is a wrapper around an existing logger that stores a copy into LOG_BUFFER for later
+// upload to the cloud. The existing logger should satisfy log::Log and the ViamLogAdapter
+// trait and then by initialized using this function at the start of main
+pub fn initialize_logger<T: ::log::Log + ViamLogAdapter + 'static>() {
+    let inner = T::new();
+    let logger = ViamLogger::new(inner);
+    let filter = logger.level_filter();
+    logger.before_log_setup();
+    let _ = ::log::set_boxed_logger(Box::new(logger));
+    ::log::set_max_level(filter)
+}
+
+struct ViamLogger<L>(L);
+
+impl<L> ViamLogger<L>
+where
+    L: ::log::Log + ViamLogAdapter,
+{
+    fn new(inner: L) -> Self {
+        Self(inner)
+    }
+
+    fn before_log_setup(&self) {
+        self.0.before_log_setup()
+    }
+
+    fn level_filter(&self) -> ::log::LevelFilter {
+        self.0.get_level_filter()
+    }
+}
+
+impl<L> ::log::Log for ViamLogger<L>
+where
+    L: ::log::Log + ViamLogAdapter,
+{
+    fn enabled(&self, metadata: &log::Metadata) -> bool {
+        self.0.enabled(metadata)
+    }
+
+    fn flush(&self) {
+        self.0.flush()
+    }
+
+    fn log(&self, record: &log::Record) {
+        if self.enabled(record.metadata()) {
+            self.0.log(record);
+            let mut buffer = get_log_buffer().lock_blocking();
+            let _ = buffer.push_overwrite(ViamLogEntry::from_record(record));
+        }
     }
 }

--- a/micro-rdk/src/common/log.rs
+++ b/micro-rdk/src/common/log.rs
@@ -12,7 +12,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use super::app_client::PeriodicAppClientTask;
+use super::app_client::{AppClient, AppClientError, PeriodicAppClientTask};
 
 // We need a static buffer of logs on the heap, but because we cannot guarantee that the current time has been set
 // at every instance of logging, so we store each log alongside an instance of Instant. We assume that current time
@@ -111,11 +111,11 @@ impl PeriodicAppClientTask for LogUploadTask {
     }
     fn invoke<'b, 'a: 'b>(
         &'a mut self,
-        app_client: &'b super::app_client::AppClient,
+        app_client: &'b AppClient,
     ) -> std::pin::Pin<
         Box<
             dyn std::future::Future<
-                    Output = Result<Option<Duration>, super::app_client::AppClientError>,
+                    Output = Result<Option<Duration>, AppClientError>,
                 > + 'b,
         >,
     > {

--- a/micro-rdk/src/esp32/log.rs
+++ b/micro-rdk/src/esp32/log.rs
@@ -45,7 +45,10 @@ unsafe extern "C" fn log_handler(arg1: *const c_char, arg2: va_list) -> i32 {
     let start_of_new_statement = (message_clone.len() >= 3)
         && (matches!(&message_clone[..3], "I (" | "E (" | "W (" | "D (" | "V (")
             || message_clone.starts_with(MESSAGE_START));
-    let mut current_fragments = CURRENT_LOG_STATEMENT.get_or_init(|| Mutex::new(vec![])).lock().unwrap();
+    let mut current_fragments = CURRENT_LOG_STATEMENT
+        .get_or_init(|| Mutex::new(vec![]))
+        .lock()
+        .unwrap();
     if start_of_new_statement && !current_fragments.is_empty() {
         let full_message = current_fragments.join(" ");
         let _ = get_log_buffer()
@@ -54,7 +57,11 @@ unsafe extern "C" fn log_handler(arg1: *const c_char, arg2: va_list) -> i32 {
         current_fragments.clear();
     }
     current_fragments.push(message_clone);
-    if let Some(prev_logger) = *(PREVIOUS_LOGGER.get_or_init(|| Mutex::new(None)).lock().unwrap()) {
+    if let Some(prev_logger) = *(PREVIOUS_LOGGER
+        .get_or_init(|| Mutex::new(None))
+        .lock()
+        .unwrap())
+    {
         prev_logger(arg1, arg2)
     } else {
         0
@@ -112,7 +119,10 @@ fn process_current_statement_and_level(mut full_message: String) -> ViamLogEntry
 
 impl ViamLogAdapter for EspLogger {
     fn before_log_setup(&self) {
-        let mut guard = PREVIOUS_LOGGER.get_or_init(|| Mutex::new(None)).lock().unwrap();
+        let mut guard = PREVIOUS_LOGGER
+            .get_or_init(|| Mutex::new(None))
+            .lock()
+            .unwrap();
         *guard = unsafe { esp_log_set_vprintf(Some(log_handler)) };
         self.initialize();
     }

--- a/micro-rdk/src/esp32/log.rs
+++ b/micro-rdk/src/esp32/log.rs
@@ -57,13 +57,9 @@ unsafe extern "C" fn log_handler(arg1: *const c_char, arg2: va_list) -> i32 {
         current_fragments.clear();
     }
     current_fragments.push(message_clone);
-    if let Some(prev_logger) = PREVIOUS_LOGGER.get() {
-        if let Some(prev_logger) = prev_logger {
-            let fmt_c_str = CString::new(message).unwrap();
-            prev_logger(fmt_c_str.as_ptr() as *const c_char, [0; 3])
-        } else {
-            0
-        }
+    if let Some(prev_logger) = PREVIOUS_LOGGER.get().unwrap_or(&None) {
+        let fmt_c_str = CString::new(message).unwrap();
+        prev_logger(fmt_c_str.as_ptr() as *const c_char, [0; 3])
     } else {
         0
     }

--- a/micro-rdk/src/esp32/log.rs
+++ b/micro-rdk/src/esp32/log.rs
@@ -123,7 +123,9 @@ impl ViamLogAdapter for EspLogger {
             .get_or_init(|| Mutex::new(None))
             .lock()
             .unwrap();
-        *guard = unsafe { esp_log_set_vprintf(Some(log_handler)) };
+        if guard.is_none() {
+            *guard = unsafe { esp_log_set_vprintf(Some(log_handler)) };
+        }
         self.initialize();
     }
     fn get_level_filter(&self) -> ::log::LevelFilter {

--- a/micro-rdk/src/esp32/log.rs
+++ b/micro-rdk/src/esp32/log.rs
@@ -1,0 +1,129 @@
+//! This is for infrastructure supporting uploading logs from an ESP32 to Viam's cloud infrastructure
+//! (see common/log.rs for more details). On an ESP32, there are two sources of logs: logs from ESP-IDF,
+//! and logs from various Rust crates. The EspLogger from esp-idf-svc efficiently redirects the latter
+//! logs to UART in a format matching the first, so it is sufficient to simply wrap it. However
+//! to capture ESP-IDF logs, it is necessary to use the replace the default vprintf function to write to LOG_BUFFER
+//! (again, see common/log.rs) before invoking the previously existing vprintf function in order to write to
+//! UART. We store the previous vprintf function in PREVIOUS_LOGGER and use esp_log_set_vprintf for this purpose.
+use crate::{
+    common::log::ViamLogEntry,
+    google::protobuf::{value::Kind, Struct, Value},
+    proto::common::v1::LogEntry,
+};
+
+use esp_idf_svc::log::EspLogger;
+use esp_idf_svc::sys::{esp_log_set_vprintf, va_list, vprintf_like_t};
+use printf_compat::output::display;
+use ringbuf::Rb;
+use std::{collections::HashMap, sync::OnceLock};
+use std::{ffi::c_char, sync::Mutex};
+
+use crate::common::log::{get_log_buffer, ViamLogAdapter};
+
+fn previous_logger() -> &'static Mutex<vprintf_like_t> {
+    static PREVIOUS_LOGGER: OnceLock<Mutex<vprintf_like_t>> = OnceLock::new();
+    PREVIOUS_LOGGER.get_or_init(|| Mutex::new(None))
+}
+
+fn current_log_statement() -> &'static Mutex<Vec<String>> {
+    static CURRENT_LOG_STATEMENT: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    CURRENT_LOG_STATEMENT.get_or_init(|| Mutex::new(vec![]))
+}
+
+// A single log statement is often broken up into multiple calls to vprintf. So we store
+// the fragments in CURRENT_LOG_STATEMENT. Detecting whether we have encountered the start
+// of a new statement is futher complicated by the fact that, depending on the ESP-IDF component
+// producing the log, the statement can be in one of the following formats
+//
+// "\x1b[0;<color_indicator>m<level_indicator> ... \x1b[0m"
+//
+// "<level_indicator> (<timestamp>) ..."
+// This complication is reflected in the function below and its helper function
+// process_current_statement_and_level
+#[allow(improper_ctypes_definitions)]
+unsafe extern "C" fn log_handler(arg1: *const c_char, arg2: va_list) -> i32 {
+    let va_list: core::ffi::VaList = std::mem::transmute(&arg2);
+    let fmt_message = display(arg1, va_list);
+    let message = format!("{}", fmt_message).trim().to_string();
+    let message_clone = message.clone();
+    let start_of_new_statement = (message_clone.len() >= 3)
+        && (matches!(&message_clone[..3], "I (" | "E (" | "W (" | "D (" | "V (")
+            || message_clone.starts_with("\x1b[0;"));
+    let mut current_fragments = current_log_statement().lock().unwrap();
+    if start_of_new_statement && !current_fragments.is_empty() {
+        let full_message = current_fragments.join(" ");
+        let _ = get_log_buffer()
+            .lock_blocking()
+            .push_overwrite(process_current_statement_and_level(full_message));
+        current_fragments.clear();
+    }
+    current_fragments.push(message_clone);
+    if let Some(prev_logger) = *(previous_logger().lock().unwrap()) {
+        prev_logger(arg1, arg2)
+    } else {
+        0
+    }
+}
+
+fn process_current_statement_and_level(mut full_message: String) -> ViamLogEntry {
+    let (mut message, level_initial) = if full_message.starts_with("\x1b[0;") {
+        let stripped = full_message.split_off("\x1b[0;".len() + 3);
+        let mut stripped_end = stripped
+            .strip_suffix("\x1b[0m")
+            .unwrap_or(stripped.as_str())
+            .to_string();
+        let stripped_without_level = stripped_end.split_off(2);
+        (stripped_without_level, stripped_end)
+    } else if full_message.len() > 1 {
+        let stripped_message = full_message.split_off(2);
+        (stripped_message, full_message)
+    } else {
+        (full_message, "U".to_string())
+    };
+    let level = match level_initial.as_str() {
+        "I " => "info",
+        "E " => "error",
+        "W " => "warn",
+        "D " => "debug",
+        "V " => "trace",
+        &_ => "unknown",
+    }
+    .to_string();
+    if level.as_str() != "unknown" {
+        // we strip the ESP-IDF timestamp in favor of our corrected one
+        if let Some(end_of_timestamp) = message.find(')') {
+            message = message[(end_of_timestamp + 1)..].to_string()
+        }
+    }
+    ViamLogEntry::new(LogEntry {
+        host: "esp32".to_string(),
+        level,
+        time: None,
+        logger_name: "viam-micro-server".to_string(),
+        message,
+        caller: Some(Struct {
+            fields: HashMap::from([(
+                "Defined".to_string(),
+                Value {
+                    kind: Some(Kind::BoolValue(false)),
+                },
+            )]),
+        }),
+        stack: "".to_string(),
+        fields: vec![],
+    })
+}
+
+impl ViamLogAdapter for EspLogger {
+    fn before_log_setup(&self) {
+        let mut guard = previous_logger().lock().unwrap();
+        *guard = unsafe { esp_log_set_vprintf(Some(log_handler)) };
+        self.initialize();
+    }
+    fn get_level_filter(&self) -> ::log::LevelFilter {
+        self.get_max_level()
+    }
+    fn new() -> Self {
+        Self {}
+    }
+}

--- a/micro-rdk/src/esp32/mod.rs
+++ b/micro-rdk/src/esp32/mod.rs
@@ -13,6 +13,7 @@ pub mod esp_idf_svc;
 #[cfg(feature = "builtin-components")]
 pub mod hcsr04;
 pub mod i2c;
+pub mod log;
 pub mod pin;
 #[cfg(feature = "builtin-components")]
 pub mod pulse_counter;

--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -4,6 +4,7 @@
 // the nightly channel, which we only use for ESP32 builds.
 // See common/data_manager.rs for why we use this feature at all.
 #![cfg_attr(feature = "data-upload-hook-unstable", feature(linkage))]
+#![cfg_attr(feature = "esp32", feature(c_variadic))]
 
 pub mod common;
 

--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -4,7 +4,7 @@
 // the nightly channel, which we only use for ESP32 builds.
 // See common/data_manager.rs for why we use this feature at all.
 #![cfg_attr(feature = "data-upload-hook-unstable", feature(linkage))]
-#![cfg_attr(feature = "esp32", feature(c_variadic))]
+#![cfg_attr(feature = "esp-idf-logs", feature(c_variadic))]
 
 pub mod common;
 

--- a/micro-rdk/src/native/log.rs
+++ b/micro-rdk/src/native/log.rs
@@ -1,0 +1,13 @@
+use crate::common::log::ViamLogAdapter;
+
+impl ViamLogAdapter for env_logger::Logger {
+    fn before_log_setup(&self) {}
+    fn get_level_filter(&self) -> ::log::LevelFilter {
+        self.filter()
+    }
+    fn new() -> Self {
+        env_logger::builder()
+            .format_timestamp(Some(env_logger::TimestampPrecision::Millis))
+            .build()
+    }
+}

--- a/micro-rdk/src/native/mod.rs
+++ b/micro-rdk/src/native/mod.rs
@@ -1,6 +1,7 @@
 pub mod certificate;
 pub mod dtls;
 pub mod entry;
+pub mod log;
 pub mod tcp;
 pub mod tls;
 pub mod conn {


### PR DESCRIPTION
This commit allows for upload of logs to app.viam.com. All logs will be uploaded EXCEPT the following:

1. System logs on the ESP32 that are performed using [ESP_LOG_EARLYx](https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/system/log.html#how-to-use-this-library), such as those coming from "boot", "esp_image", "cpu_start", etc
2. Any logs performed on panic

Additionally, this feature will break upon upgrade to version 1.49 of esp-idf-svc because their `EspLogger` has changed from an empty public struct to one with a private constructor, leaving it unable to be wrapped by `ViamLogger`. I've opened an issue with esp-rs [here](https://github.com/esp-rs/esp-idf-svc/issues/476)