### PR TITLE
[RSDK-9344] Use snappy for robot configuration compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,6 +2754,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "snap",
  "socket2",
  "stun_codec",
  "test-log",
@@ -4155,6 +4156,12 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ secrecy = { version = "~0.8.0", features = ["serde"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde_json = "1.0.133"
 sha2 = "0.10.8"
+snap = "1.1.1"
 socket2 = "0.5.8"
 stun_codec = { version = "0.3.0" , git = "https://github.com/viamrobotics/stun_codec"}
 syn = "2.0.90"

--- a/micro-rdk/Cargo.toml
+++ b/micro-rdk/Cargo.toml
@@ -89,6 +89,7 @@ stun_codec.workspace = true
 thiserror.workspace = true
 trackable.workspace = true
 uuid = { workspace = true, features = ["v4"]}
+snap.workspace = true
 
 [build-dependencies]
 embuild.workspace = true


### PR DESCRIPTION
- Before adding `snap`: `App/part. size:    3,452,128/4,128,767 bytes, 83.61%`
- After adding `snap`: `App/part. size:    3,487,808/4,128,767 bytes, 84.48%`

To test, I pasted a well-known large configuration (obtained by looking at the debug expansion of a fragment) into an attribute section of a sensor. Logs say:

```
I (8390) micro_rdk::esp32::nvs_storage: robot configuration compressed for NVS storage: 6510 bytes before, 3735 bytes after
```

So a 2,775 byte savings here, which isn't nothing given our NVS size bounds. The choice of snappy was somewhat arbitrary here, in that I tried it and it worked.

