### PR TITLE
Release v0.4.1-rc4 to fix workflow and component version issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,9 +760,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]
@@ -2085,9 +2085,9 @@ checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
 
 [[package]]
 name = "httpdate"
@@ -2103,9 +2103,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2381,9 +2381,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "async-channel 2.3.1",
  "async-executor",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-ffi"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "async-channel 2.3.1",
  "base64 0.22.1",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-installer"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-macros"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "micro-rdk",
  "proc-macro-crate 3.2.0",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-modular-driver-example"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "log",
  "micro-rdk",
@@ -2761,7 +2761,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-nmea"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-nmea-macros"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "micro-rdk-server"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "async-channel 2.3.1",
  "embedded-hal 0.2.7",
@@ -3140,7 +3140,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ota-dev-server"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 dependencies = [
  "axum",
  "axum-extra",
@@ -3834,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "same-file"
@@ -4830,9 +4830,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ description = "Viam RDK for microcontroller"
 edition = "2021"
 license = "AGPL-3.0"
 repository = "https://github.com/viamrobotics/micro-rdk"
-version = "0.4.1-rc3"
+version = "0.4.1-rc4"
 rust-version = "1.83"
 
 [profile.release]

--- a/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
+++ b/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
@@ -1,14 +1,15 @@
 idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 idf_build_set_property(INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/assets" APPEND)
 
-set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${COMPONENT_VERSION}/micro-rdk-lib.zip)
+set(LIBMICRORDK_VERSION v0.4.1-rc4)
+set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${LIBMICRORDK_VERSION}/micro-rdk-lib.zip)
 set(LIBMICRORDK_PATH ${CMAKE_BINARY_DIR}/import/micro-rdk-lib.zip)
 
 if((NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a") OR(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h"))
   file(DOWNLOAD ${LIBMICRORDK_URL} ${LIBMICRORDK_PATH} STATUS LIBMICRORDK_DOWNLOAD_STATUS)
   list(GET LIBMICRORDK_DOWNLOAD_STATUS 0 LIBMICRORDK_DOWNLOAD_STATUS_NO)
   if(LIBMICRORDK_DOWNLOAD_STATUS_NO)
-    message(FATAL_ERROR "Cannot download Micro-RDK ${COMPONENT_VERSION} library - check if the version in idf_component.yml is valid")
+    message( FATAL_ERROR "Cannot download Micro-RDK ${LIBMICRORDK_VERSION} check if the version is valid" )
   else()
     add_prebuilt_library(micro_rdk_ffi
       "${CMAKE_CURRENT_BINARY_DIR}/assets/libmicrordk.a"

--- a/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
+++ b/micro-rdk-ffi/micrordklib-idf-component/idf_component.yml
@@ -1,4 +1,4 @@
-version: "0.4.1-rc3"
+version: "0.4.1-rc4"
 description: "Micro-RDK lib"
 dependencies:
   ## Required IDF version

--- a/templates/module/Cargo.toml
+++ b/templates/module/Cargo.toml
@@ -8,8 +8,8 @@ rust-version = "1.83"
 
 [dependencies.micro-rdk]
 git = "https://github.com/viamrobotics/micro-rdk.git"
-version = "0.4.1-rc3"
-rev = "v0.4.1-rc3"
+version = "0.4.1-rc4"
+rev = "v0.4.1-rc4"
 features = [
   "{{mcu}}"
 ]

--- a/templates/project/Cargo.toml
+++ b/templates/project/Cargo.toml
@@ -15,8 +15,8 @@ opt-level = "z"
 
 [dependencies.micro-rdk]
 git = "https://github.com/viamrobotics/micro-rdk.git"
-version = "0.4.1-rc3"
-rev = "v0.4.1-rc3"
+version = "0.4.1-rc4"
+rev = "v0.4.1-rc4"
 features = [
   "esp32",
   "binstart",


### PR DESCRIPTION
I had to remove the `COMPONENT_VERSION` - I didn't realize it was ESP-IDF 5 only, and I made a mistake in my testing which made it appear that it was working. I've filed https://viam.atlassian.net/browse/RSDK-9841 so we can come back to it once we are on ESP-IDF 5.

Otherwise, this is a boring update of the version from `-rc3` to `-rc4` and a run of `cargo update`.