### PR TITLE
[RSDK-9365] fix flaky test

### DIFF
--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1332,7 +1332,7 @@ mod tests {
                 // await multiple times to give both servers opportunity to process request/response
                 let _ = Timer::after(Duration::from_millis(50)).await;
                 if !cloned_ram_storage.has_robot_credentials() {
-                    // server properly handled response from fake_server
+                    // viam_server properly handled response from fake_app_server
                     break;
                 }
             }

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1326,7 +1326,7 @@ mod tests {
             let _task = cloned_exec.spawn(async move {
                 viam_server.run().await;
             });
-            let _ = Timer::after(Duration::from_millis(500)).await;
+            let _ = Timer::after(Duration::from_millis(1000)).await;
             assert!(!cloned_ram_storage.has_robot_credentials())
         });
     }

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1065,7 +1065,7 @@ mod tests {
         rc::Rc,
         sync::{
             atomic::{AtomicI32, Ordering},
-            Arc, Condvar, Mutex,
+            Arc,
         },
         time::Duration,
     };
@@ -1315,38 +1315,25 @@ mod tests {
 
         let mut app = AppServerInsecure::default();
 
-        // condvar to serialize fake-server-task auth and viam_server.run()
-        let pair = Arc::new((Mutex::new(false), Condvar::new()));
-        let pair2 = Arc::clone(&pair);
-
         app.auth_fn = Some(Rc::new(Box::new(move |req| {
-            let (lock, cvar) = &*pair2;
-            let mut started = lock.lock().unwrap();
-            *started = true;
-            cvar.notify_one();
             assert!(req.entity.contains("test-denied"));
             false
         })));
         exec.block_on(async move {
             let other_clone = cloned_exec.clone();
-            let _fake_server_task =
-                cloned_exec.spawn(async move { run_fake_app_server(other_clone, app).await });
+            let _fake_server_task = cloned_exec.spawn(async move {
+                run_fake_app_server(other_clone, app).await;
+            });
             let _task = cloned_exec.spawn(async move {
-                let (lock, cvar) = &*pair;
-                for _ in 0..3 {
-                    // lock within loop to drop mutex guard between (a)waits
-                    let mut started = lock.lock().unwrap();
-                    let result = cvar
-                        .wait_timeout(started, Duration::from_millis(10))
-                        .unwrap();
-                    started = result.0;
-                    if *started {
-                        break;
-                    }
-                }
                 viam_server.run().await;
             });
-            let _ = Timer::after(Duration::from_millis(500)).await;
+
+            for _ in 0..10 {
+                let _ = Timer::after(Duration::from_millis(50)).await;
+                if !cloned_ram_storage.has_robot_credentials() {
+                    break;
+                }
+            }
             assert!(!cloned_ram_storage.has_robot_credentials())
         });
     }

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1329,8 +1329,10 @@ mod tests {
             });
 
             for _ in 0..10 {
+                // await multiple times to give both servers opportunity to process request/response
                 let _ = Timer::after(Duration::from_millis(50)).await;
                 if !cloned_ram_storage.has_robot_credentials() {
+                    // server properly handled response from fake_server
                     break;
                 }
             }


### PR DESCRIPTION
the test has occasionally tripped, poisoning the `global_network_lock` (fixed). 
It's unclear how much time it would be needed to ensure it doesn't trip (or if other manageable factors are involved), but 1sec seems like a still-acceptable upper-bound on a single test. still faster than running the whole CI workflow again.

If other tests with similar timeouts have this issue it might make sense to make the timeout value global for tests.