### PR TITLE
[RSDK-8757] allow disabling of individual capture configs

### DIFF
--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -329,8 +329,10 @@ impl LocalRobot {
         }
         #[cfg(feature = "data")]
         for cfg in config.data_collector_configs.iter() {
-            self.data_collector_configs
-                .push((new_resource_name.clone(), cfg.clone()));
+            if !cfg.disabled {
+                self.data_collector_configs
+                    .push((new_resource_name.clone(), cfg.clone()));
+            }
         }
         self.insert_resource(
             model,


### PR DESCRIPTION
In app, you can "turn off" individual data capture methods, but the micro-RDK infrastructure does not respect this setting. This fixes that.