### PR TITLE
use abs path, not rel path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,7 +201,7 @@ jobs:
         body: ${{ steps.changelog.outputs.changelog }}
         
     - name: Upload OTA Artifact to Bucket
-      uses: ./.github/workflows/upload_bucket.yml
+      uses: viamrobotics/micro-rdk/.github/workflows/upload_bucket.yml
       with:
         artifact-name: micro-rdk-server-esp32-ota.bin
         dir-name: ${{ github.ref_name }}

--- a/.github/workflows/upload_bucket.yml
+++ b/.github/workflows/upload_bucket.yml
@@ -1,4 +1,4 @@
-name: Upload artifact to GCP Bucket
+name: Upload Artifact to GCP Bucket
 
 on:
   workflow_call:


### PR DESCRIPTION
to reference something within the repo (ex `./.workflows/...`), you need to check out the repo at some point within the step. Instead of adding an extra step, we can reference a github repo path which does not need checkout