### PR TITLE
bump versions for 0.4.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-ffi"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "base64 0.22.1",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-installer"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-macros"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "micro-rdk",
  "proc-macro-crate 3.2.0",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-modular-driver-example"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "log",
  "micro-rdk",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-server"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "embedded-hal 0.2.7",
@@ -3097,7 +3097,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -3187,7 +3187,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ota-dev-server"
-version = "0.3.3"
+version = "0.4.0-rc1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ description = "Viam RDK for microcontroller"
 edition = "2021"
 license = "AGPL-3.0"
 repository = "https://github.com/viamrobotics/micro-rdk"
-version = "0.3.3"
+version = "0.4.0-rc1"
 # TODO(RSDK-8992): Upgrade rust to latest esp-rs version
 rust-version = "1.83"
 

--- a/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
+++ b/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.3.3"
+version: "0.4.0-rc1"
 description: "Micro-RDK lib"
 dependencies:
   ## Required IDF version


### PR DESCRIPTION
Compare with https://github.com/viamrobotics/micro-rdk/commit/bb050e53179cd419ca7f4de670142d1a566da4df

- We don't want to update `micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt` because that's pinned to 0.3.0 per https://viam.atlassian.net/browse/RSDK-9493 until 0.4.0 GA.
- We don't want to update any templates, they should remain pinned to 0.3.3 for now, until 0.4.0 GA.