### PR TITLE
Pin IDF component micro-RDK version to v0.3.0

### DIFF
--- a/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
+++ b/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 idf_build_set_property(INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/assets" APPEND)
 
-set(LIBMICRORDK_VERSION v0.3.3)
+set(LIBMICRORDK_VERSION v0.3.0)
 set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${LIBMICRORDK_VERSION}/micro-rdk-lib.zip)
 set(LIBMICRORDK_PATH ${CMAKE_BINARY_DIR}/import/micro-rdk-lib.zip)
 


### PR DESCRIPTION
This is due to a regression regarding a client, when v0.3.5 is released this should be changed back to the latest stable version