### PR TITLE
add workflow_dispatch to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: publish
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*"
@@ -183,6 +184,7 @@ jobs:
 
     - name: Publish release
       uses: ncipollo/release-action@v1
+      if: github.event_name == 'push'
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         artifacts: |


### PR DESCRIPTION
## What changed
- add `on: workflow_dispatch` to publish.yml, but suppress the actual publish step in this case
## Why
faster iterative testing of publish.yml workflow