### PR TITLE
[RSDK-8930] Add OTA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ build-esp32-bin:
 	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 4mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
 
 build-esp32-ota:
-	cargo +esp espflash save-image --package micro-rdk-server --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/ota_8mb_partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release
+	cargo +esp espflash save-image --package micro-rdk-server --features=ota --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/ota_8mb_partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release
 
 flash-esp32-bin:
 ifneq (,$(wildcard ./target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin))

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ buf: buf-clean
 	buf generate buf.build/googleapis/googleapis --template micro-rdk/buf.gen.yaml --path google/rpc --path google/api
 	buf generate buf.build/viamrobotics/api:${VIAM_API_VERSION} --template micro-rdk/buf.gen.yaml
 	printf "// AUTO-GENERATED CODE; DO NOT DELETE OR EDIT\npub const VIAM_API_VERSION: &str = \"${VIAM_API_VERSION}\";\n" > micro-rdk/src/gen/api_version.rs
-	buf generate buf.build/protocolbuffers/wellknowntypes --template micro-rdk/buf.gen.yaml
+	buf generate buf.build/protocolbuffers/wellknowntypes --template micro-rdk/buf.gen.yaml 
 
 license-finder:
 	license_finder
@@ -32,7 +32,7 @@ ifneq ($(ESPFLASHVERSION),true)
 		$(error Update espfash to version >=3.0. Update with cargo install cargo-espflash)
 endif
 
-abuild:
+build:
 	cargo +esp build  -p micro-rdk-server --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort
 
 build-native:
@@ -103,7 +103,7 @@ build-esp32-bin:
 	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 4mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
 
 build-esp32-ota:
-	cargo +esp espflash save-image --package micro-rdk-server --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release
+	cargo +esp espflash save-image --package micro-rdk-server --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/ota_8mb_partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release
 
 flash-esp32-bin:
 ifneq (,$(wildcard ./target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin))

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,10 @@ size:
 	find . -name "esp-build.map" -exec ${IDF_PATH}/tools/idf_size.py {} \;
 
 build-esp32-bin:
-	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 4mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
+	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 8mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
+
+build-esp32-ota:
+	cargo +esp espflash save-image --package micro-rdk-server --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release
 
 flash-esp32-bin:
 ifneq (,$(wildcard ./target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin))

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ buf: buf-clean
 	buf generate buf.build/googleapis/googleapis --template micro-rdk/buf.gen.yaml --path google/rpc --path google/api
 	buf generate buf.build/viamrobotics/api:${VIAM_API_VERSION} --template micro-rdk/buf.gen.yaml
 	printf "// AUTO-GENERATED CODE; DO NOT DELETE OR EDIT\npub const VIAM_API_VERSION: &str = \"${VIAM_API_VERSION}\";\n" > micro-rdk/src/gen/api_version.rs
-	buf generate buf.build/protocolbuffers/wellknowntypes --template micro-rdk/buf.gen.yaml 
+	buf generate buf.build/protocolbuffers/wellknowntypes --template micro-rdk/buf.gen.yaml
 
 license-finder:
 	license_finder
@@ -32,7 +32,7 @@ ifneq ($(ESPFLASHVERSION),true)
 		$(error Update espfash to version >=3.0. Update with cargo install cargo-espflash)
 endif
 
-build:
+abuild:
 	cargo +esp build  -p micro-rdk-server --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort
 
 build-native:
@@ -100,7 +100,7 @@ size:
 	find . -name "esp-build.map" -exec ${IDF_PATH}/tools/idf_size.py {} \;
 
 build-esp32-bin:
-	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 8mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
+	cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/partitions.csv -s 4mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
 
 build-esp32-ota:
 	cargo +esp espflash save-image --package micro-rdk-server --chip=esp32 ./target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin --bin=micro-rdk-server-esp32 --partition-table=micro-rdk-server/esp32/partitions.csv --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort --release

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ clippy-native:
 	cargo clippy -p micro-rdk --no-deps --features native  -- -Dwarnings
 
 clippy-esp32:
-	cargo +esp clippy -p micro-rdk  --features esp32  --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort -- -Dwarnings
+	cargo +esp clippy -p micro-rdk  --features esp32,ota  --target=xtensa-esp32-espidf -Zbuild-std=std,panic_abort -- -Dwarnings
 
 clippy-cli:
 	cargo clippy -p micro-rdk-installer --no-default-features -- -Dwarnings

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 ESPFLASHVERSION_MAJ := $(shell expr `cargo espflash -V | grep ^cargo-espflash | sed 's/^.* //g' | cut -f1 -d. `)
 ESPFLASHVERSION_MIN := $(shell expr `cargo espflash -V | grep ^cargo-espflash | sed 's/^.* //g' | cut -f2 -d. `)
