### PR TITLE
adjust README module dependency example

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -130,7 +130,7 @@ editing the `Cargo.toml` file to point to a path instead:
 [dependencies]
 ...
 micro-rdk = { path = "../micro-rdk/micro-rdk, features = ["esp32", "binstart","provisioning"] }
-micro-rdk-modular-driver-example = { path = "../micro-rdk/examples/modular-drives" }
+micro-rdk-modular-driver-example = { path = "../micro-rdk/examples/modular-drivers" }
 ```
 
 It is a nuisance to maintain these edits: avoiding checking them in,

--- a/examples/modular-drivers/README.md
+++ b/examples/modular-drivers/README.md
@@ -35,7 +35,7 @@ index 79fbc5c..949b5ab 100644
  smol = "1.2"
  futures-lite = "1.12.0"
  micro-rdk = {version = "0.0.3", git = "https://github.com/viamrobotics/micro-rdk.git", features = ["esp32"]}
-+micro-rdk-modular-driver-example = { git = "https://github.com/viamrobotics/micro-rdk/tree/main/examples/modular-drivers" }
++micro-rdk-modular-driver-example = { git = "https://github.com/viamrobotics/micro-rdk/.git", package = "micro-rdk-modular-driver-example" }
 ```
 
 Rebuild the project per the above Micro-RDK Development Setup


### PR DESCRIPTION
The previous line was not working for some reason when used in an actual project. This new way is more canonical to Cargo anyway I believe.