### PR TITLE
[RSDK-9875] fix linux build deps command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Install x86_64 linux dependencies
       if: ${{ matrix.job.os == 'ubuntu-latest' }}
       run: |
+        sudo apt-get update
         sudo apt-get install libudev-dev pkg-config libssl-dev
     - name: Install MacOS dependencies
       if: ${{ matrix.job.os == 'macos-latest' }}


### PR DESCRIPTION
linux `apt install` step was failing because it didn't call `apt update` first