-ESPFLASHVERSION := $(shell [ $(ESPFLASHVERSION_MAJ) -gt 2 -a $(ESPFLASHVERSION_MIN) -ge 0 ] && echo true)
+ESPFLASHVERSION := $(shell [ $(ESPFLASHVERSION_MAJ) -gt 2 -a $(ESPFLASHVERSION_MIN) -ge 2 ] && echo true)
 VIAM_API_VERSION := v0.1.336
 
 DATE := $(shell date +%F)

--- a/etc/docker/Dockerfile
+++ b/etc/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt-get install -y --no-install-recommends git libudev-dev mak
 
 RUN export TARGET=$(rustc -vV | sed -En 's/^host: //p') && \
     curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash && \
-    cargo binstall --pkg-url='https://github.com/esp-rs/espflash/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }' --pkg-fmt='zip' cargo-espflash@3.0.0 --install-path /usr -y --target $TARGET && \
+    cargo binstall --pkg-url='https://github.com/esp-rs/espflash/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }' --pkg-fmt='zip' cargo-espflash@3.2.0 --install-path /usr -y --target $TARGET && \
     cargo binstall --pkg-url='https://github.com/esp-rs/espup/releases/download/v{ version }/{ name }-{ target }{ archive-suffix }' --pkg-fmt='zip' espup@0.11 --install-path /usr -y --target $TARGET && \
     cargo binstall --pkg-url='https://github.com/esp-rs/embuild/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }' --pkg-fmt='zip' ldproxy@0.3.2 --install-path /usr -y --target $TARGET && \
     cargo binstall --pkg-url='https://github.com/mozilla/sccache/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }' --pkg-fmt='tgz' sccache@0.7.7 --install-path /usr -y --target $TARGET

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -1,5 +1,6 @@
 ## build 
 
