### PR TITLE
[RSDK-9694] Bump template versions to 0.4.0

### DIFF
--- a/templates/module/Cargo.toml
+++ b/templates/module/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 rust-version = "1.83"
 
 [dependencies]
-micro-rdk = {git = "https://github.com/viamrobotics/micro-rdk.git", features = ["{{mcu}}"], version = "0.3.3", rev = "bb050e5"}
+micro-rdk = {git = "https://github.com/viamrobotics/micro-rdk.git", features = ["{{mcu}}"], version = "0.4.0", rev = "380a098"}
 
 [package.metadata.com.viam]
 module = true

--- a/templates/project/Cargo.toml
+++ b/templates/project/Cargo.toml
@@ -15,8 +15,8 @@ opt-level = "z"
 
 [dependencies.micro-rdk]
 git = "https://github.com/viamrobotics/micro-rdk.git"
-version = "0.3.3"
-rev = "bb050e5"
+version = "0.4.0"
+rev = "380a098"
 features = [
   "esp32",
   "binstart",


### PR DESCRIPTION
Last bit of 0.4.0. I have an idea for how to not need to do this for 0.4.1: https://viam.atlassian.net/browse/RSDK-9734