### PR TITLE
[RSDK-9213] Ensure ice agent is terminated if signaling doesn't complete

### DIFF
--- a/micro-rdk/src/common/webrtc/api.rs
+++ b/micro-rdk/src/common/webrtc/api.rs
@@ -683,9 +683,7 @@ where
         // Make sure that if we leave this scope without passing
         // ownership of the `ice_agent` notifier to a new
         // WebRTCConnection that the ICEAgent is terminated.
-        let ice_done_guard = scopeguard::guard(
-            self.ice_agent.clone(), |ia| ia.done(),
-        );
+        let ice_done_guard = scopeguard::guard(self.ice_agent.clone(), |ia| ia.done());
 
         self.run_ice_until_connected(&answer)
             .or(async {

--- a/micro-rdk/src/common/webrtc/api.rs
+++ b/micro-rdk/src/common/webrtc/api.rs
@@ -35,6 +35,7 @@ use base64::{engine::general_purpose, Engine};
 use either::Either;
 use futures_lite::{Future, FutureExt, StreamExt};
 use prost::{DecodeError, EncodeError};
+use scopeguard::ScopeGuard;
 use sdp::{
     description::{
         common::{Address, ConnectionInformation},
@@ -679,6 +680,13 @@ where
         answer: Box<WebRtcSdp>,
         robot: Arc<Mutex<LocalRobot>>,
     ) -> Result<WebRTCConnection, ServerError> {
+        // Make sure that if we leave this scope without passing
+        // ownership of the `ice_agent` notifier to a new
+        // WebRTCConnection that the ICEAgent is terminated.
+        let ice_done_guard = scopeguard::guard(
+            self.ice_agent.clone(), |ia| ia.done(),
+        );
+
         self.run_ice_until_connected(&answer)
             .or(async {
                 Timer::after(Duration::from_secs(10)).await;
@@ -704,7 +712,7 @@ where
         Ok(WebRTCConnection::new(
             srv,
             self.transport,
-            self.ice_agent,
+            ScopeGuard::into_inner(ice_done_guard),
             c.1,
         ))
     }


### PR DESCRIPTION
Inside `run_ice_until_connected` a detached task is spawned for `ICEAgent::run`. That task can be canceled by calling `done` on the associated `AtomicSync` (`WebRtcApi::ice_agent`). In normal operation, that happens when the `AtomicSync` is stashed into a created `WebRTCConnection` which does indeed call `done` on the `AtomicSync` in its `Drop` implementation.

However, if `WebRtcApi::connect` launches the `ICEAgent::run` task in `run_ice_until_connected`, but does not proceed far enough to create the `WebRTCConnection`, then the detached task will never stop.

This exact scenario can happen if a client issues two WebRTC connection requests, one via app.viam.com signaling and the other via local signaling, and one of them gets cancelled during the critical window. It could also happen if a client crashes or is ^C'd in the middle of signaling.

I've written a not great fix for this in the interest time and minimal change to the complex code in `api.rs`: it simply creates a scope guard that ensures that `done` is called on the `AtomicSync` if no `WebRTCConnection` object is produced to take over that responsibility.