### PR TITLE
[RSDK-9296] [RSDK-9310] Improve interactions with STUN server

### DIFF
--- a/micro-rdk/src/common/webrtc/api.rs
+++ b/micro-rdk/src/common/webrtc/api.rs
@@ -590,7 +590,10 @@ where
         log::info!("gathering local candidates");
         let _ = ice_agent.local_candidates().await.inspect_err(|e| {
             if ice_agent.local_candidates.is_empty() {
-                log::warn!("Failed to generate any local candidates for incoming WebRTC connection: {}", e);
+                log::warn!(
+                    "Failed to generate any local candidates for incoming WebRTC connection: {}",
+                    e
+                );
             }
         });
 

--- a/micro-rdk/src/common/webrtc/api.rs
+++ b/micro-rdk/src/common/webrtc/api.rs
@@ -588,7 +588,11 @@ where
         self.signaling.send_sdp_answer(answer).await?;
 
         log::info!("gathering local candidates");
-        ice_agent.local_candidates().await.unwrap();
+        let _ = ice_agent.local_candidates().await.inspect_err(|e| {
+            if ice_agent.local_candidates.is_empty() {
+                log::warn!("Failed to generate any local candidates for incoming WebRTC connection: {}", e);
+            }
+        });
 
         for c in &ice_agent.local_candidates {
             log::debug!("sending local candidates {:?}", c);

--- a/micro-rdk/src/common/webrtc/ice.rs
+++ b/micro-rdk/src/common/webrtc/ice.rs
@@ -154,7 +154,13 @@ impl ICEAgent {
         }
 
         log::debug!("local_candidates: registering intrinsic local candidate");
-        let our_ip = SocketAddrV4::new(self.local_ip, self.transport.local_address().map_err(|_| IceError::IceIoError)?.port());
+        let our_ip = SocketAddrV4::new(
+            self.local_ip,
+            self.transport
+                .local_address()
+                .map_err(|_| IceError::IceIoError)?
+                .port(),
+        );
         let local_cand = Candidate::new_host_candidate(our_ip);
         self.local_candidates.push(local_cand);
 
@@ -175,15 +181,15 @@ impl ICEAgent {
             Err(err) => {
                 log::warn!("Failed trying to resolve STUN server address; no reflexive candidate will be generated: {}", err);
                 return Ok(());
-            },
+            }
         };
 
         let stun_ip = match stun_ip.next() {
             Some(stun_ip) => stun_ip,
             None => {
                 log::warn!("STUN server address resolution found no records; no reflexive candidate will be generated");
-                return Ok(())
-            },
+                return Ok(());
+            }
         };
 
         let stun_ip = match stun_ip {

--- a/micro-rdk/src/common/webrtc/udp_mux.rs
+++ b/micro-rdk/src/common/webrtc/udp_mux.rs
@@ -295,6 +295,10 @@ impl UdpMux {
     pub(crate) async fn send_to(&self, buf: &[u8], peer: SocketAddr) -> Result<usize> {
         self.muxer.send_to(buf, peer).await
     }
+
+    pub(crate) fn local_address(&self) -> Result<SocketAddr> {
+        self.muxer.socket.get_ref().local_addr()
+    }
 }
 
 impl Drop for UdpMux {


### PR DESCRIPTION
Failing to resolve the STUN server should not crash, since this is a realistic scenario during an offline reboot.

Similarly, failing to resolve or reach the STUN server shouldn't inhibit generating a local candidate based on the local host/port, since this can be used now by local signaling.