### PR TITLE
Fix boot loop when upgrading a device to 0.3.1

### DIFF
--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -267,18 +267,24 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         use micro_rdk::common::credentials_storage::RobotConfigurationStorage;
         use micro_rdk::proto::provisioning::v1::CloudConfig;
 
-        let mut ram_storage = RAMStorage::new();
-        // TODO: [RSDK-8923] Get app_address from machine credentials
-        let cloud_conf = if ROBOT_ID.is_some() && ROBOT_SECRET.is_some() && ROBOT_APP_ADDRESS.is_some() {
+        let ram_storage = RAMStorage::new();
+        let cloud_conf = if ROBOT_ID.is_some() && ROBOT_SECRET.is_some()  {
             Some(CloudConfig {
                 id: ROBOT_ID.unwrap().to_string(),
                 secret: ROBOT_SECRET.unwrap().to_string(),
-                app_address: ROBOT_APP_ADDRESS.unwrap().to_string(),
+		app_address: "".to_string(),
             })
         } else {
             None
         }.expect("has_robot_config set in cfg, but build-time configuration failed to set robot credentials");
-        ram_storage.store_robot_credentials(cloud_conf);
+        ram_storage
+            .store_robot_credentials(cloud_conf)
+            .expect("Failed to store cloud config");
+        if ROBOT_APP_ADDRESS.is_some() {
+            ram_storage
+                .store_app_address(ROBOT_APP_ADDRESS.unwrap())
+                .expect("Failed to store app address")
+        }
         ram_storage
     };
 

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -99,12 +99,13 @@ mod esp32 {
                         RobotCredentials::new(
                             ROBOT_ID.unwrap().to_string(),
                             ROBOT_SECRET.unwrap().to_string(),
-                            ROBOT_APP_ADDRESS.unwrap().to_string(),
                         )
-                        .expect("Failed to parse app address")
                         .into(),
                     )
                     .expect("Failed to store robot credentials to NVS");
+                storage
+                    .store_app_address(ROBOT_APP_ADDRESS.unwrap())
+                    .expect("Failed to store app address to NVS")
             }
         }
 

--- a/micro-rdk-server/native/main.rs
+++ b/micro-rdk-server/native/main.rs
@@ -51,7 +51,6 @@ mod native {
                             ROBOT_ID.unwrap().to_string(),
                             ROBOT_SECRET.unwrap().to_string(),
                         )
-                        .expect("Failed to parse app address")
                         .into(),
                     )
                     .expect("Failed to store robot credentials");

--- a/micro-rdk-server/native/main.rs
+++ b/micro-rdk-server/native/main.rs
@@ -50,12 +50,14 @@ mod native {
                         RobotCredentials::new(
                             ROBOT_ID.unwrap().to_string(),
                             ROBOT_SECRET.unwrap().to_string(),
-                            ROBOT_APP_ADDRESS.unwrap().to_string(),
                         )
                         .expect("Failed to parse app address")
                         .into(),
                     )
                     .expect("Failed to store robot credentials");
