### PR TITLE
[CONSULT-469] - introduction of NMEA message macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,8 +2831,20 @@ dependencies = [
 name = "micro-rdk-nmea"
 version = "0.4.0"
 dependencies = [
+ "base64 0.22.1",
  "micro-rdk",
+ "micro-rdk-nmea-macros",
  "thiserror 2.0.4",
+]
+
+[[package]]
+name = "micro-rdk-nmea-macros"
+version = "0.4.0"
+dependencies = [
+ "proc-macro-crate 3.2.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ name = "micro-rdk-nmea"
 version = "0.4.0"
 dependencies = [
  "base64 0.22.1",
+ "chrono",
  "micro-rdk",
  "micro-rdk-nmea-macros",
  "thiserror 2.0.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "micro-rdk-installer",
   "micro-rdk-macros",
   "micro-rdk-nmea",
+  "micro-rdk-nmea-macros",
   "micro-rdk-server",
   "micro-rdk-ffi",
   "examples/modular-drivers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ log = "0.4.22"
 mdns-sd = { version = "0.12", default-features = false, features = ["async"] }
 micro-rdk = { path = "./micro-rdk", default-features = false, features = [] }
 micro-rdk-macros = { path = "./micro-rdk-macros" }
+micro-rdk-nmea-macros = { path = "./micro-rdk-nmea-macros" }
 micro-rdk-modular-driver-example = {path = "./examples/modular-drivers" }
 once_cell = "1.20.2"
 openssl = { version = "0.10.68" }

--- a/micro-rdk-nmea-macros/Cargo.toml
+++ b/micro-rdk-nmea-macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "micro-rdk-nmea"
+name = "micro-rdk-nmea-macros"
 authors.workspace = true
 description.workspace = true
 edition.workspace = true
@@ -8,10 +8,13 @@ repository.workspace = true
 version.workspace = true
 rust-version.workspace = true
 
+[lib]
+proc-macro = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base64 = { workspace = true }
-micro-rdk = { path = "../micro-rdk", features = ["native"] }
-micro-rdk-nmea-macros = { path = "../micro-rdk-nmea-macros" }
-thiserror = { workspace = true }
+proc-macro-crate = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/micro-rdk-nmea-macros/src/attributes.rs
+++ b/micro-rdk-nmea-macros/src/attributes.rs
@@ -1,0 +1,256 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Expr, Field, Ident, Lit, Meta, Type};
+
+use crate::utils::{error_tokens, UnitConversion};
+
+// `MacroAttributes` represents the important information derived from the macro attributes
+// attached to the field of a struct using the PgnMessageDerive macro.
+//
+// bits -> size in bits of the field in the NMEA message byte slice
+// offset -> the amount of bits to skip in the message data before parsing the field
+// label -> name of the key for the field when serializing the message to a GenericReadingsResult
+// scale_token -> scale factor to be applied to the raw value of the field
+// unit -> unit that the field's value should be converted to before serialization
+// is_lookup -> whether the field is a lookup field
+// length_field -> if this field is a list of fieldsets, this is the field whose value represents
+// the expected length of this list
+//
+// Ex. of usage (each attribute generates an instance of `MacroAttributes`)
+//
+// #[derive(PgnMessageDerive, Debug)]
+// pub struct TemperatureExtendedRange {
+//     source_id: u8,
+//     instance: u8,
+//     #[lookup]
+//     #[label = "temp_src"]
+//     source: TemperatureSource,
+//     #[bits = 24]
+//     #[scale = 0.001]
+//     #[unit = "C"]
+//     temperature: u32,
+//     #[scale = 0.1]
+//     #[offset = 16]
+//     set_temperature: u16,
+// }
+
+#[derive(Debug)]
+pub(crate) struct MacroAttributes {
+    pub(crate) bits: Option<usize>,
+    pub(crate) offset: usize,
+    pub(crate) label: Option<TokenStream2>,
+    pub(crate) scale_token: Option<TokenStream2>,
+    pub(crate) unit: Option<UnitConversion>,
+    pub(crate) is_lookup: bool,
+    pub(crate) length_field: Option<Ident>,
+}
+
+// Attempt to deduce the bit size from the data type
+fn get_bits(field_ty: &Type) -> Result<usize, TokenStream> {
+    Ok(match field_ty {
+        Type::Path(type_path) if type_path.path.is_ident("u32") => 32,
+        Type::Path(type_path) if type_path.path.is_ident("u16") => 16,
+        Type::Path(type_path) if type_path.path.is_ident("u8") => 8,
+        Type::Path(type_path) if type_path.path.is_ident("i32") => 32,
+        Type::Path(type_path) if type_path.path.is_ident("i16") => 16,
+        Type::Path(type_path) if type_path.path.is_ident("i8") => 8,
+        Type::Path(type_path) if type_path.path.is_ident("i64") => 64,
+        Type::Path(type_path) if type_path.path.is_ident("u64") => 64,
+        Type::Array(type_array) => {
+            if let Expr::Lit(len) = &type_array.len {
+                if let Lit::Int(len) = &len.lit {
+                    if let Type::Path(type_path) = type_array.elem.as_ref() {
+                        if !type_path.path.is_ident("u8") {
+                            return Err(error_tokens("array instance type must be u8"));
+                        }
+                    }
+                    len.base10_parse::<usize>()
+                        .map(|x| x * 8)
+                        .map_err(|err| err.to_compile_error())?
+                } else {
+                    return Err(error_tokens("array length is unexpected literal type"));
+                }
+            } else {
+                return Err(error_tokens("array length is unexpected non-literal type"));
+            }
+        }
+        _ => 8,
+    })
+}
+
+impl MacroAttributes {
+    pub(crate) fn from_field(field: &Field) -> Result<Self, TokenStream> {
+        let mut macro_attrs = MacroAttributes {
+            is_lookup: false,
+            scale_token: None,
+            bits: None,
+            offset: 0,
+            label: None,
+            length_field: None,
+            unit: None,
+        };
+
+        for attr in field.attrs.iter() {
+            for seg in attr.path().segments.iter() {
+                let ident = &seg.ident;
+                match ident.to_string().as_str() {
+                    "lookup" => macro_attrs.is_lookup = true,
+                    "scale" => {
+                        let meta = &attr.meta;
+
+                        macro_attrs.scale_token = Some(match meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    let scale_lit = expr_lit.lit.clone();
+                                    quote!(#scale_lit)
+                                } else {
+                                    return Err(error_tokens("scale parameter must be float"));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "scale received unexpected attribute value",
+                                ));
+                            }
+                        });
+                    }
+                    "bits" => {
+                        macro_attrs.bits.get_or_insert(match &attr.meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    let bits_lit = expr_lit.lit.clone();
+                                    if let Lit::Int(bits_lit) = bits_lit {
+                                        match bits_lit.base10_parse::<usize>() {
+                                            Ok(bits) => bits,
+                                            Err(err) => {
+                                                return Err(error_tokens(err.to_string().as_str()));
+                                            }
+                                        }
+                                    } else {
+                                        return Err(error_tokens("bits parameter must be int"));
+                                    }
+                                } else {
+                                    return Err(error_tokens("bits parameter must be int"));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "bits received unexpected attribute value",
+                                ));
+                            }
+                        });
+                    }
+                    "offset" => {
+                        macro_attrs.offset = match &attr.meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    let offset_lit = expr_lit.lit.clone();
+                                    if let Lit::Int(offset_lit) = offset_lit {
+                                        match offset_lit.base10_parse::<usize>() {
+                                            Ok(offset) => offset,
+                                            Err(err) => {
+                                                return Err(error_tokens(err.to_string().as_str()));
+                                            }
+                                        }
+                                    } else {
+                                        return Err(error_tokens("offset parameter must be int"));
+                                    }
+                                } else {
+                                    return Err(error_tokens("offset parameter must be int"));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "offset received unexpected attribute value",
+                                ));
+                            }
+                        };
+                    }
+                    "label" => {
+                        macro_attrs.label = Some(match &attr.meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    let label_lit = expr_lit.lit.clone();
+                                    if let Lit::Str(label_lit) = label_lit {
+                                        let label_token = label_lit.token();
+                                        quote! {#label_token}
+                                    } else {
+                                        return Err(error_tokens("label parameter must be str"));
+                                    }
+                                } else {
+                                    return Err(error_tokens("label parameter must be str"));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "label received unexpected attribute value",
+                                ));
+                            }
+                        })
+                    }
+                    "length_field" => {
+                        let length_field_path: syn::Path = match &attr.meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    if let Lit::Str(lit_str) = &expr_lit.lit {
+                                        lit_str.parse().map_err(|_| error_tokens("uh oh"))?
+                                    } else {
+                                        return Err(error_tokens(
+                                            "length_field parameter must be string",
+                                        ));
+                                    }
+                                } else {
+                                    return Err(error_tokens(
+                                        "length_field parameter must be string",
+                                    ));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "length_field received unexpected attribute value",
+                                ));
+                            }
+                        };
+                        macro_attrs.length_field = Some(
+                            length_field_path
+                                .get_ident()
+                                .ok_or(error_tokens(
+                                    "length_field did not resolve to Ident properly",
+                                ))?
+                                .clone(),
+                        );
+                    }
+                    "unit" => {
+                        macro_attrs.unit = Some(match &attr.meta {
+                            Meta::NameValue(named) => {
+                                if let Expr::Lit(ref expr_lit) = named.value {
+                                    let unit_lit = expr_lit.lit.clone();
+                                    if let Lit::Str(unit_lit) = unit_lit {
+                                        let unit_token = unit_lit.token();
+                                        let unit_str = unit_token.to_string();
+                                        UnitConversion::try_from(
+                                            unit_str.as_str().trim_matches('"').to_string(),
+                                        )?
+                                    } else {
+                                        return Err(error_tokens("unit parameter must be str"));
+                                    }
+                                } else {
+                                    return Err(error_tokens("unit parameter must be str"));
+                                }
+                            }
+                            _ => {
+                                return Err(error_tokens(
+                                    "unit received unexpected attribute value",
+                                ));
+                            }
+                        })
+                    }
+                    _ => {}
+                };
+            }
+        }
+        macro_attrs.bits.get_or_insert(get_bits(&field.ty)?);
+        Ok(macro_attrs)
+    }
+}