+note: the build final process may take a long time (>1hr)
 ```
 $ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
 $ make -f docker.make micro-rdk-dev

--- a/etc/docker/README.md
+++ b/etc/docker/README.md
@@ -1,0 +1,11 @@
+## build 
+
+```
+$ docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes
+$ make -f docker.make micro-rdk-dev
+```
+
+## upload
+```
+$ make -f docker.make micro-rdk-upload
+```

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -25,7 +25,7 @@ async-channel.workspace = true
 embedded-hal.workspace = true
 embedded-svc.workspace = true
 futures-lite.workspace = true
-micro-rdk = { workspace = true, features = ["esp32", "binstart"], default-features = true }
+micro-rdk = { workspace = true, features = ["esp32", "binstart", "ota"], default-features = true }
 micro-rdk-modular-driver-example = {workspace = true, features = ["esp32"]}
 
 

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 
 [features]
 qemu = ["micro-rdk/qemu"]
+ota = ["micro-rdk/ota"]
 
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
 env_logger.workspace = true

--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -25,7 +25,7 @@ async-channel.workspace = true
 embedded-hal.workspace = true
 embedded-svc.workspace = true
 futures-lite.workspace = true
-micro-rdk = { workspace = true, features = ["esp32", "binstart", "ota"], default-features = true }
+micro-rdk = { workspace = true, features = ["esp32", "binstart"], default-features = true }
 micro-rdk-modular-driver-example = {workspace = true, features = ["esp32"]}
 
 

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,0 +1,7 @@
+# Name,   Type, SubType, Offset,  Size, Flags
+# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
+nvs,	       data,	nvs,	  0x9000,	0x6000,
+otadata,       data,	ota,	  0xF000,	0x2000,
+phy_init,      data,	phy, 	  0x11000, 	0x1000,
+ota_0,	       0,	ota_0,	  ,		0x377000,
+ota_1,	       0,	ota_1,	  ,		0x377000,

--- a/micro-rdk-server/esp32/partitions.csv
+++ b/micro-rdk-server/esp32/partitions.csv
@@ -1,7 +1,5 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,	       data,	nvs,	  0x9000,	0x6000,
-otadata,       data,	ota,	  0xF000,	0x2000,
-phy_init,      data,	phy, 	  0x11000, 	0x1000,
-ota_0,	       0,	ota_0,	  ,		0x377000,
-ota_1,	       0,	ota_1,	  ,		0x377000,
+nvs,      data, nvs, 0x9000    ,        0x6000,
+phy_init, data, phy, 0xf000    ,        0x1000,
+factory,  app,  factory, 0x10000,       0x3effff,

--- a/micro-rdk-server/esp32/partitions.csv
+++ b/micro-rdk-server/esp32/partitions.csv
@@ -1,5 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs, 0x9000    ,        0x6000,
-phy_init, data, phy, 0xf000    ,        0x1000,
-factory,  app,  factory, 0x10000,       0x3effff,
+nvs,	       data,	nvs,	  0x9000,	0x6000,
+otadata,       data,	ota,	  0xF000,	0x2000,
+phy_init,      data,	phy, 	  0x11000, 	0x1000,
+ota_0,	       0,	ota_0,	  ,		0x377000,
+ota_1,	       0,	ota_1,	  ,		0x377000,

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -26,6 +26,7 @@ data-upload-hook-unstable = ["data", "esp32"]
 data = []
 qemu = []
 esp-idf-logs = ["esp32"]
+ota = ["esp32"]
 
 [dev-dependencies]
 test-log.workspace = true

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -546,18 +546,19 @@ where
                 .find(|&service| service.model == ota::OTA_MODEL_TRIPLET)
             {
                 log::info!("service config: {:#?}", service);
-                let mut ota = ota::OtaService::new(&service);
-                log::info!("OtaService: {:?}", ota);
-                if let Err(e) = ota.update().await {
-                    log::error!("ota failed: {:?}", e);
+                if let Ok(mut ota) = ota::OtaService::from_config(&service) {
+                    log::info!("OtaService: {:?}", ota);
+                    if let Err(e) = ota.update().await {
+                        log::error!("ota failed: {:?}", e);
+                    } else {
+                        log::info!("ota succeeded");
+                    }
                 } else {
-                    log::info!("ota succeeded");
+                    log::info!(
+                        "no service of type `{}` found in robot config",
+                        ota::OTA_MODEL_TYPE
+                    );
                 }
-            } else {
-                log::info!(
-                    "no service of type `{}` found in robot config",
-                    ota::OTA_MODEL_TYPE
-                );
             }
         }
 

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -546,7 +546,7 @@ where
                 .find(|&service| service.model == ota::OTA_MODEL_TRIPLET)
             {
                 log::debug!("service config: {:#?}", service);
-                if let Ok(mut ota) = ota::OtaService::from_config(&service) {
+                if let Ok(mut ota) = ota::OtaService::from_config(service) {
                     log::debug!("OtaService: {:?}", ota);
                     if let Err(e) = ota.update() {
                         log::error!("ota failed: {:?}", e);

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -536,24 +536,28 @@ where
 
         #[cfg(feature = "ota")]
         {
-            log::info!("ota feature enabled");
+            use crate::esp32::ota;
+
+            log::debug!("ota feature enabled");
+
             if let Some(service) = config
                 .services
                 .iter()
-                .find(|&service| service.model == "rdk:builtin:ota_service")
+                .find(|&service| service.model == ota::OTA_MODEL_TRIPLET)
             {
                 log::info!("service config: {:#?}", service);
-                let mut ota = crate::esp32::ota::OtaService::new(&service);
+                let mut ota = ota::OtaService::new(&service);
                 log::info!("OtaService: {:?}", ota);
-                if ota.needs_update() {
-                    if let Err(e) = ota.update() {
-                        log::error!("failed to update ota partitions: {:?}", e);
-                    } else {
-                        log::info!("ota update succeeded");
-                    }
+                if let Err(e) = ota.update().await {
+                    log::error!("ota failed: {:?}", e);
+                } else {
+                    log::info!("ota succeeded");
                 }
             } else {
-                log::info!("no service of type `ota_service` found in robot config");
+                log::info!(
+                    "no service of type `{}` found in robot config",
+                    ota::OTA_MODEL_TYPE
+                );
             }
         }
 

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -548,7 +548,7 @@ where
                 log::debug!("service config: {:#?}", service);
                 if let Ok(mut ota) = ota::OtaService::from_config(&service) {
                     log::debug!("OtaService: {:?}", ota);
-                    if let Err(e) = ota.update().await {
+                    if let Err(e) = ota.update() {
                         log::error!("ota failed: {:?}", e);
                     } else {
                         log::info!("ota succeeded");

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -545,9 +545,9 @@ where
                 .iter()
                 .find(|&service| service.model == ota::OTA_MODEL_TRIPLET)
             {
-                log::info!("service config: {:#?}", service);
+                log::debug!("service config: {:#?}", service);
                 if let Ok(mut ota) = ota::OtaService::from_config(&service) {
-                    log::info!("OtaService: {:?}", ota);
+                    log::debug!("OtaService: {:?}", ota);
                     if let Err(e) = ota.update().await {
                         log::error!("ota failed: {:?}", e);
                     } else {

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -554,8 +554,8 @@ where
                         log::info!("ota succeeded");
                     }
                 } else {
-                    log::info!(
-                        "no service of type `{}` found in robot config",
+                    log::error!(
+                        "ota enabled, but no service of type `{}` found in robot config",
                         ota::OTA_MODEL_TYPE
                     );
                 }

--- a/micro-rdk/src/esp32/mod.rs
+++ b/micro-rdk/src/esp32/mod.rs
@@ -13,6 +13,8 @@ pub mod esp_idf_svc;
 pub mod hcsr04;
 pub mod i2c;
 pub mod log;
+#[cfg(feature = "ota")]
+pub mod ota;
 pub mod pin;
 #[cfg(feature = "builtin-components")]
 pub mod pulse_counter;

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -1,0 +1,177 @@
+use crate::{
+    esp32::esp_idf_svc::{
+        http::client::{Configuration, EspHttpConnection},
+        ota::{EspFirmwareInfoLoader, EspOta, FirmwareInfo},
+        sys::{EspError, ESP_ERR_IMAGE_INVALID},
+    },
+    proto::app::v1::ServiceConfig,
+};
+/// The following are sdkconfig options relevant to OTA
+/// They reflect what is currently default as of esp-idf v4.4.3 and should be reviewed when upgrading to esp-idf v5
+///
+/// - CONFIG_BOOTLOADER_FACTORY_RESET=NO
+///   - clear data partitions and boot from factory partition
+/// - CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=NO
+///   - after updating the app, bootloader runs a new app with the "ESP_OTA_IMG_PENDING_VERIFY" state set. If the image is not marked as verified
+use core::mem::size_of;
+use embedded_svc::http::{client::Client, Headers, Method};
+
+/*
+ServiceConfig {
+        name: "OTA",
+        namespace: "rdk",
+        r#type: "generic",
+        attributes: Some(
+            Struct {
+                fields: {
+                    "url": Value {
+                        kind: Some(
+                            StringValue(
+                            "https://my.bucket.com/my-ota.bin",
+                            ),
+                        ),
+                    },
+                },
+            },
+        ),
+        depends_on: [],
+        model: "rdk:builtin:ota_service",
+        api: "rdk:service:generic",
+        service_configs: [],
+        log_configuration: None,
+}
+ */
+
+const OTA_CHUNK_SIZE: usize = 1024 * 20; // 20KB
+const OTA_MAX_SIZE: usize = 1024 * 1024 * 4; // 4MB
+const OTA_MIN_SIZE: usize = size_of::<FirmwareInfo>() + 1024;
+
+#[derive(Debug)]
+pub(crate) struct OtaService {
+    url: String,
+}
+
+impl OtaService {
+    pub(crate) fn new(ota_config: &ServiceConfig) -> Self {
+        let kind = ota_config
+            .attributes
+            .as_ref()
+            .unwrap()
+            .fields
+            .get("url")
+            .unwrap()
+            .kind
+            .clone()
+            .unwrap();
+        let url = match kind {
+            crate::google::protobuf::value::Kind::StringValue(s) => s,
+            _ => "".to_string(),
+        };
+        let uri = url.parse::<hyper::Uri>().unwrap();
+
+        Self {
+            url: uri.to_string(),
+        }
+    }
+
+    // TODO
+    pub(crate) fn needs_update(&self) -> bool {
+        // check config for version/metadata
+        // get metadata from NVS storage
+        // compare hash or firmware data
+        // check hash/version/metadata compare to active ota hash/version/metadata
+        true
+    }
+
+    fn get_firmware_info(&self, buff: &[u8]) -> Result<FirmwareInfo, EspError> {
+        let mut loader = EspFirmwareInfoLoader::new();
+        loader.load(buff)?;
+        loader.get_info()
+    }
+    pub(crate) fn update(&mut self) -> Result<(), String> {
+        let connection = EspHttpConnection::new(&Configuration {
+            buffer_size: Some(1024 * 4),
+            buffer_size_tx: Some(1024 * 4),
+            use_global_ca_store: true,
+            crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
+            ..Default::default()
+        })
+        .map_err(|e| e.to_string())?;
+
+        let mut client = Client::wrap(connection);
+
+        let headers = [("accept", "application/octet_stream")];
+        let request = client
+            .request(Method::Get, &self.url, &headers)
+            .map_err(|e| e.to_string())?;
+
+        let mut response = request.submit().map_err(|e| e.to_string())?;
+        let status = response.status();
+
+        if status < 200 || status > 299 {
+            return Err(format!("Bad Request - Status:{}", status).to_string());
+        }
+
+        let file_len = response.content_len().unwrap_or(0) as usize;
+
+        if file_len <= OTA_MIN_SIZE {
+            log::info!(
+                "File size is {file_len}, too small to be a firmware! No need to proceed further."
+            );
+            return Err(ESP_ERR_IMAGE_INVALID.to_string());
+        }
+        if file_len > OTA_MAX_SIZE {
+            log::info!("File is too big ({file_len} bytes).");
+            return Err(ESP_ERR_IMAGE_INVALID.to_string());
+        }
+        // get handle to inactive slot
+        // start ota process on inactive slot, get write buffer
+        // loop through request to url with ota buffer as target
+        //   check for FirmwareInfo mid-loop
+        //   break when num_read > file_size
+        // check firmware info and hash
+        let mut ota = EspOta::new().expect("failed to initialize EspOta");
+        let mut work = ota
+            .initiate_update()
+            .expect("failed to initiate ota update");
+        let mut buff = vec![0; OTA_CHUNK_SIZE];
+        let mut total_read_len: usize = 0;
+        let mut got_info = false;
+        let dl_result = loop {
+            let n = response.read(&mut buff).unwrap_or_default();
+            total_read_len += n;
+            if !got_info {
+                match self.get_firmware_info(&buff[..n]) {
+                    Ok(info) => log::info!("Firmware to be downloaded: {info:?}"),
+                    Err(e) => {
+                        log::error!("Failed to get firmware info");
+                        break Err(e);
+                    }
+                };
+                got_info = true;
+            }
+            if n > 0 {
+                if let Err(e) = work.write(&buff[..n]) {
+                    log::error!("Failed to write to OTA. {e}");
+                    break Err(e);
+                }
+            }
+            if total_read_len >= file_len {
+                break Ok(());
+            }
+        };
+        if dl_result.is_err() {
+            let _ = work.abort();
+            return Err("download error, aborting ota".to_string());
+        }
+        if total_read_len < file_len {
+            log::error!("{total_read_len} bytes downloaded, needed {file_len} bytes");
+            let _ = work.abort();
+            return Err("download incomplete, aborting ota update".to_string());
+        }
+        // flip ota bit
+        work.complete().expect("failed to complete ota");
+        log::info!("will boot new firmware on reset");
+        Ok(())
+    }
+}

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -1,50 +1,76 @@
-use crate::{
-    esp32::esp_idf_svc::{
-        http::client::{Configuration, EspHttpConnection},
-        ota::{EspFirmwareInfoLoader, EspOta, FirmwareInfo},
-        sys::{EspError, ESP_ERR_IMAGE_INVALID},
-    },
-    proto::app::v1::ServiceConfig,
-};
-/// The following are sdkconfig options relevant to OTA
-/// They reflect what is currently default as of esp-idf v4.4.3 and should be reviewed when upgrading to esp-idf v5
+///
+/// example Config
+/// ```rs
+/// // example config from app.viam
+/// ServiceConfig {
+///         name: "OTA",
+///         namespace: "rdk",
+///         r#type: "generic",
+///         attributes: Some(
+///             Struct {
+///                 fields: {
+///                     "url": Value {
+///                         kind: Some(
+///                             StringValue(
+///                             "https://my.bucket.com/my-ota.bin",
+///                             ),
+///                         ),
+///                     },
+///                 },
+///             },
+///         ),
+///         depends_on: [],
+///         model: "rdk:builtin:ota_service",
+///         api: "rdk:service:generic",
+///         service_configs: [],
+///         log_configuration: None,
+/// }
+/// ```
+///
+/// The sdkconfig options relevant to OTA currently default as of esp-idf v4
+/// and should be reviewed when upgrading to esp-idf v5
 ///
 /// - CONFIG_BOOTLOADER_FACTORY_RESET=NO
 ///   - clear data partitions and boot from factory partition
 /// - CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=NO
