### PR TITLE
[RSDK-9593] move ota to config monitor, config monitor restart hook 

### DIFF
--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -30,7 +30,8 @@ where
     pub fn new(
         curr_config: Box<RobotConfig>,
         storage: Storage,
-        #[cfg(feature = "ota")] executor: Executor,
+        #[cfg(feature = "ota")]
+        executor: Executor,
         restart_hook: impl Fn() + 'a,
     ) -> Self {
         Self {

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -30,8 +30,7 @@ where
     pub fn new(
         curr_config: Box<RobotConfig>,
         storage: Storage,
-        #[cfg(feature = "ota")]
-        executor: Executor,
+        #[cfg(feature = "ota")] executor: Executor,
         restart_hook: impl Fn() + 'a,
     ) -> Self {
         Self {

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -132,6 +132,7 @@ where
                         e
                     );
                 } else {
+                    // TODO(RSDK-9464): flush logs to app.viam before restarting
                     self.restart();
                 }
             }

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -30,7 +30,8 @@ where
     pub fn new(
         curr_config: Box<RobotConfig>,
         storage: Storage,
-        #[cfg(feature = "ota")] executor: Executor,
+        #[cfg(feature = "ota")]
+        executor: Executor,
         restart_hook: impl Fn() + 'a,
     ) -> Self {
         Self {
@@ -87,6 +88,7 @@ where
                         .iter()
                         .find(|&service| service.model == *ota::OTA_MODEL_TRIPLET)
                     {
+                        // TODO(RSDK-9676): new OtaService created at every invocation, not ideal
                         match ota::OtaService::from_config(
                             service,
                             self.storage.clone(),

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -482,10 +482,10 @@ where
 
         #[cfg(feature = "ota")]
         {
-            if self.storage.has_ota_metadata() {
-                let metadata = self.storage.get_ota_metadata().unwrap_or_default();
-                log::info!("firmware version: {}", metadata.version);
-            }
+            match self.storage.get_ota_metadata() {
+                Ok(metadata) => log::info!("firmware version: {}", metadata.version),
+                Err(e) => log::warn!("not OTA firmware metadata available: {}", e),
+            };
         }
 
         // Since provisioning was run and completed, credentials are properly populated

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -567,11 +567,12 @@ where
             log::error!("couldn't store the robot configuration reason {:?}", err);
         }
 
-        let hook = if cfg!(feature = "esp32") {
-            || crate::esp32::esp_idf_svc::hal::reset::restart()
-        } else {
-            || std::process::exit(0)
-        };
+        #[cfg(feature = "esp32")]
+        let hook =
+            || crate::esp32::esp_idf_svc::hal::reset::restart();
+
+        #[cfg(not(feature = "esp32"))]
+        let hook = || std::process::exit(0);
 
         let config_monitor_task = Box::new(ConfigMonitor::new(
             config.clone(),

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -575,17 +575,12 @@ where
             log::error!("couldn't store the robot configuration reason {:?}", err);
         }
 
-        #[cfg(feature = "esp32")]
-        let hook = || crate::esp32::esp_idf_svc::hal::reset::restart();
-        #[cfg(not(feature = "esp32"))]
-        let hook = || std::process::exit(0);
-
         let config_monitor_task = Box::new(ConfigMonitor::new(
             config.clone(),
             self.storage.clone(),
             #[cfg(feature = "ota")]
             self.executor.clone(),
-            hook,
+            || std::process::exit(0),
         ));
         self.app_client_tasks.push(config_monitor_task);
 

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -568,8 +568,7 @@ where
         }
 
         #[cfg(feature = "esp32")]
-        let hook =
-            || crate::esp32::esp_idf_svc::hal::reset::restart();
+        let hook = || crate::esp32::esp_idf_svc::hal::reset::restart();
 
         #[cfg(not(feature = "esp32"))]
         let hook = || std::process::exit(0);

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -480,6 +480,14 @@ where
             self.provision().await;
         }
 
+        #[cfg(feature = "ota")]
+        {
+            if self.storage.has_ota_metadata() {
+                let metadata = self.storage.get_ota_metadata().unwrap_or_default();
+                log::info!("firmware version: {}", metadata.version);
+            }
+        }
+
         // Since provisioning was run and completed, credentials are properly populated
         // if wifi manager is configured loop forever until wifi is connected
         if let Some(wifi) = self.wifi_manager.as_ref().as_ref() {
@@ -569,7 +577,6 @@ where
 
         #[cfg(feature = "esp32")]
         let hook = || crate::esp32::esp_idf_svc::hal::reset::restart();
-
         #[cfg(not(feature = "esp32"))]
         let hook = || std::process::exit(0);
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -274,12 +274,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
     }
 
     pub(crate) async fn needs_update(&self) -> bool {
-        let curr_metadata = self.stored_metadata().await;
-        if curr_metadata.version == self.pending_version {
-            false
-        } else {
-            true
-        }
+        self.stored_metadata().await.version != self.pending_version
     }
 
     pub(crate) fn pending_version(&self) -> &str {

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -304,7 +304,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         let mut num_tries = 0;
         let (mut sender, conn) = loop {
-            num_tries += 1;
             if num_tries == NUM_RETRY_CONN {
                 return Err(OtaError::Other(
                     "failed to establish connection".to_string(),
@@ -343,6 +342,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
                 CONN_RETRY_SECS
             );
             Timer::after(Duration::from_secs(CONN_RETRY_SECS)).await;
+            num_tries += 1;
         };
 
         let conn = Box::new(self.exec.spawn(async move {

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -508,14 +508,10 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         log::info!("firmware update complete");
 
-        // Test experimental ffi accesses here to be recoverable without flashing
+        // Note: test experimental ota ffi accesses here to be recoverable without flashing
         #[cfg(feature = "esp32")]
         {
-            log::info!(
-                "next reboot will load firmware from `{:#x}`",
-                self.address
-            );
-            // TODO(RSDK-9464): flush logs to app.viam before restarting
+            log::info!("next reboot will load firmware from `{:#x}`", self.address);
         }
 
         Ok(())

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -190,7 +190,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
         exec: Executor,
     ) -> Result<Self, OtaError<S>> {
         let kind = new_config.attributes.as_ref().ok_or_else(|| {
-            ConfigError::Other("ota service config has no attributes".to_string())
+            ConfigError::Other("OTA service config has no attributes".to_string())
         })?;
 
         let url = kind

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -170,7 +170,7 @@ pub(crate) struct OtaService<S: OtaMetadataStorage> {
 }
 
 impl<S: OtaMetadataStorage> OtaService<S> {
-    pub(crate) async fn stored_metadata(&self) -> OtaMetadata {
+    pub(crate) fn stored_metadata(&self) -> OtaMetadata {
         if !self.storage.has_ota_metadata() {
             log::info!("no ota metadata currently stored in NVS");
         }
@@ -268,14 +268,14 @@ impl<S: OtaMetadataStorage> OtaService<S> {
         })
     }
 
-    pub(crate) async fn needs_update(&self) -> bool {
+    pub(crate) fn needs_update(&self) -> bool {
         self.stored_metadata().await.version != self.pending_version
     }
 
     /// Attempts to perform an OTA update.
     /// On success, returns an `Ok(true)` or `Ok(false)` indicating if a reboot is necessary.
     pub(crate) async fn update(&mut self) -> Result<bool, OtaError> {
-        if !(self.needs_update().await) {
+        if !(self.needs_update()) {
             return Ok(false);
         }
 
@@ -527,7 +527,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         log::info!("firmware update complete");
         // verifies nvs was stored correctly
-        let curr_metadata = self.stored_metadata().await;
+        let curr_metadata = self.stored_metadata();
         log::info!(
             "firmware update successful: version `{}`",
             curr_metadata.version

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -167,7 +167,6 @@ pub(crate) struct OtaService<S: OtaMetadataStorage> {
     pending_version: String,
     max_size: usize,
     address: usize,
-    testing: bool,
 }
 
 impl<S: OtaMetadataStorage> OtaService<S> {
@@ -205,21 +204,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             Kind::StringValue(s) => Ok(s),
             _ => Err(ConfigError::Other(format!("invalid url value: {:?}", kind))),
         }?;
-
-        let testing = if let Some(k) = kind.fields.get("test") {
-            let v = k
-                .kind
-                .as_ref()
-                .unwrap_or(&crate::google::protobuf::value::Kind::BoolValue(false))
-                .try_into()
-                .unwrap();
-            match v {
-                Kind::BoolValue(b) => b,
-                _ => false,
-            }
-        } else {
-            false
-        };
 
         let pending_version = kind
             .fields
@@ -281,7 +265,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             pending_version,
             max_size,
             address,
-            testing,
         })
     }
 
@@ -292,7 +275,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
     /// Attempts to perform an OTA update.
     /// On success, returns an `Ok(true)` or `Ok(false)` indicating if a reboot is necessary.
     pub(crate) async fn update(&mut self) -> Result<bool, OtaError> {
-        if !(self.needs_update().await) && !self.testing {
+        if !(self.needs_update().await) {
             return Ok(false);
         }
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -167,6 +167,7 @@ pub(crate) struct OtaService<S: OtaMetadataStorage> {
     pending_version: String,
     max_size: usize,
     address: usize,
+    testing: bool,
 }
 
 impl<S: OtaMetadataStorage> OtaService<S> {
@@ -204,6 +205,21 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             Kind::StringValue(s) => Ok(s),
             _ => Err(ConfigError::Other(format!("invalid url value: {:?}", kind))),
         }?;
+
+        let testing = if let Some(k) = kind.fields.get("test") {
+            let v = k
+                .kind
+                .as_ref()
+                .unwrap_or(&crate::google::protobuf::value::Kind::BoolValue(false))
+                .try_into()
+                .unwrap();
+            match v {
+                Kind::BoolValue(b) => b,
+                _ => false,
+            }
+        } else {
+            false
+        };
 
         let pending_version = kind
             .fields
@@ -265,6 +281,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
             pending_version,
             max_size,
             address,
+            testing,
         })
     }
 
@@ -275,7 +292,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
     /// Attempts to perform an OTA update.
     /// On success, returns an `Ok(true)` or `Ok(false)` indicating if a reboot is necessary.
     pub(crate) async fn update(&mut self) -> Result<bool, OtaError> {
-        if !(self.needs_update().await) {
+        if !(self.needs_update().await) && !self.testing {
             return Ok(false);
         }
 

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -331,6 +331,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
                 Ok(connection) => {
                     match connection.await {
                         Ok(io) => {
+                            // TODO(RSDK-9617): add timeout for stalled download
                             match http2::Builder::new(self.exec.clone())
                                 .max_frame_size(16_384) // lowest configurable
                                 .timer(H2Timer)

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -307,7 +307,8 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         let mut num_tries = 0;
         let (mut sender, conn) = loop {
-            if num_tries == NUM_RETRY_CONN {
+            num_tries += 1;
+            if num_tries == NUM_RETRY_CONN + 1 {
                 return Err(OtaError::Other(
                     "failed to establish connection".to_string(),
                 ));
@@ -345,7 +346,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
                 CONN_RETRY_SECS
             );
             Timer::after(Duration::from_secs(CONN_RETRY_SECS)).await;
-            num_tries += 1;
         };
 
         let conn = Box::new(self.exec.spawn(async move {

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -51,6 +51,7 @@ use crate::esp32::esp_idf_svc::{
     sys::{esp_ota_get_next_update_partition, esp_partition_t},
 };
 use async_io::Timer;
+use futures_lite::FutureExt;
 use http_body_util::{BodyExt, Empty};
 use hyper::{body::Bytes, client::conn::http2, Request};
 use once_cell::sync::Lazy;
@@ -120,6 +121,15 @@ pub(crate) enum ConfigError {
     Other(String),
 }
 
+/// used to differentiate between no-frame and a timeout
+#[derive(Error, Debug)]
+enum FrameError {
+    #[error("unreachable: file a bug ticket if surfaced")]
+    NoOp,
+    #[error("resolving next frame took longer than {0} seconds")]
+    Timeout(usize),
+}
+
 #[allow(dead_code)]
 #[derive(Error, Debug)]
 pub(crate) enum OtaError {
@@ -129,6 +139,8 @@ pub(crate) enum OtaError {
     ConfigError(#[from] ConfigError),
     #[error(transparent)]
     NetworkError(#[from] hyper::Error),
+    #[error(transparent)]
+    StalledDownload(#[from] FrameError),
     #[error("{0}")]
     UpdateError(String),
     #[error("failed to initialize ota process")]
@@ -313,7 +325,6 @@ impl<S: OtaMetadataStorage> OtaService<S> {
                 Ok(connection) => {
                     match connection.await {
                         Ok(io) => {
-                            // TODO(RSDK-9617): add timeout for stalled download
                             match http2::Builder::new(self.exec.clone())
                                 .max_frame_size(16_384) // lowest configurable
                                 .timer(H2Timer)
@@ -411,84 +422,98 @@ impl<S: OtaMetadataStorage> OtaService<S> {
         let mut got_info = false;
 
         log::info!("writing new firmware to address `{:#x}`", self.address,);
+        let mut stream = response.into_data_stream();
 
-        while let Some(next) = response.frame().await {
-            let frame = next.map_err(|e| OtaError::Other(e.to_string()))?;
-            if !frame.is_data() {
-                return Err(OtaError::Other(
-                    "download contained non-data frame".to_string(),
-                ));
-            }
+        loop {
+            match stream.next().ok_or(FrameError::NoOp).or(async {
+                async_io::Timer::after(Duration::from_secs(30)).await;
+                Err(FrameError::Timeout(30))
+            }).await {
+                Ok(frame) => {
+                    let data = frame.expect();
 
-            // Err variant returns the original frame, not an impl Error
-            let data = frame
-                .into_data()
-                .map_err(|_| OtaError::Other("failed to get data from frame".to_string()))?;
-            total_downloaded += data.len();
+                    total_downloaded += data.len();
 
-            if !got_info {
-                if total_downloaded < SIZEOF_APPDESC {
-                    log::error!("initial frame too small to retrieve esp_app_desc_t");
-                } else {
-                    #[cfg(feature = "esp32")]
-                    {
-                        log::info!("verifying new ota firmware");
-                        let mut loader = EspFirmwareInfoLoader::new();
-                        loader
-                            .load(&data)
-                            .map_err(|e| OtaError::InvalidFirmware(e.to_string()))?;
-                        let new_fw = loader
-                            .get_info()
-                            .map_err(|e| OtaError::InvalidFirmware(e.to_string()))?;
-                        log::debug!("current firmware app description: {:?}", running_fw_info);
-                        log::debug!("new firmware app description: {:?}", new_fw);
-                    }
-                    #[cfg(not(feature = "esp32"))]
-                    {
-                        log::debug!("deserializing app header");
-                        if let Ok(decoded) = bincode::decode_from_slice::<
-                            EspAppDesc,
-                            bincode::config::Configuration,
-                        >(
-                            &data[..SIZEOF_APPDESC], bincode::config::standard()
-                        ) {
-                            log::debug!("{:?}", decoded.0);
+                    if !got_info {
+                        if total_downloaded < SIZEOF_APPDESC {
+                            log::error!("initial frame too small to retrieve esp_app_desc_t");
+                        } else {
+                            #[cfg(feature = "esp32")]
+                            {
+                                log::info!("verifying new ota firmware");
+                                let mut loader = EspFirmwareInfoLoader::new();
+                                loader
+                                    .load(&data)
+                                    .map_err(|e| OtaError::InvalidFirmware(e.to_string()))?;
+                                let new_fw = loader
+                                    .get_info()
+                                    .map_err(|e| OtaError::InvalidFirmware(e.to_string()))?;
+                                log::debug!(
+                                    "current firmware app description: {:?}",
+                                    running_fw_info
+                                );
+                                log::debug!("new firmware app description: {:?}", new_fw);
+                            }
+                            #[cfg(not(feature = "esp32"))]
+                            {
+                                log::debug!("deserializing app header");
+                                if let Ok(decoded) = bincode::decode_from_slice::<
+                                    EspAppDesc,
+                                    bincode::config::Configuration,
+                                >(
+                                    &data[..SIZEOF_APPDESC],
+                                    bincode::config::standard(),
+                                ) {
+                                    log::debug!("{:?}", decoded.0);
+                                }
+                            }
+                            got_info = true;
                         }
                     }
-                    got_info = true;
+
+                    if data.len() + nwritten > self.max_size {
+                        log::error!("file is larger than expected, aborting");
+                        #[cfg(feature = "esp32")]
+                        update_handle
+                            .abort()
+                            .map_err(|e| OtaError::AbortError(format!("{:?}", e)))?;
+                        return Err(OtaError::InvalidImageSize(
+                            data.len() + nwritten,
+                            self.max_size,
+                        ));
+                    }
+
+                    // TODO(RSDK-9271) add async writer for ota
+                    #[cfg(feature = "esp32")]
+                    update_handle
+                        .write(&data)
+                        .map_err(|e| OtaError::WriteError(e.to_string()))?;
+                    #[cfg(not(feature = "esp32"))]
+                    let _n = update_handle
+                        .write(&data)
+                        .await
+                        .map_err(|e| OtaError::WriteError(e.to_string()))?;
+                    // TODO change back to 'n' after impl async writer
+                    nwritten += data.len();
+                    log::info!(
+                        "updating next OTA partition at {:#x}: {}/{} bytes written",
+                        self.address,
+                        nwritten,
+                        file_len
+                    );
+                }
+                Err(e) => {
+                    match e {
+                        // no further frames to be processed
+                        FrameError::NoOp => break,
+                        FrameError::Timeout(s) => {
+                            // close resources
+                            //return larger error
+                            return Err(OtaError::StalledDownload(e));
+                        }
+                    }
                 }
             }
-
-            if data.len() + nwritten > self.max_size {
-                log::error!("file is larger than expected, aborting");
-                #[cfg(feature = "esp32")]
-                update_handle
-                    .abort()
-                    .map_err(|e| OtaError::AbortError(format!("{:?}", e)))?;
-                return Err(OtaError::InvalidImageSize(
-                    data.len() + nwritten,
-                    self.max_size,
-                ));
-            }
-
-            // TODO(RSDK-9271) add async writer for ota
-            #[cfg(feature = "esp32")]
-            update_handle
-                .write(&data)
-                .map_err(|e| OtaError::WriteError(e.to_string()))?;
-            #[cfg(not(feature = "esp32"))]
-            let _n = update_handle
-                .write(&data)
-                .await
-                .map_err(|e| OtaError::WriteError(e.to_string()))?;
-            // TODO change back to 'n' after impl async writer
-            nwritten += data.len();
-            log::info!(
-                "updating next OTA partition at {:#x}: {}/{} bytes written",
-                self.address,
-                nwritten,
-                file_len
-            );
         }
 
         drop(conn);

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -512,11 +512,10 @@ impl<S: OtaMetadataStorage> OtaService<S> {
         #[cfg(feature = "esp32")]
         {
             log::info!(
-                "next rebooting will load firmware from `{:#x}`",
+                "next reboot will load firmware from `{:#x}`",
                 self.address
             );
             // TODO(RSDK-9464): flush logs to app.viam before restarting
-            esp_idf_svc::hal::reset::restart();
         }
 
         Ok(())


### PR DESCRIPTION
This PR:
- moves ota logic to the config monitor
- ~uses a `while let Err()` loop on `ota.update()` to ensure retries, **blocking other config changes from being applied**~.
- uses the periodic nature of the `ConfigMonitor` (every 10sec by default) to retry failed OTA attemps
- ~addresses ticket [RSDK-9594](https://viam.atlassian.net/browse/RSDK-9594) in the config monitor, haven't checked if this change needs to be made in other parts of the codebase.~

[RSDK-9594]: https://viam.atlassian.net/browse/RSDK-9594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