+                storage
+                    .store_app_address(ROBOT_APP_ADDRESS.unwrap())
+                    .expect("Failed to store app address")
             }
         }
 

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1230,6 +1230,7 @@ mod tests {
     fn test_app_permission_denied() {
         let _unused = global_network_test_lock();
         let ram_storage = RAMStorage::new();
+        let _ = ram_storage.store_app_address(LOCALHOST_URI);
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
             _ => panic!("oops expected ipv4"),
@@ -1288,6 +1289,8 @@ mod tests {
     fn test_app_client_transient_failure() {
         let _unused = global_network_test_lock();
         let ram_storage = RAMStorage::new();
+        let _ = ram_storage.store_app_address(LOCALHOST_URI);
+
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
             _ => panic!("oops expected ipv4"),
@@ -1395,6 +1398,8 @@ mod tests {
     fn test_multiple_connection_http2() {
         let _unused = global_network_test_lock();
         let ram_storage = RAMStorage::new();
+        let _ = ram_storage.store_app_address(LOCALHOST_URI);
+
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
             _ => panic!("oops expected ipv4"),
@@ -1546,6 +1551,8 @@ mod tests {
     fn test_provisioning() {
         let _unused = global_network_test_lock();
         let ram_storage = RAMStorage::new();
+        let _ = ram_storage.store_app_address(LOCALHOST_URI);
+
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),
             _ => panic!("oops expected ipv4"),
@@ -1724,6 +1731,7 @@ mod tests {
             secret: "".to_string(),
             app_address: LOCALHOST_URI.to_owned(),
         };
+        let _ = ram_storage.store_app_address(LOCALHOST_URI);
 
         let network = match local_ip_address::local_ip().expect("error parsing local IP") {
             std::net::IpAddr::V4(ip) => ExternallyManagedNetwork::new(ip),

--- a/micro-rdk/src/common/credentials_storage.rs
+++ b/micro-rdk/src/common/credentials_storage.rs
@@ -15,20 +15,14 @@ use crate::proto::{
 pub struct RobotCredentials {
     pub(crate) robot_id: String,
     pub(crate) robot_secret: String,
-    pub(crate) app_address: Uri,
 }
 
 impl RobotCredentials {
-    pub fn new(
-        robot_id: String,
-        robot_secret: String,
-        app_address: String,
-    ) -> Result<Self, <Uri as FromStr>::Err> {
-        Ok(Self {
+    pub fn new(robot_id: String, robot_secret: String) -> Self {
+        Self {
             robot_secret,
             robot_id,
-            app_address: app_address.parse::<Uri>()?,
-        })
+        }
     }
 
     pub(crate) fn robot_id(&self) -> &str {
@@ -37,10 +31,6 @@ impl RobotCredentials {
 
     pub(crate) fn robot_secret(&self) -> &str {
         &self.robot_secret
-    }
-
-    pub(crate) fn app_address(&self) -> Uri {
-        self.app_address.clone()
     }
 }
 
@@ -59,7 +49,6 @@ impl TryFrom<CloudConfig> for RobotCredentials {
         Ok(Self {
             robot_id: value.id,
             robot_secret: value.secret,
-            app_address: value.app_address.parse::<Uri>()?,
         })
     }
 }
@@ -67,7 +56,7 @@ impl TryFrom<CloudConfig> for RobotCredentials {
 impl From<RobotCredentials> for CloudConfig {
     fn from(value: RobotCredentials) -> Self {
         Self {
-            app_address: value.app_address.to_string(),
+            app_address: "".to_string(),
             id: value.robot_id,
             secret: value.robot_secret,
         }
@@ -122,6 +111,11 @@ pub trait RobotConfigurationStorage {
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error>;
     fn reset_robot_credentials(&self) -> Result<(), Self::Error>;
 
+    fn has_app_address(&self) -> bool;
+    fn store_app_address(&self, uri: &str) -> Result<(), Self::Error>;
+    fn get_app_address(&self) -> Result<Uri, Self::Error>;
+    fn reset_app_address(&self) -> Result<(), Self::Error>;
+
     fn has_robot_configuration(&self) -> bool;
     fn store_robot_configuration(&self, cfg: &RobotConfig) -> Result<(), Self::Error>;
     fn get_robot_configuration(&self) -> Result<RobotConfig, Self::Error>;
@@ -139,6 +133,7 @@ struct RAMCredentialStorageInner {
     robot_config: Option<RobotConfig>,
     wifi_creds: Option<WifiCredentials>,
     tls_cert: Option<TlsCertificate>,
+    app_address: Option<String>,
 }
 
 /// Simple CrendentialStorage made for testing purposes
@@ -152,6 +147,7 @@ impl RAMStorage {
             robot_config: None,
             wifi_creds: None,
             tls_cert: None,
+            app_address: None,
         })))
     }
 }
@@ -218,6 +214,28 @@ impl RobotConfigurationStorage for RAMStorage {
         let mut inner_ref = self.0.lock().unwrap();
         let _ = inner_ref.tls_cert.take();
         Ok(())
+    }
+    fn store_app_address(&self, uri: &str) -> Result<(), Self::Error> {
+        let mut inner_ref = self.0.lock().unwrap();
+        let _ = inner_ref.app_address.insert(uri.to_string());
+        Ok(())
+    }
+    fn get_app_address(&self) -> Result<Uri, Self::Error> {
+        let inner_ref = self.0.lock().unwrap();
+        inner_ref
+            .app_address
+            .clone()
+            .unwrap_or_default()
+            .parse::<Uri>()
+    }
+    fn reset_app_address(&self) -> Result<(), Self::Error> {
+        let mut inner_ref = self.0.lock().unwrap();
+        let _ = inner_ref.app_address.take();
+        Ok(())
+    }
+    fn has_app_address(&self) -> bool {
+        let inner_ref = self.0.lock().unwrap();
+        inner_ref.app_address.is_some()
     }
 }
 

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -145,12 +145,25 @@ impl RobotConfigurationStorage for NVSStorage {
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
         let robot_secret = self.get_string(NVS_ROBOT_SECRET_KEY)?;
         let robot_id = self.get_string(NVS_ROBOT_ID_KEY)?;
-        let app_address = self.get_string(NVS_ROBOT_APP_ADDRESS)?;
         Ok(RobotCredentials {
             robot_secret,
             robot_id,
-            app_address: app_address.parse::<Uri>()?,
         })
+    }
+
+    fn get_app_address(&self) -> Result<Uri, Self::Error> {
+        Ok(self.get_string(NVS_ROBOT_APP_ADDRESS)?.parse::<Uri>()?)
+    }
+
+    fn has_app_address(&self) -> bool {
+        self.has_string(NVS_ROBOT_APP_ADDRESS).unwrap_or(false)
+    }
+
+    fn store_app_address(&self, uri: &str) -> Result<(), Self::Error> {
+        self.set_string(NVS_ROBOT_APP_ADDRESS, uri)
+    }
+    fn reset_app_address(&self) -> Result<(), Self::Error> {
+        self.erase_key(NVS_ROBOT_APP_ADDRESS)
     }
 
     fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error> {

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -176,7 +176,6 @@ impl RobotConfigurationStorage for NVSStorage {
     fn reset_robot_credentials(&self) -> Result<(), Self::Error> {
         self.erase_key(NVS_ROBOT_SECRET_KEY)?;
         self.erase_key(NVS_ROBOT_ID_KEY)?;
-        self.erase_key(NVS_ROBOT_APP_ADDRESS)?;
         Ok(())
     }
 

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -83,7 +83,7 @@ fn main() {
     if !storage.has_robot_configuration() {
         // check if any were statically compiled
         // TODO(RSDK-9148): update with app address storage logic when version is incremented
-        if ROBOT_ID.is_some() && ROBOT_SECRET.is_some() {
+        if ROBOT_ID.is_some() && ROBOT_SECRET.is_some() && ROBOT_APP_ADDRESS.is_some() {
             log::info!("Storing static values from build time robot configuration to NVS");
             storage
                 .store_robot_credentials(

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -90,12 +90,13 @@ fn main() {
                     RobotCredentials::new(
                         ROBOT_ID.unwrap().to_string(),
                         ROBOT_SECRET.unwrap().to_string(),
-                        ROBOT_APP_ADDRESS.unwrap().to_string(),
                     )
-                    .expect("Failed to parse app address")
                     .into(),
                 )
                 .expect("Failed to store robot credentials to NVS");
+            storage
+                .store_app_address(ROBOT_APP_ADDRESS.unwrap())
+                .expect("Failed to store app address to NVS")
         }
     }
 


### PR DESCRIPTION
[This PR](https://github.com/viamrobotics/micro-rdk/pull/338) introduced a bug where when upgrading systems to 0.3.1 the server will enter a boot loop because app address wouldn't have been stored before. This PR introduce a fix to default to app.viam.com and stores that if app address is not present in storage. In the future (like a month or two) this commit should be reversed so that the implementation in the PR remains the one we use.