### PR TITLE
Rsdk 9697 support multiple nvs

### DIFF
--- a/examples/esp-idf-component/main/main.c
+++ b/examples/esp-idf-component/main/main.c
@@ -45,7 +45,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     } else {
       xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
     }
-    ESP_LOGI(TAG,"connect to the AP fail");
+    ESP_LOGI(TAG, "connect to the AP fail");
   } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
     ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
     ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
@@ -274,7 +274,7 @@ void app_main(void)
     viam_server_register_c_generic_sensor(viam_ctx, "sensorA", config_A);
 
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't register sensorA model, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't register sensorA model, error : %i", ret);
     return;
   }
 
@@ -286,47 +286,47 @@ void app_main(void)
   ret = viam_server_register_c_generic_sensor(viam_ctx, "sensorB", config_B);
 
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't register sensorB model, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't register sensorB model, error : %i", ret);
     return;
   }
 
   ret = viam_server_set_provisioning_manufacturer(viam_ctx, "viam-example");
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't set manufacturer, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't set manufacturer, error : %i", ret);
     return;
   }
 
   uint8_t mac[8];
   esp_err_t esp_err = esp_efuse_mac_get_default(mac);
   if (esp_err != ESP_OK){
-    ESP_LOGE(TAG,"couldn't get default mac, error : %i", esp_err);
+    ESP_LOGE(TAG, "couldn't get default mac, error : %i", esp_err);
     return;
   }
   char model[50];
   snprintf(model, 50, "esp32-%02X%02X", mac[6],mac[7]);
   ret = viam_server_set_provisioning_model(viam_ctx, model);
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't set model, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't set model, error : %i", ret);
     return;
   }
 
   ret = viam_server_add_nvs_storage(viam_ctx, "nvs");
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't set add nvs partition, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't set add nvs partition, error : %i", ret);
     return;
   }
 
   ret = viam_server_add_nvs_storage(viam_ctx, "nvs_other");
   if (ret != VIAM_OK) {
-    ESP_LOGE(TAG,"couldn't set add nvs partition, error : %i", ret);
+    ESP_LOGE(TAG, "couldn't set add nvs partition, error : %i", ret);
     return;
   }
 
-  ESP_LOGI(TAG,"starting viam server\r\n");
+  ESP_LOGI(TAG, "starting viam server\r\n");
 
   xTaskCreatePinnedToCore((void*)viam_server_start, "viam", CONFIG_MICRO_RDK_TASK_STACK_SIZE, viam_ctx, 6, NULL, CONFIG_MICRO_RDK_TASK_PINNED_TO_CORE_1);
 #else
-  ESP_LOGE(TAG,"enable MICRO_RDK_ENABLE_BUILD_LIBRARY ");
+  ESP_LOGE(TAG, "enable MICRO_RDK_ENABLE_BUILD_LIBRARY ");
 #endif
 
 }

--- a/examples/esp-idf-component/main/main.c
+++ b/examples/esp-idf-component/main/main.c
@@ -310,6 +310,18 @@ void app_main(void)
     return;
   }
 
+  ret = viam_server_add_nvs_storage(viam_ctx, "nvs");
+  if (ret != VIAM_OK) {
+    ESP_LOGE(TAG,"couldn't set add nvs partition, error : %i", ret);
+    return;
+  }
+
+  ret = viam_server_add_nvs_storage(viam_ctx, "nvs_other");
+  if (ret != VIAM_OK) {
+    ESP_LOGE(TAG,"couldn't set add nvs partition, error : %i", ret);
+    return;
+  }
+
   ESP_LOGI(TAG,"starting viam server\r\n");
 
   xTaskCreatePinnedToCore((void*)viam_server_start, "viam", CONFIG_MICRO_RDK_TASK_STACK_SIZE, viam_ctx, 6, NULL, CONFIG_MICRO_RDK_TASK_PINNED_TO_CORE_1);

