### PR TITLE
[RSDK-9647] Standardize on 8MB OTA capable partition scheme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build-esp32-bin: build-esp32-ota
 		--features=ota \
 		--chip=esp32 \
 		--bin=micro-rdk-server-esp32 \
-		--partition-table=micro-rdk-server/esp32/ota_8mb_partitions.csv \
+		--partition-table=micro-rdk-server/esp32/partitions.csv \
 		--target=xtensa-esp32-espidf \
 		-Zbuild-std=std,panic_abort --release \
 		--flash-size=8mb \
@@ -120,7 +120,7 @@ build-esp32-ota:
 		--features=ota \
 		--chip=esp32 \
 		--bin=micro-rdk-server-esp32 \
-		--partition-table=micro-rdk-server/esp32/ota_8mb_partitions.csv \
+		--partition-table=micro-rdk-server/esp32/partitions.csv \
 		--target=xtensa-esp32-espidf \
 		-Zbuild-std=std,panic_abort --release \
 		target/xtensa-esp32-espidf/micro-rdk-server-esp32-ota.bin

--- a/examples/esp-idf-component/partitions.csv
+++ b/examples/esp-idf-component/partitions.csv
@@ -1,4 +1,7 @@
-# Name,   Type, SubType, Offset,   Size
-nvs,      data, nvs,     0x09000,  0x4000
-phy_init, data, phy,     0x13000,  0x1000
-factory,  app,  factory, 0x20000,  4M
+# Name,		Type,	SubType,	Offset,		Size,		Flags
+phy_init,	data,	phy,		0x9000,		0x1000,
+otadata,	data,	ota,		0xa000,		0x2000,
+nvs,		data,	nvs,		0xc000,		0x14000,
+ota_0,		app,	ota_0,		0x20000,	0x3e0000,
+ota_1,		app,	ota_1,		0x400000,	0x3e0000,
+coredump,	data,	coredump,	0x7e0000,	0x20000,

--- a/micro-rdk-server/esp32/ota_8mb_partitions.csv
+++ b/micro-rdk-server/esp32/ota_8mb_partitions.csv
@@ -1,7 +1,0 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,	       data,	nvs,	  0x9000,	0x6000,
-otadata,       data,	ota,	  0xF000,	0x2000,
-phy_init,      data,	phy, 	  0x11000, 	0x1000,
-ota_0,	       0,	ota_0,	  ,		0x377000,
-ota_1,	       0,	ota_1,	  ,		0x377000,

--- a/micro-rdk-server/esp32/partitions.csv
+++ b/micro-rdk-server/esp32/partitions.csv
@@ -1,5 +1,7 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs, 0x9000    ,        0x6000,
-phy_init, data, phy, 0xf000    ,        0x1000,
-factory,  app,  factory, 0x10000,       0x3effff,
+# Name,		Type,	SubType,	Offset,		Size,		Flags
+phy_init,	data,	phy,		0x9000,		0x1000,
+otadata,	data,	ota,		0xa000,		0x2000,
+nvs,		data,	nvs,		0xc000,		0x14000,
+ota_0,		app,	ota_0,		0x20000,	0x3e0000,
+ota_1,		app,	ota_1,		0x400000,	0x3e0000,
+coredump,	data,	coredump,	0x7e0000,	0x20000,

--- a/templates/project/partitions.csv
+++ b/templates/project/partitions.csv
@@ -1,7 +1,7 @@
-# Name,   Type, SubType, Offset,  Size, Flags
-# Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
-nvs,      data, nvs, 0x9000    ,        0x8000,
-phy_init, data, phy, 0x11000    ,        0x1000,
-#reserved, data, undefined,0x12000,0x4e000
-factory,  app,  factory, 0x30000,       0x3D0000,
-coredump, data, coredump,,128K
+# Name,		Type,	SubType,	Offset,		Size,		Flags
+phy_init,	data,	phy,		0x9000,		0x1000,
+otadata,	data,	ota,		0xa000,		0x2000,
+nvs,		data,	nvs,		0xc000,		0x14000,
+ota_0,		app,	ota_0,		0x20000,	0x3e0000,
+ota_1,		app,	ota_1,		0x400000,	0x3e0000,
+coredump,	data,	coredump,	0x7e0000,	0x20000,


### PR DESCRIPTION
Standardize on a new partition scheme using two OTA segments at 3968k each, 80k NVS, and 128k coredump.