### PR TITLE
[RSDK-9817] add required secrets during publich.yml call to canary_ota.yml

### DIFF
--- a/.github/workflows/canary_ota.yml
+++ b/.github/workflows/canary_ota.yml
@@ -6,6 +6,23 @@ on:
       otaTag:
         required: true
         type: string
+    secrets:
+      ESP32_CANARY_ROBOT:
+        required: true
+      ESP32_CANARY_ROBOT_PART_ID:
+        required: true
+      ESP32_CANARY_API_KEY:
+        required: true
+      ESP32_CANARY_API_KEY_ID:
+        required: true
+      GCP_BUCKET_URL:
+        required: true
+      GCP_BUCKET_NAME:
+        required: true
+      CANARY_SLACKBOT_TOKEN:
+        required: true
+      MICRO_RDK_TEAM_CHANNEL_ID:
+        required: true
   workflow_dispatch:
     inputs:
       otaTag:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -217,5 +217,6 @@ jobs:
   update-canary-ota-config:
     uses: ./.github/workflows/canary_ota.yml
     needs: [publish-release]
+    secrets: inherit
     with:
       otaTag: ${{ github.ref_name }}


### PR DESCRIPTION
appears to be working, executed from `publish.yml` job here: https://github.com/viamrobotics/micro-rdk/actions/runs/13076878920