--- a/micro-rdk-ffi/include/micrordk.h
+++ b/micro-rdk-ffi/include/micrordk.h
@@ -166,6 +166,12 @@ enum viam_code viam_server_register_c_generic_sensor(struct viam_server_context 
                                                      struct generic_c_sensor_config *sensor);
 
 /*
+ Add an nvs partition to the storage collection
+ */
+enum viam_code viam_server_add_nvs_storage(struct viam_server_context *ctx,
+                                           const char *storage_name);
+
+/*
  Starts the viam server, the function will take ownership of `ctx` therefore future call
  */
 enum viam_code viam_server_start(struct viam_server_context *ctx);

--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -27,6 +27,7 @@ pub struct viam_server_context {
     registry: Box<ComponentRegistry>,
     provisioning_info: ProvisioningInfo,
     _marker: PhantomData<(*mut u8, PhantomPinned)>, // Non Send, Non Sync
+    storage: Vec<String>,
 }
 
 #[cfg(target_os = "espidf")]
@@ -49,6 +50,7 @@ pub extern "C" fn init_viam_server_context() -> *mut viam_server_context {
         registry,
         provisioning_info,
         _marker: Default::default(),
+        storage: Default::default(),
     }))
 }
 
@@ -188,6 +190,35 @@ pub unsafe extern "C" fn viam_server_register_c_generic_sensor(
     viam_code::VIAM_OK
 }
 
+/// Add an nvs partition to the storage collection
+///
+/// When the viam server starts each partitions (if they exists) will be added to a storage collection
+/// and made available to the server
+///
+/// # Safety
+/// `ctx`, `storage_name` must be valid pointers
+/// may panic if the storage_name cannot be pushed on the vector
+#[no_mangle]
+pub unsafe extern "C" fn viam_server_add_nvs_storage(
+    ctx: *mut viam_server_context,
+    storage_name: *const c_char,
+) -> viam_code {
+    if ctx.is_null() || storage_name.is_null() {
+        return viam_code::VIAM_INVALID_ARG;
+    }
+
+    let ctx = unsafe { &mut *ctx };
+    let name = if let Ok(s) = unsafe { CStr::from_ptr(storage_name) }.to_str() {
+        s
+    } else {
+        return viam_code::VIAM_INVALID_ARG;
+    };
+
+    ctx.storage.push(name.to_owned());
+
+    viam_code::VIAM_OK
+}
+
 #[allow(dead_code)]
 const ROBOT_ID: Option<&str> = option_env!("MICRO_RDK_ROBOT_ID");
 #[allow(dead_code)]
@@ -257,7 +288,7 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         use micro_rdk::common::credentials_storage::RAMStorage;
         use micro_rdk::common::credentials_storage::RobotConfigurationStorage;
         use micro_rdk::proto::provisioning::v1::CloudConfig;
