### PR TITLE
[RSDK-9734] Release 0.4.1-rc1 and reduce number of release touchpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-ffi"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "base64 0.22.1",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-installer"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-macros"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "micro-rdk",
  "proc-macro-crate 3.2.0",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-modular-driver-example"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "log",
  "micro-rdk",
@@ -2829,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-nmea"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "micro-rdk",
  "thiserror 2.0.4",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-server"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "async-channel 2.3.1",
  "embedded-hal 0.2.7",
@@ -3195,7 +3195,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ota-dev-server"
-version = "0.4.0"
+version = "0.4.1-rc1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ description = "Viam RDK for microcontroller"
 edition = "2021"
 license = "AGPL-3.0"
 repository = "https://github.com/viamrobotics/micro-rdk"
-version = "0.4.0"
+version = "0.4.1-rc1"
 rust-version = "1.83"
 
 [profile.release]

--- a/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
+++ b/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
@@ -1,15 +1,14 @@
 idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 idf_build_set_property(INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/assets" APPEND)
 
-set(LIBMICRORDK_VERSION v0.4.0)
-set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${LIBMICRORDK_VERSION}/micro-rdk-lib.zip)
+set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${COMPONENT_VERSION}/micro-rdk-lib.zip)
 set(LIBMICRORDK_PATH ${CMAKE_BINARY_DIR}/import/micro-rdk-lib.zip)
 
 if((NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a") OR(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h"))
   file(DOWNLOAD ${LIBMICRORDK_URL} ${LIBMICRORDK_PATH} STATUS LIBMICRORDK_DOWNLOAD_STATUS)
   list(GET LIBMICRORDK_DOWNLOAD_STATUS 0 LIBMICRORDK_DOWNLOAD_STATUS_NO)
   if(LIBMICRORDK_DOWNLOAD_STATUS_NO)
-    message( FATAL_ERROR "Cannot download Micro-RDK ${LIBMICRORDK_VERSION} check if the version is valid" )
+    message(FATAL_ERROR "Cannot download Micro-RDK ${COMPONENT_VERSION} library - check if the version in idf_component.yml is valid")
   else()
     add_prebuilt_library(micro_rdk_ffi
       "${CMAKE_CURRENT_BINARY_DIR}/assets/libmicrordk.a"

--- a/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
+++ b/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.4.0"
+version: "0.4.1-rc1"
 description: "Micro-RDK lib"
 dependencies:
   ## Required IDF version

--- a/templates/module/Cargo.toml
+++ b/templates/module/Cargo.toml
@@ -6,8 +6,13 @@ authors = ["{{authors}}"]
 resolver = "2"
 rust-version = "1.83"
 
-[dependencies]
-micro-rdk = {git = "https://github.com/viamrobotics/micro-rdk.git", features = ["{{mcu}}"], version = "0.4.0", rev = "380a098"}
+[dependencies.micro-rdk]
+git = "https://github.com/viamrobotics/micro-rdk.git"
+version = "0.4.1-rc1"
+rev = "v0.4.1-rc1"
+features = [
+  "{{mcu}}"
+]
 
 [package.metadata.com.viam]
 module = true

--- a/templates/project/Cargo.toml
+++ b/templates/project/Cargo.toml
@@ -15,8 +15,8 @@ opt-level = "z"
 
 [dependencies.micro-rdk]
 git = "https://github.com/viamrobotics/micro-rdk.git"
-version = "0.4.0"
-rev = "380a098"
+version = "0.4.1-rc1"
+rev = "v0.4.1-rc1"
 features = [
   "esp32",
   "binstart",


### PR DESCRIPTION
This is the commit I would like to tag as 0.4.0-rc1.

Along with the usual update of version numbers, there are some other simplifications here: 

- It starts using the tag name rather than a git hash in the template configs. This will mean we won't need a post release commit to update the templates with the now-known SHA1 of the release commit.
- It moves both templates to use the same style of declaration for the micro-rdk dependency.
- The `micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt` infrastructure now *derives* the version information from the version metadata in `micro-rdk-ffi/micrordklib-idf-component/idf_component.yml` by way of the `COMPONENT_VERSION` ESP-IDF CMake variable. This eliminates a duplicative touchpoint for releases.
- The version number in `micro-rdk-ffi/micrordklib-idf-component/idf_component.yml` is being advanced to reflect the RC. Downstream consumers of `micrordklib-idf-component` will need to explicitly specify a version when adding `micro-rdk` to their`idf_components.yml` to avoid pulling the RC. But they should be doing that anyway.