-///   - after updating the app, bootloader runs a new app with the "ESP_OTA_IMG_PENDING_VERIFY" state set. If the image is not marked as verified
-use core::mem::size_of;
+///   - after updating the app, bootloader runs a new app with the "ESP_OTA_IMG_PENDING_VERIFY" state set. If the image is not marked as verified, will boot to previous ota slot
+///
+use crate::{
+    esp32::esp_idf_svc::{
+        http::client::{Configuration, EspHttpConnection},
+        ota::{EspFirmwareInfoLoader, EspOta},
+        sys::EspError,
+    },
+    proto::app::v1::ServiceConfig,
+};
 use embedded_svc::http::{client::Client, Headers, Method};
 
-/*
-ServiceConfig {
-        name: "OTA",
-        namespace: "rdk",
-        r#type: "generic",
-        attributes: Some(
-            Struct {
-                fields: {
-                    "url": Value {
-                        kind: Some(
-                            StringValue(
-                            "https://my.bucket.com/my-ota.bin",
-                            ),
-                        ),
-                    },
-                },
-            },
-        ),
-        depends_on: [],
-        model: "rdk:builtin:ota_service",
-        api: "rdk:service:generic",
-        service_configs: [],
-        log_configuration: None,
-}
- */
-
 const OTA_CHUNK_SIZE: usize = 1024 * 20; // 20KB