-
+        log::info!("when the FFI was built a robot config was supplied, defaulting to this robot");
         let ram_storage = RAMStorage::new();
         let cloud_conf = if ROBOT_ID.is_some() && ROBOT_SECRET.is_some()  {
             Some(CloudConfig {
@@ -284,7 +315,22 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         #[cfg(not(target_os = "espidf"))]
         let storage = micro_rdk::common::credentials_storage::RAMStorage::default();
         #[cfg(target_os = "espidf")]
-        let storage = micro_rdk::esp32::nvs_storage::NVSStorage::new("nvs").unwrap();
+        //let storage =  {micro_rdk::esp32::nvs_storage::NVSStorage::new("nvs").unwrap()};
+        let storage: Vec<micro_rdk::esp32::nvs_storage::NVSStorage> = ctx
+            .storage
+            .iter()
+            .map(|s| {
+                micro_rdk::esp32::nvs_storage::NVSStorage::new(s).inspect_err(|err| {
+                    log::error!(
+                        "storage {} cannot be built reason {} continuing without",
+                        s,
+                        err
+                    )
+                })
+            })
+            .filter(|r| r.is_ok())
+            .map(|r| r.unwrap())
+            .collect();
         storage
     };
 

--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         use micro_rdk::common::credentials_storage::RAMStorage;
         use micro_rdk::common::credentials_storage::RobotConfigurationStorage;
         use micro_rdk::proto::provisioning::v1::CloudConfig;
-
+        //TODO(RSDK-9715)
         let ram_storage = RAMStorage::new();
         let cloud_conf = if ROBOT_ID.is_some() && ROBOT_SECRET.is_some()  {
             Some(CloudConfig {

--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -269,7 +269,7 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
             None
         }.expect("has_robot_config set in cfg, but build-time configuration failed to set robot credentials");
         ram_storage
-            .store_robot_credentials(cloud_conf)
+            .store_robot_credentials(&cloud_conf)
             .expect("Failed to store cloud config");
         if ROBOT_APP_ADDRESS.is_some() {
             ram_storage

--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -288,7 +288,7 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         use micro_rdk::common::credentials_storage::RAMStorage;
         use micro_rdk::common::credentials_storage::RobotConfigurationStorage;
         use micro_rdk::proto::provisioning::v1::CloudConfig;
-        log::info!("when the FFI was built a robot config was supplied, defaulting to this robot");
+
         let ram_storage = RAMStorage::new();
         let cloud_conf = if ROBOT_ID.is_some() && ROBOT_SECRET.is_some()  {
             Some(CloudConfig {
@@ -315,7 +315,6 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         #[cfg(not(target_os = "espidf"))]
         let storage = micro_rdk::common::credentials_storage::RAMStorage::default();
         #[cfg(target_os = "espidf")]
-        //let storage =  {micro_rdk::esp32::nvs_storage::NVSStorage::new("nvs").unwrap()};
         let storage: Vec<micro_rdk::esp32::nvs_storage::NVSStorage> = ctx
             .storage
             .iter()
@@ -329,7 +328,7 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
                 })
             })
             .filter(|r| r.is_ok())
-            .map(|r| r.unwrap())
+            .flatten()
             .collect();
         storage
     };

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -82,7 +82,7 @@ mod esp32 {
             if SSID.is_some() && PASS.is_some() {
                 log::info!("Storing static values from build time wifi configuration to NVS");
                 storage
-                    .store_wifi_credentials(WifiCredentials::new(
+                    .store_wifi_credentials(&WifiCredentials::new(
                         SSID.unwrap().to_string(),
                         PASS.unwrap().to_string(),
                     ))
@@ -96,7 +96,7 @@ mod esp32 {
                 log::info!("Storing static values from build time robot configuration to NVS");
                 storage
                     .store_robot_credentials(
-                        RobotCredentials::new(
+                        &RobotCredentials::new(
                             ROBOT_ID.unwrap().to_string(),
                             ROBOT_SECRET.unwrap().to_string(),
                         )

--- a/micro-rdk-server/native/main.rs
+++ b/micro-rdk-server/native/main.rs
@@ -47,7 +47,7 @@ mod native {
                 log::info!("Storing static values from build time robot configuration");
                 storage
                     .store_robot_credentials(
-                        RobotCredentials::new(
+                        &RobotCredentials::new(
                             ROBOT_ID.unwrap().to_string(),
                             ROBOT_SECRET.unwrap().to_string(),
                         )

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -609,7 +609,7 @@ where
                     .await
                     .map(|cert_resp| {
                         let cert: TlsCertificate = cert_resp.into();
-                        match self.storage.store_tls_certificate(cert.clone()) {
+                        match self.storage.store_tls_certificate(&cert) {
                             Ok(_) => {
                                 log::debug!("stored TLS certificate received by app");
                             }
@@ -1290,7 +1290,7 @@ mod tests {
             secret: "".to_string(),
             app_address: LOCALHOST_URI.to_owned(),
         };
-        assert!(ram_storage.store_robot_credentials(creds).is_ok());
+        assert!(ram_storage.store_robot_credentials(&creds).is_ok());
 
         let mdns = NativeMdns::new("".to_owned(), network.get_ip());
         assert!(mdns.is_ok());
@@ -1350,7 +1350,7 @@ mod tests {
             secret: "".to_string(),
             app_address: LOCALHOST_URI.to_owned(),
         };
-        assert!(ram_storage.store_robot_credentials(creds).is_ok());
+        assert!(ram_storage.store_robot_credentials(&creds).is_ok());
 
         let mdns = NativeMdns::new("".to_owned(), network.get_ip());
         assert!(mdns.is_ok());
@@ -1460,7 +1460,7 @@ mod tests {
             app_address: LOCALHOST_URI.to_owned(),
         };
 
-        assert!(ram_storage.store_robot_credentials(creds).is_ok());
+        assert!(ram_storage.store_robot_credentials(&creds).is_ok());
 
         let mdns = NativeMdns::new("".to_owned(), network.get_ip());
         assert!(mdns.is_ok());
@@ -1787,7 +1787,7 @@ mod tests {
             _ => panic!("oops expected ipv4"),
         };
 
-        ram_storage.store_robot_credentials(creds).unwrap();
+        ram_storage.store_robot_credentials(&creds).unwrap();
 
         let mut a = ViamServerBuilder::new(ram_storage);
         let mdns = NativeMdns::new("".to_owned(), Ipv4Addr::new(0, 0, 0, 0)).unwrap();

--- a/micro-rdk/src/common/credentials_storage.rs
+++ b/micro-rdk/src/common/credentials_storage.rs
@@ -261,7 +261,6 @@ impl RobotConfigurationStorage for RAMStorage {
     }
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
         let inner_ref = self.0.lock().unwrap();
-        log::info!("get robot creds");
         inner_ref
             .robot_creds
             .clone()
@@ -270,7 +269,6 @@ impl RobotConfigurationStorage for RAMStorage {
     fn reset_robot_credentials(&self) -> Result<(), Self::Error> {
         let mut inner_ref = self.0.lock().unwrap();
         let _ = inner_ref.robot_creds.take();
-        log::info!("reset robot creds");
         Ok(())
     }
 

--- a/micro-rdk/src/common/credentials_storage.rs
+++ b/micro-rdk/src/common/credentials_storage.rs
@@ -230,7 +230,7 @@ where
     fn get_ota_metadata(&self) -> Result<OtaMetadata, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_ota_metadata()),
+            |val, s| val.or_else(|_| s.get_ota_metadata()),
         )
     }
     fn reset_ota_metadata(&self) -> Result<(), Self::Error> {
@@ -242,7 +242,7 @@ where
     fn store_ota_metadata(&self, ota_metadata: &OtaMetadata) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_ota_metadata(ota_metadata)),
+            |val, s| val.or_else(|_| s.store_ota_metadata(ota_metadata)),
         )
     }
 }
@@ -261,6 +261,7 @@ impl RobotConfigurationStorage for RAMStorage {
     }
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
         let inner_ref = self.0.lock().unwrap();
+        log::info!("get robot creds");
         inner_ref
             .robot_creds
             .clone()
@@ -269,6 +270,7 @@ impl RobotConfigurationStorage for RAMStorage {
     fn reset_robot_credentials(&self) -> Result<(), Self::Error> {
         let mut inner_ref = self.0.lock().unwrap();
         let _ = inner_ref.robot_creds.take();
+        log::info!("reset robot creds");
         Ok(())
     }
 
@@ -358,49 +360,49 @@ where
     fn get_robot_credentials(&self) -> Result<RobotCredentials, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_robot_credentials()),
+            |val, s| val.or_else(|_| s.get_robot_credentials()),
         )
     }
     fn get_tls_certificate(&self) -> Result<TlsCertificate, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_tls_certificate()),
+            |val, s| val.or_else(|_| s.get_tls_certificate()),
         )
     }
     fn get_app_address(&self) -> Result<Uri, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_app_address()),
+            |val, s| val.or_else(|_| s.get_app_address()),
         )
     }
     fn store_app_address(&self, uri: &str) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_app_address(uri)),
+            |val, s| val.or_else(|_| s.store_app_address(uri)),
         )
     }
     fn store_tls_certificate(&self, creds: &TlsCertificate) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_tls_certificate(creds)),
