### PR TITLE
[RSDK-9283] add ota metadata storage, compare stored and latest

### DIFF
--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -51,10 +51,7 @@ use super::server::{IncomingConnectionManager, WebRtcConfiguration};
 use crate::common::provisioning::server::AsNetwork;
 
 #[cfg(feature = "ota")]
-use crate::{
-    common::{credentials_storage::OtaMetadataStorage, ota},
-    proto::app::v1::ServiceConfig,
-};
+use crate::common::{credentials_storage::OtaMetadataStorage, ota};
 
 pub struct RobotCloudConfig {
     local_fqdn: String,

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -542,7 +542,7 @@ where
                 .iter()
                 .find(|&service| service.model == *ota::OTA_MODEL_TRIPLET)
             {
-                match ota::OtaService::from_config_boxed(
+                match ota::OtaService::from_config(
                     service,
                     self.storage.clone(),
                     self.executor.clone(),

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -529,6 +529,13 @@ where
             log::error!("couldn't store the robot configuration reason {:?}", err);
         }
 
+        let config_monitor_task = Box::new(ConfigMonitor::new(
+            config.clone(),
+            self.storage.clone(),
+            || std::process::exit(0),
+        ));
+        self.app_client_tasks.push(config_monitor_task);
+
         #[cfg(feature = "ota")]
         {
             log::debug!("ota feature enabled");
@@ -559,13 +566,6 @@ where
                 );
             }
         }
-
-        let config_monitor_task = Box::new(ConfigMonitor::new(
-            config.clone(),
-            self.storage.clone(),
-            || std::process::exit(0),
-        ));
-        self.app_client_tasks.push(config_monitor_task);
 
         let mut robot = LocalRobot::from_cloud_config(
             self.executor.clone(),

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -51,7 +51,10 @@ use super::server::{IncomingConnectionManager, WebRtcConfiguration};
 use crate::common::provisioning::server::AsNetwork;
 
 #[cfg(feature = "ota")]
-use crate::{common::{credentials_storage::OtaMetadataStorage, ota}, proto::app::v1::ServiceConfig};
+use crate::{
+    common::{credentials_storage::OtaMetadataStorage, ota},
+    proto::app::v1::ServiceConfig,
+};
 
 pub struct RobotCloudConfig {
     local_fqdn: String,
@@ -535,9 +538,11 @@ where
                 .iter()
                 .find(|&service| service.model == *ota::OTA_MODEL_TRIPLET)
             {
-                if let Ok(mut ota) =
-                    ota::OtaService::from_config(service, self.storage.clone(), self.executor.clone())
-                {
+                if let Ok(mut ota) = ota::OtaService::from_config(
+                    service,
+                    self.storage.clone(),
+                    self.executor.clone(),
+                ) {
                     self.ota_service_task
                         .replace(self.executor.spawn(async move {
                             if let Err(e) = ota.update().await {

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -542,7 +542,7 @@ where
                 .iter()
                 .find(|&service| service.model == *ota::OTA_MODEL_TRIPLET)
             {
-                match ota::OtaService::from_config(
+                match ota::OtaService::from_config_boxed(
                     service,
                     self.storage.clone(),
                     self.executor.clone(),

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -527,7 +527,9 @@ where
                 .iter()
                 .find(|&service| service.model == *ota::OTA_MODEL_TRIPLET)
             {
-                if let Ok(mut ota) = ota::OtaService::from_config(service, self.executor.clone()) {
+                // TODO, get cached robot config and pass through to ota init
+                //let curr_conf = self.sto
+                if let Ok(mut ota) = ota::OtaService::from_config(service, None, self.executor.clone()) {
                     self.ota_service_task
                         .replace(self.executor.spawn(async move {
                             if let Err(e) = ota.update().await {

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -187,13 +187,13 @@ impl OtaService {
             }
         };
 
-        let curr_version = match curr_config {
-            Some(curr_config) => {
-                let kind = new_config.attributes.as_ref().ok_or_else(|| {
+        let current_version: String = match current_config {
+            Some(current_config) => {
+                let kind = current_config.attributes.as_ref().ok_or_else(|| {
                     OtaError::ConfigError("config missing `attributes`".to_string())
                 })?;
 
-                let curr_version = kind
+                let current_version = kind
                     .fields
                     .get("version")
                     .ok_or(OtaError::ConfigError(
@@ -206,12 +206,12 @@ impl OtaService {
                     ))?
                     .try_into()
                     .map_err(|e: AttributeError| OtaError::ConfigError(e.to_string()))?;
-                match pending_version {
+                match current_version {
                     Kind::StringValue(s) => s,
                     _ => {
                         return Err(OtaError::ConfigError(format!(
-                            "invalid url value: {:?}",
-                            pending_version
+                            "invalid format: {:?}",
+                            current_version
                         )))
                     }
                 }
@@ -224,15 +224,14 @@ impl OtaService {
             url,
             connector,
             exec,
-            url,
             pending_version,
-            curr_version,
+            current_version,
         })
     }
 
     pub(crate) async fn update(&mut self) -> Result<(), OtaError> {
-        if self.pending_version == self.curr_version {
-            log::info!("firmware is up-to-date: {}", self.curr_version);
+        if self.pending_version == self.current_version {
+            log::info!("firmware is up-to-date: {}", self.current_version);
             return Ok(());
         }
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -218,7 +218,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             .get_ota_metadata()
             .map_err(|e| OtaError::Other(e.to_string()))?;
 
-        if self.pending_version == stored_metadata.version {
+        if self.pending_version == stored_metadata.version() {
             log::info!("firmware is up-to-date: {}", stored_metadata.version);
             return Ok(());
         }

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -294,11 +294,11 @@ impl<S: OtaMetadataStorage> OtaService<S> {
                 .map_err(|e| OtaError::Other(e.to_string()))?
         };
 
-        let conn = self.exec.spawn(async move {
+        let conn = Box::new(self.exec.spawn(async move {
             if let Err(err) = conn.await {
                 log::error!("connection failed: {:?}", err);
             }
-        });
+        }));
 
         log::info!("ota connected, beginning download");
         let request = Request::builder()

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -219,7 +219,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             .map_err(|e| OtaError::Other(e.to_string()))?;
 
         if self.pending_version == stored_metadata.version {
-            log::info!("firmware is up-to-date: {}", self.current_version);
+            log::info!("firmware is up-to-date: {}", stored_metadata.version);
             return Ok(());
         }
 
@@ -400,8 +400,8 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         log::info!("updating metadata in NVS");
         self.storage
-            .set_ota_metadata(OtaMetadata {
-                self.pending_version.clone()
+            .store_ota_metadata(OtaMetadata {
+                version: self.pending_version.clone()
             })
             .map_err(|e| OtaError::Other(e.to_string()))?;
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -401,7 +401,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
         log::info!("updating metadata in NVS");
         self.storage
             .store_ota_metadata(OtaMetadata {
-                version: self.pending_version.clone()
+                version: self.pending_version.clone(),
             })
             .map_err(|e| OtaError::Other(e.to_string()))?;
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -148,13 +148,6 @@ pub(crate) struct OtaService<S: OtaMetadataStorage> {
 }
 
 impl<S: OtaMetadataStorage> OtaService<S> {
-    pub(crate) fn from_config_boxed(
-        new_config: &ServiceConfig,
-        storage: S,
-        exec: Executor,
-    ) -> Result<Box<Self>, OtaError> {
-        Ok(Box::new(Self::from_config(new_config, storage, exec)?))
-    }
     pub(crate) fn from_config(
         new_config: &ServiceConfig,
         storage: S,

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -135,6 +135,32 @@ const NVS_WIFI_PASSWORD_KEY: &str = "WIFI_PASSWORD";
 const NVS_TLS_CERTIFICATE_KEY: &str = "TLS_CERT";
 const NVS_TLS_PRIVATE_KEY_KEY: &str = "TLS_PRIV_KEY";
 
+#[cfg(feature = "ota")]
+const NVS_OTA_VERSION_KEY: &str = "OTA_VERSION";
+#[cfg(feature = "ota")]
+use crate::common::{credentials_storage::OtaMetadataStorage, ota::OtaMetadata};
+
+#[cfg(feature = "ota")]
+impl OtaMetadataStorage for NVSStorage {
+    type Error = NVSStorageError;
+    fn has_ota_metadata(&self) -> bool {
+        self.has_string(NVS_OTA_VERSION_KEY).unwrap_or(false)
+    }
+    fn get_ota_metadata(&self) -> Result<OtaMetadata, Self::Error> {
+        let version = self.get_string(NVS_OTA_VERSION_KEY)?;
+        Ok(
+        OtaMetadata {
+            version
+        })
+    }
+    fn store_ota_metadata(&self, ota_metadata: OtaMetadata) -> Result<(), Self::Error>{
+        self.set_string(NVS_OTA_VERSION_KEY, &ota_metadata.version)
+    }
+    fn reset_ota_metadata(&self) -> Result<(), Self::Error> {
+        self.erase_key(NVS_OTA_VERSION_KEY)
+    }
+}
+
 impl RobotConfigurationStorage for NVSStorage {
     type Error = NVSStorageError;
     fn has_robot_credentials(&self) -> bool {

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -148,12 +148,9 @@ impl OtaMetadataStorage for NVSStorage {
     }
     fn get_ota_metadata(&self) -> Result<OtaMetadata, Self::Error> {
         let version = self.get_string(NVS_OTA_VERSION_KEY)?;
-        Ok(
-        OtaMetadata {
-            version
-        })
+        Ok(OtaMetadata { version })
     }
-    fn store_ota_metadata(&self, ota_metadata: OtaMetadata) -> Result<(), Self::Error>{
+    fn store_ota_metadata(&self, ota_metadata: OtaMetadata) -> Result<(), Self::Error> {
         self.set_string(NVS_OTA_VERSION_KEY, &ota_metadata.version)
     }
     fn reset_ota_metadata(&self) -> Result<(), Self::Error> {


### PR DESCRIPTION
Instead of storing the OTA ServiceConfig in storage like originally planned, using the cached robot config achieves the same effect.

Still testing on hardware, will update when verified