+/// bounded by partition scheme
 const OTA_MAX_SIZE: usize = 1024 * 1024 * 4; // 4MB
-const OTA_MIN_SIZE: usize = size_of::<FirmwareInfo>() + 1024;
+/// The actual minimum size of an (app image)[https://github.com/espressif/esp-idf/blob/v4.4.8/components/bootloader_support/include/esp_app_format.h] would be more like:
+/// min_bytes = `sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t) + sizeof(esp_app_desc_t) + sizeof(esp_image_segment_header_t) + sizeof(esp_image application) = 24 + 8 + 265 + 8 + ? `.
+/// However, builds have not been beneath 2MB in a while so the minimum is set as such.
+const OTA_MIN_SIZE: usize = 1024 * 1024 * 2; // 2MB
+/// Determined by partition scheme, currently <4MB to support 8MB devices.
+const OTA_HTTP_BUFSIZE: usize = 1024 * 4; // 4KB
+pub const OTA_MODEL_TYPE: &str = "ota_service";
+pub const OTA_MODEL_TRIPLET: &str = "rdk:builtin:ota_service";
+
+use thiserror::Error;
+#[derive(Error, Debug)]
+pub enum OtaError {
+    #[error("error downloading new firmware: ")]
+    DownloadError(String),
+    #[error(transparent)]
+    EspError(#[from] EspError),
+    #[error("failed to initialize ota process")]
+    InitError,
+    #[error("new image is invalid")]
+    InvalidImage,
+    #[error("{0}")]
+    Other(String),
+}
 
 #[derive(Debug)]
 pub(crate) struct OtaService {
@@ -74,103 +100,89 @@ impl OtaService {
         }
     }
 
-    // TODO
-    pub(crate) fn needs_update(&self) -> bool {
-        // check config for version/metadata
-        // get metadata from NVS storage
-        // compare hash or firmware data
-        // check hash/version/metadata compare to active ota hash/version/metadata
-        true
-    }
-
-    fn get_firmware_info(&self, buff: &[u8]) -> Result<FirmwareInfo, EspError> {
-        let mut loader = EspFirmwareInfoLoader::new();
-        loader.load(buff)?;
-        loader.get_info()
-    }
-    pub(crate) fn update(&mut self) -> Result<(), String> {
+    pub(crate) async fn update(&mut self) -> Result<(), OtaError> {
         let connection = EspHttpConnection::new(&Configuration {
-            buffer_size: Some(1024 * 4),
-            buffer_size_tx: Some(1024 * 4),
+            buffer_size: Some(OTA_HTTP_BUFSIZE),
+            buffer_size_tx: Some(OTA_HTTP_BUFSIZE),
             use_global_ca_store: true,
             crt_bundle_attach: Some(esp_idf_svc::sys::esp_crt_bundle_attach),
             ..Default::default()
         })
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| OtaError::DownloadError(e.to_string()))?;
 
         let mut client = Client::wrap(connection);
 
         let headers = [("accept", "application/octet_stream")];
         let request = client
             .request(Method::Get, &self.url, &headers)
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| OtaError::DownloadError(e.to_string()))?;
 
-        let mut response = request.submit().map_err(|e| e.to_string())?;
+        let mut response = request
+            .submit()
+            .map_err(|e| OtaError::DownloadError(e.to_string()))?;
         let status = response.status();
 
         if status < 200 || status > 299 {
-            return Err(format!("Bad Request - Status:{}", status).to_string());
+            return Err(OtaError::DownloadError(
+                format!("Bad Request - Status:{}", status).to_string(),
+            ));
         }
 
         let file_len = response.content_len().unwrap_or(0) as usize;
 
         if file_len <= OTA_MIN_SIZE {
-            log::info!(
-                "File size is {file_len}, too small to be a firmware! No need to proceed further."
-            );
-            return Err(ESP_ERR_IMAGE_INVALID.to_string());
+            log::error!("new image too small: {} bytes", file_len);
+            return Err(OtaError::InvalidImage);
         }
         if file_len > OTA_MAX_SIZE {
-            log::info!("File is too big ({file_len} bytes).");
-            return Err(ESP_ERR_IMAGE_INVALID.to_string());
+            log::error!("new image too big: {} bytes", file_len);
+            return Err(OtaError::InvalidImage);
         }
-        // get handle to inactive slot
-        // start ota process on inactive slot, get write buffer
-        // loop through request to url with ota buffer as target
-        //   check for FirmwareInfo mid-loop
-        //   break when num_read > file_size
-        // check firmware info and hash
-        let mut ota = EspOta::new().expect("failed to initialize EspOta");
-        let mut work = ota
-            .initiate_update()
-            .expect("failed to initiate ota update");
+
+        let mut ota = EspOta::new().map_err(OtaError::EspError)?;
+        let running_fw_info = ota.get_running_slot().map_err(OtaError::EspError)?.firmware;
+        let mut update_handle = ota.initiate_update().map_err(|_| OtaError::InitError)?;
         let mut buff = vec![0; OTA_CHUNK_SIZE];
         let mut total_read_len: usize = 0;
         let mut got_info = false;
-        let dl_result = loop {
+        while total_read_len < file_len {
             let n = response.read(&mut buff).unwrap_or_default();
             total_read_len += n;
             if !got_info {
-                match self.get_firmware_info(&buff[..n]) {
-                    Ok(info) => log::info!("Firmware to be downloaded: {info:?}"),
-                    Err(e) => {
-                        log::error!("Failed to get firmware info");
-                        break Err(e);
+                let mut loader = EspFirmwareInfoLoader::new();
+                loader.load(&mut buff).map_err(OtaError::EspError)?;
+                let new_fw = loader.get_info().map_err(OtaError::EspError)?;
+
+                log::info!("Firmware to be downloaded: {new_fw:?}");
+                if let Some(ref running_fw) = running_fw_info {
+                    if running_fw.version == new_fw.version {
+                        log::info!("current firmware is up to date");
+                        let _ = update_handle.abort();
+                        return Ok(());
                     }
-                };
+                }
                 got_info = true;
             }
-            if n > 0 {
-                if let Err(e) = work.write(&buff[..n]) {
-                    log::error!("Failed to write to OTA. {e}");
-                    break Err(e);
-                }
+            if n == 0 {
+                break;
             }
-            if total_read_len >= file_len {
-                break Ok(());
+
+            if let Err(e) = update_handle.write(&buff[..n]) {
+                log::error!("Failed to write to OTA. {e}");
+                let _ = update_handle.abort();
+                return Err(OtaError::EspError(e));
             }
-        };
-        if dl_result.is_err() {
-            let _ = work.abort();
-            return Err("download error, aborting ota".to_string());
         }
+
         if total_read_len < file_len {
             log::error!("{total_read_len} bytes downloaded, needed {file_len} bytes");
-            let _ = work.abort();
-            return Err("download incomplete, aborting ota update".to_string());
+            let _ = update_handle.abort();
+            return Err(OtaError::DownloadError(
+                "download incomplete, aborting ota update".to_string(),
+            ));
         }
         // flip ota bit
-        work.complete().expect("failed to complete ota");
+        update_handle.complete().expect("failed to complete ota");
         log::info!("will boot new firmware on reset");
         Ok(())
     }

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -90,7 +90,9 @@ impl OtaService {
             ))?
             .kind
             .as_ref()
-            .ok_or(OtaError::ConfigError("failed to get inner `Value`".to_string()))?
+            .ok_or(OtaError::ConfigError(
+                "failed to get inner `Value`".to_string(),
+            ))?
             .try_into()
             .map_err(|e: AttributeError| OtaError::ConfigError(e.to_string()))?;
 

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -45,6 +45,7 @@ use crate::{
     proto::app::v1::ServiceConfig,
 };
 use embedded_svc::http::{client::Client, Headers};
+use thiserror::Error;
 
 // TODO(RSDK-9200): set according to active partition scheme
 const OTA_MAX_IMAGE_SIZE: usize = 1024 * 1024 * 4; // 4MB
@@ -53,7 +54,7 @@ const OTA_HTTP_BUFSIZE: usize = 1024 * 16; // 16KB
 pub const OTA_MODEL_TYPE: &str = "ota_service";
 pub const OTA_MODEL_TRIPLET: &str = "rdk:builtin:ota_service";
 
-use thiserror::Error;
+// TODO(RSDK-9214)
 #[derive(Error, Debug)]
 pub enum OtaError {
     #[error("{0}")]

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -90,7 +90,7 @@ impl OtaService {
             ))?
             .kind
             .as_ref()
-            .ok_or_else(|| OtaError::ConfigError("failed to get inner `Value`".to_string()))?
+            .ok_or(OtaError::ConfigError("failed to get inner `Value`".to_string()))?
             .try_into()
             .map_err(|e: AttributeError| OtaError::ConfigError(e.to_string()))?;
 

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -183,7 +183,9 @@ impl OtaService {
             ));
         }
         update_handle.complete().map_err(OtaError::EspError)?;
-        log::info!("will boot new firmware on reset");
-        Ok(())
+
+        log::info!("resetting now to boot from new firmware");
+
+        std::process::exit(0);
     }
 }

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -92,7 +92,12 @@ impl OtaService {
 
         let url = match kind {
             crate::google::protobuf::value::Kind::StringValue(s) => s,
-            _ => return Err(OtaError::ConfigError(format!("invalid url value: {:?}", kind))),
+            _ => {
+                return Err(OtaError::ConfigError(format!(
+                    "invalid url value: {:?}",
+                    kind
+                )))
+            }
         };
 
         let _ = url

--- a/micro-rdk/src/esp32/ota.rs
+++ b/micro-rdk/src/esp32/ota.rs
@@ -153,7 +153,9 @@ impl OtaService {
                 log::info!("current firmware: {:?}", running_fw_info);
                 log::info!("new firmware: {:?}", new_fw);
                 if let Some(ref running_fw) = running_fw_info {
-                    if running_fw.version == new_fw.version {
+                    if running_fw.version == new_fw.version
+                        && running_fw.released == new_fw.released
+                    {
                         log::info!("current firmware is up to date");
                         let _ = update_handle.abort();
                         return Ok(());


### PR DESCRIPTION
Next Steps after this PR:
- Convert OtaService to async `Task` [RSDK-9195](https://viam.atlassian.net/browse/RSDK-9195?atlOrigin=eyJpIjoiODAxZDBiM2Y2MzQ3NDIxMGFkMzFiZjY1OTEyYzg3OTciLCJwIjoiaiJ9)
- Use hyper::http2/http1 instead of `EspHttpClient` to reduce code size [RSDK-9198](https://viam.atlassian.net/browse/RSDK-9198?atlOrigin=eyJpIjoiOTgyMWYzNGVjOTc3NGUyZmE2ZWFhZTA4YzNjOTcxMGYiLCJwIjoiaiJ9)
- Add exponential backoff [RSDK-9196](https://viam.atlassian.net/browse/RSDK-9196?atlOrigin=eyJpIjoiYTIzNjFhOWIwOWUyNGI4NTk2NTJlNDI1ODg2NDY4OTYiLCJwIjoiaiJ9)
- Finalize ota init criteria (change in url/version in ServiceConfig, app_desc_t, etc) [RSDK-9197](https://viam.atlassian.net/browse/RSDK-9197?atlOrigin=eyJpIjoiMzM4YjE4NzM1NTI0NDBlZjk0OTUzMWQxYzNiMGY4MmYiLCJwIjoiaiJ9)

Changes in this PR for basic ota implementation:
- [x] new partition table for 8MB devices, `micro-rdk-server/esp32/ota_8mb_partitions.csv`
- [x] new make commands for building ota app-images, `make build-esp32-ota`
- [x] cargo-espflash v3.2.0 req by Makefile
- [x] downloading ota image from a url in an OTA service config
- [x] comparing the currently running app-image with the one to be downloaded
- [x] downloading the new app image
- [x] writing the new image to the next ota partition
- [x] setting to boot from newly written partition on reboot

example build output:
```
Chip type:         esp32
Merge:             false
Skip padding:      false
Bootloader:        /home/mperez/viam/micro-rdk/target/xtensa-esp32-espidf/release/build/esp-idf-sys-6cb1750f97da4845/out/build/bootloader/bootloader.bin
Partition table:   micro-rdk-server/esp32/ota_8mb_partitions.csv
App/part. size:    3,457,808/3,633,152 bytes, 95.17%
[2024-11-01T17:46:32Z INFO ] Image successfully saved!
```

example running ota output
```
I (29977) micro_rdk::esp32::ota: current firmware: Some(FirmwareInfo { version: "v0.3.0-15-gedbe2c1-dirty", released: "Oct 22 2024 14:10:21", description: Some("libespidf"), signature: Some([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), download_id: None })
I (29996) micro_rdk::esp32::ota: new firmware: FirmwareInfo { version: "v0.3.0-15-gedbe2c1-dirty", released: "Oct 22 2024 14:10:21", description: Some("libespidf"), signature: Some([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]), download_id: None }
I (30022) micro_rdk::esp32::ota: current firmware is up to date
I (30029) esp_idf_svc::ota: Dropped
I (30036) micro_rdk::common::conn::viam: ota succeeded
```

To build the 8MB full image to be flashed using `make flash-esp32-bin`:
- add `ota` feature to `micro-rdk-server/Cargo.toml` 
- run `cargo +esp espflash save-image --package micro-rdk-server --merge --chip esp32 target/xtensa-esp32-espidf/micro-rdk-server-esp32.bin -T micro-rdk-server/esp32/ota_8mb_partitions.csv -s 8mb  --bin micro-rdk-server-esp32 --target=xtensa-esp32-espidf  -Zbuild-std=std,panic_abort --release
`

To build the ~3.6MB app image (the download target during ota), run
```
make build-esp32-ota
```

[RSDK-9195]: https://viam.atlassian.net/browse/RSDK-9195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-9196]: https://viam.atlassian.net/browse/RSDK-9196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RSDK-9197]: https://viam.atlassian.net/browse/RSDK-9197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RSDK-9198]: https://viam.atlassian.net/browse/RSDK-9198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