### PR TITLE
[RSDK-9366] Clear poisoned lock in tests

### DIFF
--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -213,6 +213,8 @@ mod tests {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let lock = LOCK.get_or_init(|| Mutex::new(()));
         lock.lock().unwrap_or_else(|lock_result| {
+            // the shared data is (), which is not modifiable
+            // therefore always in a consistent state
             lock.clear_poison();
             lock_result.into_inner()
         })

--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -212,6 +212,9 @@ mod tests {
     pub fn global_network_test_lock<'a>() -> MutexGuard<'a, ()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let lock = LOCK.get_or_init(|| Mutex::new(()));
-        lock.lock().unwrap()
+        lock.lock().unwrap_or_else(|lock_result| {
+            lock.clear_poison();
+            lock_result.into_inner()
+        })
     }
 }


### PR DESCRIPTION
the `global_network_test_lock` is used to serialize access to network resources to ensure parallelized tests don't trip over one another. We don't actually care to propagate poisons across tests because each test is meant to be self-contained and the underlying network resources are in-fact available.