--- a/micro-rdk-nmea-macros/src/attributes.rs
+++ b/micro-rdk-nmea-macros/src/attributes.rs
@@ -5,35 +5,35 @@ use syn::{Expr, Field, Ident, Lit, Meta, Type};
 
 use crate::utils::{error_tokens, UnitConversion};
 
-// `MacroAttributes` represents the important information derived from the macro attributes
-// attached to the field of a struct using the PgnMessageDerive macro.
-//
-// bits -> size in bits of the field in the NMEA message byte slice
-// offset -> the amount of bits to skip in the message data before parsing the field
-// label -> name of the key for the field when serializing the message to a GenericReadingsResult
-// scale_token -> scale factor to be applied to the raw value of the field
-// unit -> unit that the field's value should be converted to before serialization
-// is_lookup -> whether the field is a lookup field
-// length_field -> if this field is a list of fieldsets, this is the field whose value represents
-// the expected length of this list
-//
-// Ex. of usage (each attribute generates an instance of `MacroAttributes`)
-//
-// #[derive(PgnMessageDerive, Debug)]
-// pub struct TemperatureExtendedRange {
-//     source_id: u8,
-//     instance: u8,
-//     #[lookup]
-//     #[label = "temp_src"]
-//     source: TemperatureSource,
-//     #[bits = 24]
-//     #[scale = 0.001]
-//     #[unit = "C"]
-//     temperature: u32,
-//     #[scale = 0.1]
-//     #[offset = 16]
-//     set_temperature: u16,
-// }
+/// `MacroAttributes` represents the important information derived from the macro attributes
+/// attached to the field of a struct using the PgnMessageDerive macro.
+///
+/// `bits`: size in bits of the field in the NMEA message byte slice
+/// `offset`: the amount of bits to skip in the message data before parsing the field
+/// `label`: name of the key for the field when serializing the message to a GenericReadingsResult
+/// `scale_token`: scale factor to be applied to the raw value of the field
+/// `unit`: unit that the field's value should be converted to before serialization
+/// `is_lookup`: whether the field is a lookup field
+/// `length_field`: if this field is a list of fieldsets, this is the field whose value represents
+/// the expected length of this list
+///
+/// Ex. of usage (each attribute generates an instance of `MacroAttributes`)
+///
+/// #[derive(PgnMessageDerive, Debug)]
+/// pub struct TemperatureExtendedRange {
+///     source_id: u8,
+///     instance: u8,
+///     #[lookup]
+///     #[label = "temp_src"]
+///     source: TemperatureSource,
+///     #[bits = 24]
+///     #[scale = 0.001]
+///     #[unit = "C"]
+///     temperature: u32,
+///     #[scale = 0.1]
+///     #[offset = 16]
+///     set_temperature: u16,
+/// }
 
 #[derive(Debug)]
 pub(crate) struct MacroAttributes {
@@ -230,7 +230,7 @@ impl MacroAttributes {
                                         let unit_token = unit_lit.token();
                                         let unit_str = unit_token.to_string();
                                         UnitConversion::try_from(
-                                            unit_str.as_str().trim_matches('"').to_string(),
+                                            unit_str.as_str().trim_matches('"'),
                                         )?
                                     } else {
                                         return Err(error_tokens("unit parameter must be str"));

--- a/micro-rdk-nmea-macros/src/composition.rs
+++ b/micro-rdk-nmea-macros/src/composition.rs
@@ -1,0 +1,243 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Field, Ident, Type};
+
+use crate::attributes::MacroAttributes;
+use crate::utils::{determine_supported_numeric, error_tokens, get_micro_nmea_crate_ident};
+
+/// Represents a subset of auto-generated code statements for the implementation of a particular
+/// NMEA message. Each field in a message struct contributes its own set of statements to the macro
+/// sorted into buckets by category. Those statements are then merged into the set of statements
+/// compiled by the previous field until the code for the message is complete, at which point the
+/// composition can be turned into a TokenStream that can be returned by the macro function
+pub(crate) struct PgnComposition {
+    pub(crate) attribute_getters: Vec<TokenStream2>,
+    pub(crate) parsing_logic: Vec<TokenStream2>,
+    pub(crate) struct_initialization: Vec<TokenStream2>,
+    pub(crate) proto_conversion_logic: Vec<TokenStream2>,
+}
+
+impl PgnComposition {
+    pub(crate) fn new() -> Self {
+        Self {
+            attribute_getters: vec![],
+            parsing_logic: vec![],
+            struct_initialization: vec![],
+            proto_conversion_logic: vec![],
+        }
+    }
+
+    pub(crate) fn merge(&mut self, mut other: Self) {
+        self.attribute_getters.append(&mut other.attribute_getters);
+        self.parsing_logic.append(&mut other.parsing_logic);
+        self.struct_initialization
+            .append(&mut other.struct_initialization);
+        self.proto_conversion_logic
+            .append(&mut other.proto_conversion_logic);
+    }
+
+    pub(crate) fn from_field(field: &Field) -> Result<Self, TokenStream> {
+        let mut statements = Self::new();
+        if let Some(name) = &field.ident {
+            if name == "source_id" {
+                let num_ty = &field.ty;
+                statements.attribute_getters.push(quote! {
+                    pub fn #name(&self) -> #num_ty { self.#name }
+                });
+                statements
+                    .struct_initialization
+                    .push(quote! { source_id: source_id.unwrap(), });
+                return Ok(statements);
+            }
+
+            let macro_attrs = MacroAttributes::from_field(field)?;
+            if macro_attrs.offset != 0 {
+                let offset = macro_attrs.offset / 8;
+                statements
+                    .parsing_logic
+                    .push(quote! { let _ = cursor.read(#offset)?; });
+            }
+
+            let new_statements = if determine_supported_numeric(&field.ty) {
+                handle_number_field(name, field, &macro_attrs)?
+            } else if macro_attrs.is_lookup {
+                handle_lookup_field(name, &field.ty, &macro_attrs)?
+            } else {
+                let err_msg = format!(
+                    "field type for {:?} unsupported for PGN message, macro attributes: {:?}",
+                    name.to_string(),
+                    macro_attrs
+                );
+                return Err(error_tokens(&err_msg));
+            };
+
+            statements.merge(new_statements);
+            Ok(statements)
+        } else {
+            Err(error_tokens(
+                "could not parse parsing/getter statements for field",
+            ))
+        }
+    }
+
+    pub(crate) fn into_token_stream(self, input: &DeriveInput) -> TokenStream2 {
+        let name = &input.ident;
+        let parsing_logic = self.parsing_logic;
+        let attribute_getters = self.attribute_getters;
+        let struct_initialization = self.struct_initialization;
+        let proto_conversion_logic = self.proto_conversion_logic;
+        let (impl_generics, src_generics, src_where_clause) = input.generics.split_for_impl();
+        let crate_ident = crate::utils::get_micro_nmea_crate_ident();
+        let error_ident = quote! {#crate_ident::parse_helpers::errors::NmeaParseError};
+        let mrdk_crate = crate::utils::get_micro_rdk_crate_ident();
+        quote! {
+            impl #impl_generics #name #src_generics #src_where_clause {
+                pub fn from_bytes(data: Vec<u8>, source_id: Option<u8>) -> Result<(Self, usize), #error_ident> {
+                    use #crate_ident::parse_helpers::parsers::{DataCursor, FieldReader};
+                    println!("data: {:?}", data);
+                    let mut cursor = DataCursor::new(data);
+                    #(#parsing_logic)*
+                    Ok((Self {
+                        #(#struct_initialization)*
+                    }, current_index))
+                }
+                #(#attribute_getters)*
+
+                pub fn to_readings(self) -> Result<#mrdk_crate::common::sensor::GenericReadingsResult, #error_ident> {
+                    let mut readings = std::collections::HashMap::new();
+                    #(#proto_conversion_logic)*
+                    Ok(readings)
+                }
+            }
+        }
+    }
+}
+
+fn handle_number_field(
+    name: &Ident,
+    field: &Field,
+    macro_attrs: &MacroAttributes,
+) -> Result<PgnComposition, TokenStream> {
+    let bits_size: usize = macro_attrs.bits.unwrap();
+    let scale_token = macro_attrs.scale_token.as_ref();
+    let unit = macro_attrs.unit.as_ref();
+
+    let num_ty = &field.ty;
+    let mut new_statements = PgnComposition::new();
+    let proto_import_prefix = crate::utils::get_proto_import_prefix();
+    let prop_name = name.to_string();
+    let label = macro_attrs.label.clone().unwrap_or(quote! {#prop_name});
+
+    let crate_ident = crate::utils::get_micro_nmea_crate_ident();
+    let error_ident = quote! {
+        #crate_ident::parse_helpers::errors::NumberFieldError
+    };
+    let raw_fn_name = format_ident!("{}_raw", name);
+
+    new_statements.attribute_getters.push(quote! {
+        pub fn #raw_fn_name(&self) -> #num_ty { self.#name }
+    });
+
+    let mut return_type = quote! {#num_ty};
+    let raw_value_statement = quote! {
+        let mut result = self.#raw_fn_name();
+    };
+    let mut scaling_logic = quote! {};
+    let mut unit_conversion_logic = quote! {};
+
+    if let Some(scale_token) = scale_token {
+        let name_as_string_ident = name.to_string();
+        let max_token = match bits_size {
+            8 | 16 | 32 | 64 => {
+                quote! { let max = <#num_ty>::MAX; }
+            }
+            x => {
+                let x = x as u32;
+                quote! {
+                    let base: #num_ty = 2;
+                    let max = base.pow(#x);
+                }
+            }
+        };
+        scaling_logic = quote! {
+            #max_token
+            let result = match result {
+                x if x == max => { return Err(#error_ident::FieldNotPresent(#name_as_string_ident.to_string())); },
+                x if x == (max - 1) => { return Err(#error_ident::FieldError(#name_as_string_ident.to_string())); },
+                x => {
+                    (x as f64) * #scale_token
+                }
+            };
+        };
+        return_type = quote! {f64};
+    }
+
+    if let Some(unit) = unit {
+        unit_conversion_logic = unit.tokens();
+        return_type = quote! {f64};
+    }
+
+    new_statements.attribute_getters.push(quote! {
+        pub fn #name(&self) -> Result<#return_type, #error_ident> {
+            #raw_value_statement
+            #scaling_logic
+            #unit_conversion_logic
+            Ok(result)
+        }
+    });
+
+    new_statements.proto_conversion_logic.push(quote! {
+        let value = #proto_import_prefix::Value {
+            kind: Some(#proto_import_prefix::value::Kind::NumberValue(
+                self.#name()? as f64
+            ))
+        };
+        readings.insert(#label.to_string(), value);
+    });
+
+    let nmea_crate = get_micro_nmea_crate_ident();
+    new_statements.parsing_logic.push(quote! {
+        let reader = #nmea_crate::parse_helpers::parsers::NumberField::<#num_ty>::new(#bits_size)?;
+        let #name = reader.read_from_cursor(&mut cursor)?;
+    });
+
+    new_statements.struct_initialization.push(quote! {#name,});
+    Ok(new_statements)
+}
+
+fn handle_lookup_field(
+    name: &Ident,
+    field_type: &Type,
+    macro_attrs: &MacroAttributes,
+) -> Result<PgnComposition, TokenStream> {
+    let mut new_statements = PgnComposition::new();
+    let bits_size = macro_attrs.bits.unwrap();
+    if let Type::Path(type_path) = field_type {
+        let enum_type = type_path.clone();
+        new_statements.attribute_getters.push(quote! {
+            pub fn #name(&self) -> #enum_type { self.#name }
+        });
+
+        let nmea_crate = get_micro_nmea_crate_ident();
+        let setters = quote! {
+            let reader = #nmea_crate::parse_helpers::parsers::LookupField::<#enum_type>::new(#bits_size)?;
+            let #name = reader.read_from_cursor(&mut cursor)?;
+        };
+
+        new_statements.parsing_logic.push(setters);
+
+        new_statements.struct_initialization.push(quote! {#name,});
+        let proto_import_prefix = crate::utils::get_proto_import_prefix();
+        let prop_name = name.to_string();
+        let label = macro_attrs.label.clone().unwrap_or(quote! {#prop_name});
+        new_statements.proto_conversion_logic.push(quote! {
+            let value = self.#name();
+            let value = #proto_import_prefix::Value {
+                kind: Some(#proto_import_prefix::value::Kind::StringValue(value.to_string()))
+            };
+            readings.insert(#label.to_string(), value);
+        })
+    }
+    Ok(new_statements)
+}

--- a/micro-rdk-nmea-macros/src/composition.rs
+++ b/micro-rdk-nmea-macros/src/composition.rs
@@ -93,14 +93,13 @@ impl PgnComposition {
         let mrdk_crate = crate::utils::get_micro_rdk_crate_ident();
         quote! {
             impl #impl_generics #name #src_generics #src_where_clause {
-                pub fn from_bytes(data: Vec<u8>, source_id: Option<u8>) -> Result<(Self, usize), #error_ident> {
+                pub fn from_bytes(data: Vec<u8>, source_id: Option<u8>) -> Result<Self, #error_ident> {
                     use #crate_ident::parse_helpers::parsers::{DataCursor, FieldReader};
-                    println!("data: {:?}", data);
                     let mut cursor = DataCursor::new(data);
                     #(#parsing_logic)*
-                    Ok((Self {
+                    Ok(Self {
                         #(#struct_initialization)*
-                    }, current_index))
+                    })
                 }
                 #(#attribute_getters)*
 

--- a/micro-rdk-nmea-macros/src/composition.rs
+++ b/micro-rdk-nmea-macros/src/composition.rs
@@ -148,7 +148,7 @@ fn handle_number_field(
     field: &Field,
     macro_attrs: &MacroAttributes,
 ) -> Result<PgnComposition, TokenStream> {
-    let bits_size: usize = macro_attrs.bits.unwrap();
+    let bits_size: usize = macro_attrs.bits;
     let scale_token = macro_attrs.scale_token.as_ref();
     let unit = macro_attrs.unit.as_ref();
 
@@ -190,7 +190,7 @@ fn handle_number_field(
             }
         };
         scaling_logic = match bits_size {
-            x if x > 4 => quote! {
+            x if ((x < 4) && x > 1) => quote! {
                 #max_token
                 let result = match result {
                     x if x == max => { return Err(#error_ident::FieldNotPresent(#name_as_string_ident.to_string())); },
@@ -253,7 +253,7 @@ fn handle_lookup_field(
     macro_attrs: &MacroAttributes,
 ) -> Result<PgnComposition, TokenStream> {
     let mut new_statements = PgnComposition::new();
-    let bits_size = macro_attrs.bits.unwrap();
+    let bits_size = macro_attrs.bits;
     if let Type::Path(type_path) = field_type {
         let enum_type = type_path.clone();
         new_statements.attribute_getters.push(quote! {

--- a/micro-rdk-nmea-macros/src/lib.rs
+++ b/micro-rdk-nmea-macros/src/lib.rs
@@ -1,0 +1,73 @@
+pub(crate) mod attributes;
+pub(crate) mod composition;
+pub(crate) mod utils;
+
+use crate::composition::PgnComposition;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::DeriveInput;
+
+fn get_statements(
+    input: &DeriveInput,
+    initialize_current_index: bool,
+) -> Result<PgnComposition, TokenStream> {
+    let src_fields = if let syn::Data::Struct(syn::DataStruct { ref fields, .. }) = input.data {
+        fields
+    } else {
+        return Err(
+            syn::Error::new(Span::call_site(), "PgnMessageDerive expected struct")
+                .to_compile_error()
+                .into(),
+        );
+    };
+
+    let named_fields = if let syn::Fields::Named(f) = src_fields {
+        &f.named
+    } else {
+        return Err(crate::utils::error_tokens(
+            "PgnMessageDerive expected struct with named fields",
+        ));
+    };
+
+    let mut statements = PgnComposition::new();
+    if initialize_current_index {
+        statements
+            .parsing_logic
+            .push(quote! { let mut current_index: usize = 0; });
+    } else {
+        statements
+            .parsing_logic
+            .push(quote! { let mut current_index: usize = current_index; });
+    }
+    for field in named_fields.iter() {
+        match PgnComposition::from_field(field) {
+            Ok(new_statements) => {
+                statements.merge(new_statements);
+            }
+            Err(err) => {
+                return Err(err);
+            }
+        };
+    }
+
+    Ok(statements)
+}
+
+/// PgnMessageDerive is a macro that implements parsing logic for a struct in the form of a method
+/// `from_bytes(data: Vec<u8>, source_id: u8) -> Result<Self, NmeaParseError>`, attribute accessors,
+/// and a function `to_readings` for serializing to an instance of `GenericReadingsResult` as defined in
+/// micro-RDK. Refer to the comment for `attributes::MacroAttributes` to understand the attributes
+/// annotating the struct fields to customize the parsing/deserializing logic
+#[proc_macro_derive(
+    PgnMessageDerive,
+    attributes(label, scale, lookup, bits, offset, fieldset, length_field, unit)
+)]
+pub fn pgn_message_derive(item: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(item as syn::DeriveInput);
+
+    match get_statements(&input, true) {
+        Ok(gen) => gen.into_token_stream(&input).into(),
+        Err(tokens) => tokens,
+    }
+}

--- a/micro-rdk-nmea-macros/src/lib.rs
+++ b/micro-rdk-nmea-macros/src/lib.rs
@@ -5,13 +5,9 @@ pub(crate) mod utils;
 use crate::composition::PgnComposition;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::quote;
 use syn::DeriveInput;
 
-fn get_statements(
-    input: &DeriveInput,
-    initialize_current_index: bool,
-) -> Result<PgnComposition, TokenStream> {
+fn get_statements(input: &DeriveInput) -> Result<PgnComposition, TokenStream> {
     let src_fields = if let syn::Data::Struct(syn::DataStruct { ref fields, .. }) = input.data {
         fields
     } else {
@@ -31,15 +27,6 @@ fn get_statements(
     };
 
     let mut statements = PgnComposition::new();
-    if initialize_current_index {
-        statements
-            .parsing_logic
-            .push(quote! { let mut current_index: usize = 0; });
-    } else {
-        statements
-            .parsing_logic
-            .push(quote! { let mut current_index: usize = current_index; });
-    }
     for field in named_fields.iter() {
         match PgnComposition::from_field(field) {
             Ok(new_statements) => {
@@ -66,7 +53,7 @@ fn get_statements(
 pub fn pgn_message_derive(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::DeriveInput);
 
-    match get_statements(&input, true) {
+    match get_statements(&input) {
         Ok(gen) => gen.into_token_stream(&input).into(),
         Err(tokens) => tokens,
     }

--- a/micro-rdk-nmea-macros/src/lib.rs
+++ b/micro-rdk-nmea-macros/src/lib.rs
@@ -4,42 +4,6 @@ pub(crate) mod utils;
 
 use crate::composition::PgnComposition;
 use proc_macro::TokenStream;
-use proc_macro2::Span;
-use syn::DeriveInput;
-
-fn get_statements(input: &DeriveInput) -> Result<PgnComposition, TokenStream> {
-    let src_fields = if let syn::Data::Struct(syn::DataStruct { ref fields, .. }) = input.data {
-        fields
-    } else {
-        return Err(
-            syn::Error::new(Span::call_site(), "PgnMessageDerive expected struct")
-                .to_compile_error()
-                .into(),
-        );
-    };
-
-    let named_fields = if let syn::Fields::Named(f) = src_fields {
-        &f.named
-    } else {
-        return Err(crate::utils::error_tokens(
-            "PgnMessageDerive expected struct with named fields",
-        ));
-    };
-
-    let mut statements = PgnComposition::new();
-    for field in named_fields.iter() {
-        match PgnComposition::from_field(field) {
-            Ok(new_statements) => {
-                statements.merge(new_statements);
-            }
-            Err(err) => {
-                return Err(err);
-            }
-        };
-    }
-
-    Ok(statements)
-}
 
 /// PgnMessageDerive is a macro that implements parsing logic for a struct in the form of a method
 /// `from_bytes(data: Vec<u8>, source_id: u8) -> Result<Self, NmeaParseError>`, attribute accessors,
@@ -53,8 +17,8 @@ fn get_statements(input: &DeriveInput) -> Result<PgnComposition, TokenStream> {
 pub fn pgn_message_derive(item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::DeriveInput);
 
-    match get_statements(&input) {
-        Ok(gen) => gen.into_token_stream(&input).into(),
+    match PgnComposition::from_input(&input) {
+        Ok(statements) => statements.into_token_stream(&input).into(),
         Err(tokens) => tokens,
     }
 }

--- a/micro-rdk-nmea-macros/src/utils.rs
+++ b/micro-rdk-nmea-macros/src/utils.rs
@@ -1,0 +1,97 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use proc_macro_crate::{crate_name, FoundCrate};
+use quote::quote;
+use syn::{Ident, Type};
+
+// Our Golang variant of this library currently automatically performs standard conversions
+// for particular units. `UnitConversion` auto-generates this logic for a given supported result unit.
+// The source unit is assumed (for example, "C" for Celsius indicates that the parsed value is in
+// Kelvin and should be converted into Celsius, so "C" => UnitConversion::KelvinToCelsius)
+#[derive(Debug)]
+pub(crate) enum UnitConversion {
+    KelvinToCelsius,
+    CoulombToAmpereHour,
+    PascalToBar,
+    RadianToDegree,
+    RadPerSecToDegPerSec,
+}
+
+impl TryFrom<String> for UnitConversion {
+    type Error = TokenStream;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        match value.as_str() {
+            "Ah" => Ok(Self::CoulombToAmpereHour),
+            "bar" => Ok(Self::PascalToBar),
+            "C" => Ok(Self::KelvinToCelsius),
+            "deg" => Ok(Self::RadianToDegree),
+            "deg/s" => Ok(Self::RadPerSecToDegPerSec),
+            x => Err(error_tokens(
+                format!("encountered unsupported unit {:?}", x).as_str(),
+            )),
+        }
+    }
+}
+
+impl UnitConversion {
+    pub(crate) fn tokens(&self) -> TokenStream2 {
+        match self {
+            Self::KelvinToCelsius => quote! {
+                let result = (result as f64) - 273.15;
+            },
+            Self::CoulombToAmpereHour => quote! {
+                let result = (result as f64) / 3600;
+            },
+            Self::PascalToBar => quote! {
+                let result = (result as f64) / 100000.0;
+            },
+            Self::RadianToDegree | Self::RadPerSecToDegPerSec => quote! {
+                let result = (result as f64) * (180.0 / std::f64::consts::PI);
+            },
+        }
+    }
+}
+
+pub(crate) fn error_tokens(msg: &str) -> TokenStream {
+    syn::Error::new(Span::call_site(), msg)
+        .to_compile_error()
+        .into()
+}
+
+pub(crate) fn get_micro_nmea_crate_ident() -> Ident {
+    let found_crate =
+        crate_name("micro-rdk-nmea").expect("micro-rdk-nmea is present in `Cargo.toml`");
+    match found_crate {
+        FoundCrate::Itself => Ident::new("crate", Span::call_site()),
+        FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
+    }
+}
+
+pub(crate) fn get_micro_rdk_crate_ident() -> Ident {
+    let found_crate = crate_name("micro-rdk").expect("micro-rdk is present in `Cargo.toml`");
+    match found_crate {
+        FoundCrate::Itself => Ident::new("crate", Span::call_site()),
+        FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
+    }
+}
+
+pub(crate) fn get_proto_import_prefix() -> TokenStream2 {
+    let crate_ident = get_micro_rdk_crate_ident();
+    quote! {#crate_ident::google::protobuf}
+}
+
+pub(crate) fn determine_supported_numeric(field_type: &Type) -> bool {
+    match field_type {
+        Type::Path(type_path) => {
+            type_path.path.is_ident("u32")
+                || type_path.path.is_ident("u16")
+                || type_path.path.is_ident("u8")
+                || type_path.path.is_ident("i32")
+                || type_path.path.is_ident("i16")
+                || type_path.path.is_ident("i64")
+                || type_path.path.is_ident("u64")
+                || type_path.path.is_ident("i8")
+        }
+        _ => false,
+    }
+}

--- a/micro-rdk-nmea-macros/src/utils.rs
+++ b/micro-rdk-nmea-macros/src/utils.rs
@@ -17,10 +17,10 @@ pub(crate) enum UnitConversion {
     RadPerSecToDegPerSec,
 }
 
-impl TryFrom<String> for UnitConversion {
+impl TryFrom<&str> for UnitConversion {
     type Error = TokenStream;
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        match value.as_str() {
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
             "Ah" => Ok(Self::CoulombToAmpereHour),
             "bar" => Ok(Self::PascalToBar),
             "C" => Ok(Self::KelvinToCelsius),
@@ -80,7 +80,7 @@ pub(crate) fn get_proto_import_prefix() -> TokenStream2 {
     quote! {#crate_ident::google::protobuf}
 }
 
-pub(crate) fn determine_supported_numeric(field_type: &Type) -> bool {
+pub(crate) fn is_supported_integer_type(field_type: &Type) -> bool {
     match field_type {
         Type::Path(type_path) => {
             type_path.path.is_ident("u32")

--- a/micro-rdk-nmea/Cargo.toml
+++ b/micro-rdk-nmea/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 
 [dependencies]
 base64 = { workspace = true }
-micro-rdk = { path = "../micro-rdk", features = ["native"] }
-micro-rdk-nmea-macros = { path = "../micro-rdk-nmea-macros" }
+chrono = { workspace = true }
+micro-rdk = { workspace = true, features = ["native"] }
+micro-rdk-nmea-macros = { workspace = true }
 thiserror = { workspace = true }

--- a/micro-rdk-nmea/src/lib.rs
+++ b/micro-rdk-nmea/src/lib.rs
@@ -10,13 +10,17 @@ mod tests {
         parse_helpers::{enums::TemperatureSource, errors::NumberFieldError},
     };
 
+    // The strings in the below test represent base64-encoded data examples taken from raw results
+    // posted by an active CAN sensor. The first 32 bytes involve a header that is represented in serialized
+    // form by parse_helpers::parsers::NmeaMessageMetadata.
+
     #[test]
     fn water_depth_parse() {
         let water_depth_str = "C/UBAHg+gD/TL/RmAAAAAFZODAAAAAAACAD/ABMAAwD/1AAAAAAA/w==";
         let mut data = Vec::<u8>::new();
         let res = general_purpose::STANDARD.decode_vec(water_depth_str, &mut data);
         assert!(res.is_ok());
-        let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
+        let message = WaterDepth::from_bytes(data[33..].to_vec(), 13);
         assert!(message.is_ok());
         let message = message.unwrap();
         assert_eq!(message.source_id(), 13);
@@ -38,7 +42,7 @@ mod tests {
         let mut data = Vec::<u8>::new();
         let res = general_purpose::STANDARD.decode_vec(water_depth_str, &mut data);
         assert!(res.is_ok());
-        let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
+        let message = WaterDepth::from_bytes(data[33..].to_vec(), 13);
         assert!(message.is_ok());
         let message = message.unwrap();
         assert_eq!(message.source_id(), 13);
@@ -61,7 +65,7 @@ mod tests {
         let res = general_purpose::STANDARD.decode_vec(temp_str, &mut data);
         assert!(res.is_ok());
 
-        let message = TemperatureExtendedRange::from_bytes(data[33..].to_vec(), Some(23));
+        let message = TemperatureExtendedRange::from_bytes(data[33..].to_vec(), 23);
         assert!(message.is_ok());
         let message = message.unwrap();
         assert_eq!(message.source_id(), 23);

--- a/micro-rdk-nmea/src/lib.rs
+++ b/micro-rdk-nmea/src/lib.rs
@@ -18,7 +18,7 @@ mod tests {
         assert!(res.is_ok());
         let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
         assert!(message.is_ok());
-        let (message, _) = message.unwrap();
+        let message = message.unwrap();
         assert_eq!(message.source_id(), 13);
         let depth = message.depth();
         assert!(depth.is_ok());
@@ -40,7 +40,7 @@ mod tests {
         assert!(res.is_ok());
         let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
         assert!(message.is_ok());
-        let (message, _) = message.unwrap();
+        let message = message.unwrap();
         assert_eq!(message.source_id(), 13);
         let depth = message.depth();
         assert!(depth.is_ok());
@@ -63,7 +63,7 @@ mod tests {
 
         let message = TemperatureExtendedRange::from_bytes(data[33..].to_vec(), Some(23));
         assert!(message.is_ok());
-        let (message, _) = message.unwrap();
+        let message = message.unwrap();
         assert_eq!(message.source_id(), 23);
         let temp = message.temperature();
         assert!(temp.is_ok());

--- a/micro-rdk-nmea/src/lib.rs
+++ b/micro-rdk-nmea/src/lib.rs
@@ -1,1 +1,82 @@
+pub mod messages;
 pub mod parse_helpers;
+
+#[cfg(test)]
+mod tests {
+    use base64::{engine::general_purpose, Engine};
+
+    use crate::{
+        messages::pgns::{TemperatureExtendedRange, WaterDepth},
+        parse_helpers::{enums::TemperatureSource, errors::NumberFieldError},
+    };
+
+    #[test]
+    fn water_depth_parse() {
+        let water_depth_str = "C/UBAHg+gD/TL/RmAAAAAFZODAAAAAAACAD/ABMAAwD/1AAAAAAA/w==";
+        let mut data = Vec::<u8>::new();
+        let res = general_purpose::STANDARD.decode_vec(water_depth_str, &mut data);
+        assert!(res.is_ok());
+        let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
+        assert!(message.is_ok());
+        let (message, _) = message.unwrap();
+        assert_eq!(message.source_id(), 13);
+        let depth = message.depth();
+        assert!(depth.is_ok());
+        assert_eq!(depth.unwrap(), 2.12);
+        let offset = message.offset();
+        assert!(offset.is_ok());
+        assert_eq!(offset.unwrap(), 0.0);
+        let range = message.range();
+        assert!(range.is_err_and(|err| {
+            matches!(err, NumberFieldError::FieldNotPresent(x) if x.as_str() == "range")
+        }));
+    }
+
+    #[test]
+    fn water_depth_parse_2() {
+        let water_depth_str = "C/UBAHg+gD8l2A2A/////40fszsAAAAACAD/AAIAAwAAhgEAALwC/w==";
+        let mut data = Vec::<u8>::new();
+        let res = general_purpose::STANDARD.decode_vec(water_depth_str, &mut data);
+        assert!(res.is_ok());
+        let message = WaterDepth::from_bytes(data[33..].to_vec(), Some(13));
+        assert!(message.is_ok());
+        let (message, _) = message.unwrap();
+        assert_eq!(message.source_id(), 13);
+        let depth = message.depth();
+        assert!(depth.is_ok());
+        assert_eq!(depth.unwrap(), 3.9);
+        let offset = message.offset();
+        assert!(offset.is_ok());
+        assert_eq!(offset.unwrap(), 0.7000000000000001);
+        let range = message.range();
+        assert!(range.is_err_and(|err| {
+            matches!(err, NumberFieldError::FieldNotPresent(x) if x.as_str() == "range")
+        }));
+    }
+
+    #[test]
+    fn temperature_parse() {
+        let temp_str = "DP0BAHg+gD8QkDZnAAAAABLFBAAAAAAACAD/ACMABQD/AADzmwT//w==";
+        let mut data = Vec::<u8>::new();
+        let res = general_purpose::STANDARD.decode_vec(temp_str, &mut data);
+        assert!(res.is_ok());
+
+        let message = TemperatureExtendedRange::from_bytes(data[33..].to_vec(), Some(23));
+        assert!(message.is_ok());
+        let (message, _) = message.unwrap();
+        assert_eq!(message.source_id(), 23);
+        let temp = message.temperature();
+        assert!(temp.is_ok());
+        let temp = temp.unwrap();
+        assert_eq!(temp, 28.91700000000003);
+
+        let instance = message.instance();
+        assert!(instance.is_ok());
+        let instance = instance.unwrap();
+        assert_eq!(instance, 0);
+        assert!(matches!(
+            message.source(),
+            TemperatureSource::SeaTemperature
+        ));
+    }
+}

--- a/micro-rdk-nmea/src/messages/mod.rs
+++ b/micro-rdk-nmea/src/messages/mod.rs
@@ -1,0 +1,1 @@
+pub mod pgns;

--- a/micro-rdk-nmea/src/messages/pgns.rs
+++ b/micro-rdk-nmea/src/messages/pgns.rs
@@ -1,0 +1,28 @@
+use micro_rdk_nmea_macros::PgnMessageDerive;
+
+use crate::parse_helpers::enums::TemperatureSource;
+
+#[derive(PgnMessageDerive, Debug)]
+pub struct WaterDepth {
+    source_id: u8,
+    #[scale = 0.01]
+    depth: u32,
+    #[scale = 0.001]
+    offset: i16,
+    #[scale = 10.0]
+    range: u8,
+}
+
+#[derive(PgnMessageDerive, Debug)]
+pub struct TemperatureExtendedRange {
+    source_id: u8,
+    instance: u8,
+    #[lookup]
+    source: TemperatureSource,
+    #[bits = 24]
+    #[scale = 0.001]
+    #[unit = "C"]
+    temperature: u32,
+    #[scale = 0.1]
+    set_temperature: u16,
+}

--- a/micro-rdk-nmea/src/parse_helpers/errors.rs
+++ b/micro-rdk-nmea/src/parse_helpers/errors.rs
@@ -4,6 +4,10 @@ use thiserror::Error;
 pub enum NumberFieldError {
     #[error("field bit size {0} too large for max size {0}")]
     ImproperBitSize(usize, usize),
+    #[error("{0} field not present in message")]
+    FieldNotPresent(String),
+    #[error("{0} field was error value")]
+    FieldError(String),
 }
 
 #[derive(Debug, Error)]

--- a/micro-rdk-nmea/src/parse_helpers/errors.rs
+++ b/micro-rdk-nmea/src/parse_helpers/errors.rs
@@ -18,6 +18,8 @@ pub enum NmeaParseError {
     TryFromSliceError(#[from] std::array::TryFromSliceError),
     #[error("not enough data to parse next field")]
     NotEnoughData,
+    #[error("could not parse timestamp")]
+    MalformedTimestamp,
     #[error("found unsupported PGN {0}")]
     UnsupportedPgn(u32),
 }

--- a/micro-rdk-nmea/src/parse_helpers/parsers.rs
+++ b/micro-rdk-nmea/src/parse_helpers/parsers.rs
@@ -1,6 +1,6 @@
-use std::marker::PhantomData;
+use std::{array::TryFromSliceError, marker::PhantomData};
 
-use micro_rdk::common::sensor::GenericReadingsResult;
+use micro_rdk::{common::sensor::GenericReadingsResult, google::protobuf::Timestamp};
 
 use super::{
     enums::NmeaEnumeratedField,
@@ -213,15 +213,81 @@ where
     }
 }
 
+// The first 32 bytes of the unparsed message stores metadata appearing in the header
+// of an NMEA message (the library assumes that a previous process has correctly serialized
+// this data from the CAN frame). For an explanation of the fields in this header, see
+// the section labeled "ISO-11783 and NMEA2000 header" at https://canboat.github.io/canboat/canboat.html
+pub struct NmeaMessageMetadata {
+    timestamp: Timestamp,
+    priority: u16,
+    src: u16,
+    dst: u16,
+}
+
+impl NmeaMessageMetadata {
+    pub fn from_bytes(data: [u8; 32]) -> Result<Self, TryFromSliceError> {
+        let seconds = u64::from_le_bytes(data[8..16].try_into()?) as i64;
+        let millis = u64::from_le_bytes(data[16..24].try_into()?);
+        let timestamp = Timestamp {
+            seconds,
+            nanos: (millis * 1000) as i32,
+        };
+
+        let dst = u16::from_le_bytes(data[26..28].try_into()?);
+        let src = u16::from_le_bytes(data[28..30].try_into()?);
+        let priority = u16::from_le_bytes(data[30..32].try_into()?);
+        Ok(Self {
+            timestamp,
+            priority,
+            src,
+            dst,
+        })
+    }
+
+    pub fn src(&self) -> u16 {
+        self.src
+    }
+
+    pub fn dst(&self) -> u16 {
+        self.dst
+    }
+
+    pub fn priority(&self) -> u16 {
+        self.priority
+    }
+
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use base64::{engine::general_purpose, Engine};
+
     use crate::parse_helpers::{
         enums::MagneticVariationSource,
         errors::NmeaParseError,
-        parsers::{DataCursor, FieldReader},
+        parsers::{DataCursor, FieldReader, NmeaMessageMetadata},
     };
 
     use super::{ArrayField, FieldSet, FieldSetList, LookupField, NumberField};
+
+    #[test]
+    fn parse_metadata() {
+        let data_str = "C/UBAHg+gD8l2A2A/////40fszsAAAAACAD/AAIAAwAAhgEAALwC/w==";
+        let mut data = Vec::<u8>::new();
+        let res = general_purpose::STANDARD.decode_vec(data_str, &mut data);
+        assert!(res.is_ok());
+
+        let metadata = NmeaMessageMetadata::from_bytes(data[0..32].try_into().unwrap());
+        assert!(metadata.is_ok());
+        let metadata = metadata.unwrap();
+
+        assert_eq!(metadata.priority, 3);
+        assert_eq!(metadata.dst, 255);
+        assert_eq!(metadata.src, 2);
+    }
 
     #[test]
     fn number_field_test() {


### PR DESCRIPTION
This is the first PR actually introducing the procedural macro. As explained in the [previous commit](https://github.com/viamrobotics/micro-rdk/pull/377#issue-2776548392), it is recommended that one uses `cargo expand` in the micro-rdk-nmea directory to view the code that is generated by the macro used in the example PGN structs.

This PR includes
-  parsing logic for the message header
- logic for parsing a message struct used by the procedural macro itself
- procedural code generation for messages using number and lookup field types

The next PR will include
- procedural code generation support for array and fieldset fields (also understood as "repeated fields")