### PR TITLE
[RSDK-9196] add init connection retry

### DIFF
--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -274,13 +274,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             uri = hyper::Uri::from_parts(parts).map_err(|e| OtaError::Other(e.to_string()))?;
         };
 
-        let io = self
-            .connector
-            .connect_to(&uri)
-            .map_err(|e| OtaError::Other(e.to_string()))?
-            .await
-            .map_err(|e| OtaError::Other(e.to_string()))?;
-
         let (mut sender, conn) = loop {
             match self.connector.connect_to(&uri) {
                 Ok(connection) => {


### PR DESCRIPTION
This adds a retry in the event a connection cannot be established (ex no network connection).
It does not implement resumable download.

It compiles, but need to verify on native and hardware. won't merge before doing so