### PR TITLE
[RSDK-9647] update 8mb partitions

### DIFF
--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,8 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs, data, nvs, 0x9000, 0x6000,
-otadata, data, ota, 0xf000, 0x2000,
-phy_init, data, phy, 0x11000, 0x1000,
-ota_0,       app,   ota_0,    0x20000,  3968K,
-ota_1,       app,   ota_1,    0x400000, 3968K,
-coredump,    data,  coredump, 0x7e0000, 128K,
+nvs,	       data,	nvs,	  0x9000,	0x6000,
+otadata,       data,	ota,	  0xf000,	0x2000,
+phy_init,      data,	phy, 	  0x11000, 	0x1000,
+ota_0,         app,     ota_0,    0x20000,      3968K,
+ota_1,         app,     ota_1,    0x400000,     3968K,
+coredump,      data,    coredump, 0x7e0000,     128K,

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,7 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,	       data,	nvs,	  0x9000,	0x6000,
-otadata,       data,	ota,	  0xF000,	0x2000,
-phy_init,      data,	phy, 	  0x11000, 	0x1000,
-ota_0,	       0,	ota_0,	  ,		0x377000,
-ota_1,	       0,	ota_1,	  ,		0x377000,
+nvs,	       data,	nvs,	    0x9000,	  0x6000,
+otadata,     data,	ota,	    0xF000,	  0x2000,
+phy_init,    data,	phy, 	    0x11000, 	0x1000,
+ota_0,	     app,	  ota_0,	  0x20000,	3968K,
+ota_1,	     app,	  ota_1,	  0x400000,	3968K,
+coredump,    data,  coredump, 0x7e0000, 128K,

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,8 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,	       data,	nvs,	    0x9000,	  0x6000,
-otadata,     data,	ota,	    0xF000,	  0x2000,
-phy_init,    data,	phy, 	    0x11000, 	0x1000,
-ota_0,	     app,	  ota_0,	  0x20000,	3968K,
-ota_1,	     app,	  ota_1,	  0x400000,	3968K,
+nvs,         data,  nvs,      0x9000,   0x6000,
+otadata,     data,  ota,      0xF000,   0x2000,
+phy_init,    data,  phy,      0x11000,  0x1000,
+ota_0,       app,   ota_0,    0x20000,  3968K,
+ota_1,       app,   ota_1,    0x400000, 3968K,
 coredump,    data,  coredump, 0x7e0000, 128K,

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,7 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
 nvs,         data,  nvs,      0x9000,   0x6000,
-otadata,     data,  ota,      0xF000,   0x2000,
+otadata,     data,  ota,      0xf000,   0x2000,
 phy_init,    data,  phy,      0x11000,  0x1000,
 ota_0,       app,   ota_0,    0x20000,  3968K,
 ota_1,       app,   ota_1,    0x400000, 3968K,

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,8 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,         data,  nvs,      0x9000,   0x6000,
-otadata,     data,  ota,      0xf000,   0x2000,
-phy_init,    data,  phy,      0x11000,  0x1000,
+nvs, data, nvs, 0x9000, 0x6000,
+otadata, data, ota, 0xf000, 0x2000,
+phy_init, data, phy, 0x11000, 0x1000,
 ota_0,       app,   ota_0,    0x20000,  3968K,
 ota_1,       app,   ota_1,    0x400000, 3968K,
 coredump,    data,  coredump, 0x7e0000, 128K,

--- a/templates/project/partitions.csv
+++ b/templates/project/partitions.csv
@@ -1,7 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs, 0x9000    ,        0x8000,
-phy_init, data, phy, 0x11000    ,        0x1000,
-#reserved, data, undefined,0x12000,0x4e000
-factory,  app,  factory, 0x30000,       0x3D0000,
-coredump, data, coredump,,128K
+nvs,	       data,	nvs,	    0x9000,	  0x6000,
+otadata,     data,	ota,	    0xF000,	  0x2000,
+phy_init,    data,	phy, 	    0x11000, 	0x1000,
+ota_0,	     app,	  ota_0,	  0x20000,	3968K,
+ota_1,	     app,	  ota_1,	  0x400000,	3968K,
+coredump,    data,  coredump, 0x7e0000, 128K,

--- a/templates/project/partitions.csv
+++ b/templates/project/partitions.csv
@@ -1,8 +1,8 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,	       data,	nvs,	    0x9000,	  0x6000,
-otadata,     data,	ota,	    0xF000,	  0x2000,
-phy_init,    data,	phy, 	    0x11000, 	0x1000,
-ota_0,	     app,	  ota_0,	  0x20000,	3968K,
-ota_1,	     app,	  ota_1,	  0x400000,	3968K,
+nvs,         data,  nvs,      0x9000,   0x6000,
+otadata,     data,  ota,      0xF000,   0x2000,
+phy_init,    data,  phy,      0x11000,  0x1000,
+ota_0,       app,   ota_0,    0x20000,  3968K,
+ota_1,       app,   ota_1,    0x400000, 3968K,
 coredump,    data,  coredump, 0x7e0000, 128K,

--- a/templates/project/partitions.csv
+++ b/templates/project/partitions.csv
@@ -1,8 +1,7 @@
 # Name,   Type, SubType, Offset,  Size, Flags
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,         data,  nvs,      0x9000,   0x6000,
-otadata,     data,  ota,      0xF000,   0x2000,
-phy_init,    data,  phy,      0x11000,  0x1000,
-ota_0,       app,   ota_0,    0x20000,  3968K,
-ota_1,       app,   ota_1,    0x400000, 3968K,
-coredump,    data,  coredump, 0x7e0000, 128K,
+nvs,      data, nvs, 0x9000    ,        0x8000,
+phy_init, data, phy, 0x11000    ,        0x1000,
+#reserved, data, undefined,0x12000,0x4e000
+factory,  app,  factory, 0x30000,       0x3D0000,
+coredump, data, coredump,,128K


### PR DESCRIPTION
previous table left 1MB of space available, this recovers that and adds the coredump partition to micro-rdk-server