+            |val, s| val.or_else(|_| s.store_tls_certificate(creds)),
         )
     }
     fn store_robot_configuration(&self, cfg: &RobotConfig) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_robot_configuration(cfg)),
+            |val, s| val.or_else(|_| s.store_robot_configuration(cfg)),
         )
     }
     fn store_robot_credentials(&self, cfg: &CloudConfig) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_robot_credentials(cfg)),
+            |val, s| val.or_else(|_| s.store_robot_credentials(cfg)),
         )
     }
     fn get_robot_configuration(&self) -> Result<RobotConfig, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_robot_configuration()),
+            |val, s| val.or_else(|_| s.get_robot_configuration()),
         )
     }
     fn reset_app_address(&self) -> Result<(), Self::Error> {
@@ -467,13 +469,13 @@ where
     fn get_wifi_credentials(&self) -> Result<WifiCredentials, Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.get_wifi_credentials()),
+            |val, s| val.or_else(|_| s.get_wifi_credentials()),
         )
     }
     fn store_wifi_credentials(&self, creds: &WifiCredentials) -> Result<(), Self::Error> {
         self.into_iter().fold(
             Err::<_, Self::Error>(EmptyStorageCollectionError.into()),
-            |val, s| val.or(s.store_wifi_credentials(creds)),
+            |val, s| val.or_else(|_| s.store_wifi_credentials(creds)),
         )
     }
     fn reset_wifi_credentials(&self) -> Result<(), Self::Error> {

--- a/micro-rdk/src/common/ota.rs
+++ b/micro-rdk/src/common/ota.rs
@@ -549,7 +549,7 @@ impl<S: OtaMetadataStorage> OtaService<S> {
 
         log::info!("updating firmware metadata in NVS");
         self.storage
-            .store_ota_metadata(OtaMetadata {
+            .store_ota_metadata(&OtaMetadata {
                 version: self.pending_version.clone(),
             })
             .map_err(|e| OtaError::Other(e.to_string()))?;

--- a/micro-rdk/src/common/provisioning/server.rs
+++ b/micro-rdk/src/common/provisioning/server.rs
@@ -256,7 +256,7 @@ where
                 })?;
 
             self.storage
-                .store_wifi_credentials(creds)
+                .store_wifi_credentials(&creds)
                 .map_err(|e| ServerError::new(GrpcError::RpcInternal, Some(Box::new(e.into()))))?;
 
             let resp = SetNetworkCredentialsResponse::default();
@@ -331,7 +331,8 @@ where
     fn set_smart_machine_credentials(&self, body: Bytes) -> Result<Bytes, ServerError> {
         let creds =
             SetSmartMachineCredentialsRequest::decode(body).map_err(|_| GrpcError::RpcInternal)?;
-        self.storage.store_robot_credentials(creds.cloud.unwrap())?;
+        self.storage
+            .store_robot_credentials(creds.cloud.as_ref().unwrap())?;
         let resp = SetSmartMachineCredentialsResponse::default();
 
         let len = resp.encoded_len();

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -47,17 +47,6 @@ pub struct NVSStorage {
     part: EspCustomNvsPartition,
 }
 
-#[derive(Clone)]
-pub struct MultiNVSStorage {
-    parts: Vec<NVSStorage>,
-}
-
-impl MultiNVSStorage {
-    pub fn new(parts: Vec<NVSStorage>) -> Self {
-        Self { parts }
-    }
-}
-
 impl NVSStorage {
     // taking partition name as argument so we can use another NVS part name if we want to.
     pub fn new(partition_name: &str) -> Result<Self, NVSStorageError> {

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -205,7 +205,7 @@ impl OtaMetadataStorage for NVSStorage {
         let version = self.get_string(NVS_OTA_VERSION_KEY)?;
         Ok(OtaMetadata { version })
     }
-    fn store_ota_metadata(&self, ota_metadata: OtaMetadata) -> Result<(), Self::Error> {
+    fn store_ota_metadata(&self, ota_metadata: &OtaMetadata) -> Result<(), Self::Error> {
         self.set_string(NVS_OTA_VERSION_KEY, &ota_metadata.version)
     }
     fn reset_ota_metadata(&self) -> Result<(), Self::Error> {
@@ -244,7 +244,7 @@ impl RobotConfigurationStorage for NVSStorage {
         self.erase_key(NVS_ROBOT_APP_ADDRESS)
     }
 
-    fn store_robot_credentials(&self, cfg: CloudConfig) -> Result<(), Self::Error> {
+    fn store_robot_credentials(&self, cfg: &CloudConfig) -> Result<(), Self::Error> {
         self.set_string(NVS_ROBOT_SECRET_KEY, &cfg.secret)?;
         self.set_string(NVS_ROBOT_ID_KEY, &cfg.id)?;
         self.set_string(NVS_ROBOT_APP_ADDRESS, &cfg.app_address)?;
@@ -290,9 +290,15 @@ impl RobotConfigurationStorage for NVSStorage {
         })
     }
 
-    fn store_tls_certificate(&self, creds: TlsCertificate) -> Result<(), Self::Error> {
-        self.set_blob(NVS_TLS_CERTIFICATE_KEY, Bytes::from(creds.certificate))?;
-        self.set_blob(NVS_TLS_PRIVATE_KEY_KEY, Bytes::from(creds.private_key))?;
+    fn store_tls_certificate(&self, creds: &TlsCertificate) -> Result<(), Self::Error> {
+        self.set_blob(
+            NVS_TLS_CERTIFICATE_KEY,
+            Bytes::from(creds.certificate.clone()),
+        )?;
+        self.set_blob(
+            NVS_TLS_PRIVATE_KEY_KEY,
+            Bytes::from(creds.private_key.clone()),
+        )?;
         Ok(())
     }
 
@@ -316,7 +322,7 @@ impl WifiCredentialStorage for NVSStorage {
         Ok(WifiCredentials { ssid, pwd })
     }
 
-    fn store_wifi_credentials(&self, creds: WifiCredentials) -> Result<(), Self::Error> {
+    fn store_wifi_credentials(&self, creds: &WifiCredentials) -> Result<(), Self::Error> {
         self.set_string(NVS_WIFI_SSID_KEY, &creds.ssid)?;
         self.set_string(NVS_WIFI_PASSWORD_KEY, &creds.pwd)?;
         Ok(())

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -231,8 +231,15 @@ impl RobotConfigurationStorage for NVSStorage {
 
     fn store_robot_credentials(&self, cfg: &CloudConfig) -> Result<(), Self::Error> {
         self.set_string(NVS_ROBOT_SECRET_KEY, &cfg.secret)?;
-        self.set_string(NVS_ROBOT_ID_KEY, &cfg.id)?;
-        self.set_string(NVS_ROBOT_APP_ADDRESS, &cfg.app_address)?;
+        self.set_string(NVS_ROBOT_ID_KEY, &cfg.id).or_else(|err| {
+            let _ = self.reset_robot_credentials();
+            Err(err)
+        })?;
+        self.set_string(NVS_ROBOT_APP_ADDRESS, &cfg.app_address)
+            .or_else(|err| {
+                let _ = self.reset_robot_credentials();
+                Err(err)
+            })?;
         Ok(())
     }
 
@@ -283,7 +290,11 @@ impl RobotConfigurationStorage for NVSStorage {
         self.set_blob(
             NVS_TLS_PRIVATE_KEY_KEY,
             Bytes::from(creds.private_key.clone()),
-        )?;
+        )
+        .or_else(|err| {
+            let _ = self.reset_tls_certificate();
+            Err(err)
+        })?;
         Ok(())
     }
 
@@ -309,7 +320,11 @@ impl WifiCredentialStorage for NVSStorage {
 
     fn store_wifi_credentials(&self, creds: &WifiCredentials) -> Result<(), Self::Error> {
         self.set_string(NVS_WIFI_SSID_KEY, &creds.ssid)?;
-        self.set_string(NVS_WIFI_PASSWORD_KEY, &creds.pwd)?;
+        self.set_string(NVS_WIFI_PASSWORD_KEY, &creds.pwd)
+            .or_else(|err| {
+                let _ = self.reset_wifi_credentials();
+                Err(err)
+            })?;
         Ok(())
     }
 

--- a/micro-rdk/src/esp32/nvs_storage.rs
+++ b/micro-rdk/src/esp32/nvs_storage.rs
@@ -2,7 +2,7 @@
 use bytes::Bytes;
 use hyper::{http::uri::InvalidUri, Uri};
 use prost::{DecodeError, Message};
-use std::{cell::RefCell, ffi::CString, num::NonZeroI32, rc::Rc};
+use std::{cell::RefCell, rc::Rc};
 use thiserror::Error;
 
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
     esp32::esp_idf_svc::{
         handle::RawHandle,
         nvs::{EspCustomNvs, EspCustomNvsPartition, EspNvs},
-        sys::{esp, nvs_get_stats, nvs_stats_t, EspError, ESP_ERR_INVALID_ARG},
+        sys::{esp, nvs_get_stats, nvs_stats_t, EspError},
     },
     proto::{app::v1::RobotConfig, provisioning::v1::CloudConfig},
 };
@@ -44,7 +44,6 @@ pub struct NVSStorage {
     // esp-idf-svc partition driver ensures that only one handle of a type can be created
     // so inner mutability can be achieves safely with RefCell
     nvs: Rc<RefCell<EspCustomNvs>>,
-    partition_name: CString,
     part: EspCustomNvsPartition,
 }
 
@@ -67,9 +66,6 @@ impl NVSStorage {
 
         Ok(Self {
             nvs: Rc::new(nvs.into()),
-            partition_name: CString::new(partition_name).map_err(|_| {
-                EspError::from_non_zero(NonZeroI32::new(ESP_ERR_INVALID_ARG).unwrap())
-            })?,
             part: partition,
         })
     }

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -72,7 +72,7 @@ fn main() {
         if SSID.is_some() && PASS.is_some() {
             log::info!("Storing static values from build time wifi configuration to NVS");
             storage
-                .store_wifi_credentials(WifiCredentials::new(
+                .store_wifi_credentials(&WifiCredentials::new(
                     SSID.unwrap().to_string(),
                     PASS.unwrap().to_string(),
                 ))
@@ -87,7 +87,7 @@ fn main() {
             log::info!("Storing static values from build time robot configuration to NVS");
             storage
                 .store_robot_credentials(
-                    RobotCredentials::new(
+                    &RobotCredentials::new(
                         ROBOT_ID.unwrap().to_string(),
                         ROBOT_SECRET.unwrap().to_string(),
                     )


### PR DESCRIPTION
Implements the storage traits for any type we can iterate over, we can then easily pass an array of a vec as a storage to viam server. 
With this something like
`let storage = vec![
            NVSStorage::new("nvs").unwrap(),
            NVSStorage::new("nvs2").unwrap(),
 ];`
Will allow use to store the robot data over multiple NVS 

I didn't want to add an extra type to represent a collection of storage and this way the logic is driven by the underlying storage implementation. 