### PR TITLE
[RSDK-9979] update protos v0.1.394

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 ESPFLASHVERSION_MAJ := $(shell expr `cargo espflash -V | grep ^cargo-espflash | sed 's/^.* //g' | cut -f1 -d. `)
 ESPFLASHVERSION_MIN := $(shell expr `cargo espflash -V | grep ^cargo-espflash | sed 's/^.* //g' | cut -f2 -d. `)
 ESPFLASHVERSION := $(shell [ $(ESPFLASHVERSION_MAJ) -gt 2 -a $(ESPFLASHVERSION_MIN) -ge 2 ] && echo true)
-VIAM_API_VERSION := v0.1.336
+VIAM_API_VERSION := v0.1.394
 
 DATE := $(shell date +%F)
 IMAGE_BASE = ghcr.io/viamrobotics/micro-rdk-dev-env

--- a/micro-rdk/src/common/app_client.rs
+++ b/micro-rdk/src/common/app_client.rs
@@ -257,7 +257,7 @@ impl AppClient {
             version: env!("CARGO_PKG_VERSION").to_string(),
             git_revision: "".to_string(),
             platform: Some("esp32".to_string()),
-            platform_tags: Vec::new(),
+            platform_tags: vec![],
         });
 
         let req = ConfigRequest {

--- a/micro-rdk/src/common/app_client.rs
+++ b/micro-rdk/src/common/app_client.rs
@@ -257,6 +257,7 @@ impl AppClient {
             version: env!("CARGO_PKG_VERSION").to_string(),
             git_revision: "".to_string(),
             platform: Some("esp32".to_string()),
+            platform_tags: Vec::new(),
         });
 
         let req = ConfigRequest {

--- a/micro-rdk/src/common/config.rs
+++ b/micro-rdk/src/common/config.rs
@@ -364,6 +364,8 @@ pub trait Component {
             r#type: "component".to_string(),
             subtype: self.get_type().to_string(),
             name: self.get_name().to_string(),
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         }
     }
     fn get_attribute<'a, T>(&'a self, key: &str) -> Result<T, AttributeError>

--- a/micro-rdk/src/common/config.rs
+++ b/micro-rdk/src/common/config.rs
@@ -364,8 +364,8 @@ pub trait Component {
             r#type: "component".to_string(),
             subtype: self.get_type().to_string(),
             name: self.get_name().to_string(),
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
+            local_name: self.get_name().to_string(),
+            remote_path: vec![],
         }
     }
     fn get_attribute<'a, T>(&'a self, key: &str) -> Result<T, AttributeError>

--- a/micro-rdk/src/common/data_collector.rs
+++ b/micro-rdk/src/common/data_collector.rs
@@ -273,6 +273,8 @@ impl DataCollector {
                     seconds: reading_requested_ts.as_secs() as i64,
                     nanos: reading_requested_ts.subsec_nanos() as i32,
                 }),
+                annotations: None,
+                mime_type: 0,
             }),
             data: Some(data),
         })

--- a/micro-rdk/src/common/data_collector.rs
+++ b/micro-rdk/src/common/data_collector.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 use std::time::{Duration, Instant};
 
 use crate::google::protobuf::Timestamp;
-use crate::proto::app::data_sync::v1::{SensorData, SensorMetadata};
+use crate::proto::app::data_sync::v1::{SensorData, SensorMetadata, MimeType};
 
 use super::{
     config::{AttributeError, Kind},
@@ -274,7 +274,7 @@ impl DataCollector {
                     nanos: reading_requested_ts.subsec_nanos() as i32,
                 }),
                 annotations: None,
-                mime_type: 0,
+                mime_type: MimeType::Unspecified.into(),
             }),
             data: Some(data),
         })

--- a/micro-rdk/src/common/data_collector.rs
+++ b/micro-rdk/src/common/data_collector.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 use std::time::{Duration, Instant};
 
 use crate::google::protobuf::Timestamp;
-use crate::proto::app::data_sync::v1::{SensorData, SensorMetadata, MimeType};
+use crate::proto::app::data_sync::v1::{MimeType, SensorData, SensorMetadata};
 
 use super::{
     config::{AttributeError, Kind},

--- a/micro-rdk/src/common/data_store.rs
+++ b/micro-rdk/src/common/data_store.rs
@@ -328,7 +328,7 @@ mod tests {
     use crate::google::protobuf::Timestamp;
     use crate::google::protobuf::{value::Kind, Struct, Value};
     use crate::proto::app::data_sync::v1::sensor_data::Data;
-    use crate::proto::app::data_sync::v1::{SensorData, SensorMetadata};
+    use crate::proto::app::data_sync::v1::{MimeType, SensorData, SensorMetadata};
     use prost::{length_delimiter_len, Message};
     use rand::distributions::Alphanumeric;
     use rand::Rng;
@@ -395,6 +395,8 @@ mod tests {
                     seconds: reading_received_dt.timestamp(),
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
+                mime_type: MimeType::Unspecified.into(),
+                annotations: None,
             }),
             data: Some(Data::Struct(Struct {
                 fields: HashMap::from([
@@ -432,6 +434,8 @@ mod tests {
                     seconds: reading_received_dt.timestamp(),
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
+                mime_type: MimeType::Unspecified.into(),
+                annotations: None,
             }),
             data: Some(Data::Struct(Struct {
                 fields: HashMap::from([
@@ -495,6 +499,8 @@ mod tests {
                     seconds: reading_received_dt.timestamp(),
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
+                mime_type: MimeType::Unspecified.into(),
+                annotations: None,
             }),
             data: Some(Data::Struct(Struct {
                 fields: HashMap::from([
@@ -531,6 +537,8 @@ mod tests {
                     seconds: reading_received_dt.timestamp(),
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
+                mime_type: MimeType::Unspecified.into(),
+                annotations: None,
             }),
             data: Some(Data::Struct(Struct {
                 fields: HashMap::from([
@@ -784,6 +792,8 @@ mod tests {
                     seconds: reading_received_ts.as_secs() as i64,
                     nanos: reading_received_ts.subsec_nanos() as i32,
                 }),
+                mime_type: MimeType::Unspecified.into(),
+                annotations: None,
             }),
             data: Some(data),
         };

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -151,8 +151,8 @@ fn resource_name_from_component_cfg(cfg: &DynamicComponentConfig) -> ResourceNam
         r#type: "component".to_string(),
         subtype: cfg.r#type.to_string(),
         name: cfg.name.to_string(),
-        local_name: "".to_string(),
-        remote_path: Vec::new(),
+        local_name: cfg.name.to_string(),
+        remote_path: vec![],
     }
 }
 
@@ -373,8 +373,8 @@ impl LocalRobot {
                     r#type: "component".to_owned(),
                     subtype: key.0.to_owned(),
                     name: key.1.clone(),
-                    local_name: "".to_string(),
-                    remote_path: Vec::new(),
+                    local_name: key.1.clone().to_string(),
+                    remote_path: vec![],
                 };
 
                 let res = match self.resources.get(&r_name) {
@@ -722,9 +722,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "motor".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Motor(r)) => Some(r.clone()),
@@ -738,9 +738,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "camera".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Camera(r)) => Some(r.clone()),
@@ -753,9 +753,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "base".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Base(r)) => Some(r.clone()),
@@ -768,9 +768,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "board".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Board(r)) => Some(r.clone()),
@@ -783,9 +783,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "sensor".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Sensor(r)) => Some(r.clone()),
@@ -802,9 +802,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "movement_sensor".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::MovementSensor(r)) => Some(r.clone()),
@@ -818,9 +818,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "encoder".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Encoder(r)) => Some(r.clone()),
@@ -834,9 +834,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "power_sensor".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::PowerSensor(r)) => Some(r.clone()),
@@ -850,9 +850,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "servo".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Servo(r)) => Some(r.clone()),
@@ -869,9 +869,9 @@ impl LocalRobot {
             namespace: "rdk".to_string(),
             r#type: "component".to_string(),
             subtype: "generic".to_string(),
+            local_name: name.clone(),
+            remote_path: vec![],
             name,
-            local_name: "".to_string(),
-            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Generic(r)) => Some(r.clone()),

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -151,6 +151,8 @@ fn resource_name_from_component_cfg(cfg: &DynamicComponentConfig) -> ResourceNam
         r#type: "component".to_string(),
         subtype: cfg.r#type.to_string(),
         name: cfg.name.to_string(),
+        local_name: "".to_string(),
+        remote_path: Vec::new(),
     }
 }
 
@@ -371,6 +373,8 @@ impl LocalRobot {
                     r#type: "component".to_owned(),
                     subtype: key.0.to_owned(),
                     name: key.1.clone(),
+                    local_name: "".to_string(),
+                    remote_path: Vec::new(),
                 };
 
                 let res = match self.resources.get(&r_name) {
@@ -719,6 +723,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "motor".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Motor(r)) => Some(r.clone()),
@@ -733,6 +739,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "camera".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Camera(r)) => Some(r.clone()),
@@ -746,6 +754,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "base".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Base(r)) => Some(r.clone()),
@@ -759,6 +769,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "board".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Board(r)) => Some(r.clone()),
@@ -772,6 +784,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "sensor".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Sensor(r)) => Some(r.clone()),
@@ -789,6 +803,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "movement_sensor".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::MovementSensor(r)) => Some(r.clone()),
@@ -803,6 +819,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "encoder".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Encoder(r)) => Some(r.clone()),
@@ -817,6 +835,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "power_sensor".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::PowerSensor(r)) => Some(r.clone()),
@@ -831,6 +851,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "servo".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Servo(r)) => Some(r.clone()),
@@ -848,6 +870,8 @@ impl LocalRobot {
             r#type: "component".to_string(),
             subtype: "generic".to_string(),
             name,
+            local_name: "".to_string(),
+            remote_path: Vec::new(),
         };
         match self.resources.get(&name) {
             Some(ResourceType::Generic(r)) => Some(r.clone()),

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 #[cfg(feature = "data")]
 use crate::{
     google::protobuf::Timestamp,
-    proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata, MimeType},
+    proto::app::data_sync::v1::{sensor_data::Data, MimeType, SensorData, SensorMetadata},
 };
 
 #[cfg(feature = "esp32")]

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -99,6 +99,8 @@ pub trait Readings {
                     seconds: reading_received_dt.timestamp(),
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
+                annotations: None,
+                mime_type: 0,
             }),
             data: Some(readings.into()),
         })

--- a/micro-rdk/src/common/sensor.rs
+++ b/micro-rdk/src/common/sensor.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 #[cfg(feature = "data")]
 use crate::{
     google::protobuf::Timestamp,
-    proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata},
+    proto::app::data_sync::v1::{sensor_data::Data, SensorData, SensorMetadata, MimeType},
 };
 
 #[cfg(feature = "esp32")]
@@ -100,7 +100,7 @@ pub trait Readings {
                     nanos: reading_received_dt.timestamp_subsec_nanos() as i32,
                 }),
                 annotations: None,
-                mime_type: 0,
+                mime_type: MimeType::Unspecified.into(),
             }),
             data: Some(readings.into()),
         })

--- a/micro-rdk/src/gen/api_version.rs
+++ b/micro-rdk/src/gen/api_version.rs
@@ -1,2 +1,2 @@
 // AUTO-GENERATED CODE; DO NOT DELETE OR EDIT
-pub const VIAM_API_VERSION: &str = "v0.1.336";
+pub const VIAM_API_VERSION: &str = "v0.1.394";

--- a/micro-rdk/src/gen/google.api.rs
+++ b/micro-rdk/src/gen/google.api.rs
@@ -449,6 +449,9 @@ pub struct CommonLanguageSettings {
     /// The destination where API teams want this client library to be published.
     #[prost(enumeration="ClientLibraryDestination", repeated, tag="2")]
     pub destinations: ::prost::alloc::vec::Vec<i32>,
+    /// Configuration for which RPCs should be generated in the GAPIC client.
+    #[prost(message, optional, tag="3")]
+    pub selective_gapic_generation: ::core::option::Option<SelectiveGapicGeneration>,
 }
 /// Details about how and where to publish client libraries.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -620,6 +623,18 @@ pub mod python_settings {
         /// feature in preview packages.
         #[prost(bool, tag="1")]
         pub rest_async_io_enabled: bool,
+        /// Enables generation of protobuf code using new types that are more
+        /// Pythonic which are included in `protobuf>=5.29.x`. This feature will be
+        /// enabled by default 1 month after launching the feature in preview
+        /// packages.
+        #[prost(bool, tag="2")]
+        pub protobuf_pythonic_types_enabled: bool,
+        /// Disables generation of an unversioned Python package for this client
+        /// library. This means that the module names will need to be versioned in
+        /// import statements. For example `import google.cloud.library_v2` instead
+        /// of `import google.cloud.library`.
+        #[prost(bool, tag="3")]
+        pub unversioned_package_disabled: bool,
     }
 }
 /// Settings for Node client libraries.
@@ -683,6 +698,16 @@ pub struct GoSettings {
     /// Some settings.
     #[prost(message, optional, tag="1")]
     pub common: ::core::option::Option<CommonLanguageSettings>,
+    /// Map of service names to renamed services. Keys are the package relative
+    /// service names and values are the name to be used for the service client
+    /// and call options.
+    ///
+    /// publishing:
+    ///    go_settings:
+    ///      renamed_services:
+    ///        Publisher: TopicAdmin
+    #[prost(map="string, string", tag="2")]
+    pub renamed_services: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 /// Describes the generator configuration for a method.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -757,6 +782,24 @@ pub mod method_settings {
         #[prost(message, optional, tag="4")]
         pub total_poll_timeout: ::core::option::Option<super::super::protobuf::Duration>,
     }
+}
+/// This message is used to configure the generation of a subset of the RPCs in
+/// a service for client libraries.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SelectiveGapicGeneration {
+    /// An allowlist of the fully qualified names of RPCs that should be included
+    /// on public client surfaces.
+    #[prost(string, repeated, tag="1")]
+    pub methods: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Setting this to true indicates to the client generators that methods
+    /// that would be excluded from the generation should instead be generated
+    /// in a way that indicates these methods should not be consumed by
+    /// end users. How this is expressed is up to individual language
+    /// implementations to decide. Some examples may be: added annotations,
+    /// obfuscated identifiers, or other language idiomatic patterns.
+    #[prost(bool, tag="2")]
+    pub generate_omitted_as_internal: bool,
 }
 /// The organization for which the client libraries are being published.
 /// Affects the url where generated docs are published, etc.

--- a/micro-rdk/src/gen/google.protobuf.rs
+++ b/micro-rdk/src/gen/google.protobuf.rs
@@ -549,7 +549,7 @@ pub struct Method {
 /// The mixin construct implies that all methods in `AccessControl` are
 /// also declared with same name and request/response types in
 /// `Storage`. A documentation generator or annotation processor will
-/// see the effective `Storage.GetAcl` method after inherting
+/// see the effective `Storage.GetAcl` method after inheriting
 /// documentation and annotations as follows:
 ///
 ///      service Storage {
@@ -1516,8 +1516,6 @@ pub mod field_options {
         }
     }
     /// If set to RETENTION_SOURCE, the option will be omitted from the binary.
-    /// Note: as of January 2023, support for this is in progress and does not yet
-    /// have an effect (b/264593489).
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum OptionRetention {
@@ -1549,8 +1547,7 @@ pub mod field_options {
     }
     /// This indicates the types of entities that the field may apply to when used
     /// as an option. If it is unset, then the field may be freely used as an
-    /// option on any kind of entity. Note: as of January 2023, support for this is
-    /// in progress and does not yet have an effect (b/264593489).
+    /// option on any kind of entity.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
     #[repr(i32)]
     pub enum OptionTargetType {
@@ -2270,7 +2267,7 @@ pub enum Edition {
     Edition2023 = 1000,
     Edition2024 = 1001,
     /// Placeholder editions for testing feature resolution.  These should not be
-    /// used or relyed on outside of tests.
+    /// used or relied on outside of tests.
     Edition1TestOnly = 1,
     Edition2TestOnly = 2,
     Edition99997TestOnly = 99997,

--- a/micro-rdk/src/gen/google.rpc.context.rs
+++ b/micro-rdk/src/gen/google.rpc.context.rs
@@ -296,7 +296,8 @@ pub mod attribute_context {
         /// may be set by external tools to store and retrieve arbitrary metadata.
         /// They are not queryable and should be preserved when modifying objects.
         ///
-        /// More info: <https://kubernetes.io/docs/user-guide/annotations>
+        /// More info:
+        /// <https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/>
         #[prost(map="string, string", tag="6")]
         pub annotations: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
         /// Mutable. The display name set by clients. Must be <= 63 characters.

--- a/micro-rdk/src/gen/google.rpc.rs
+++ b/micro-rdk/src/gen/google.rpc.rs
@@ -266,11 +266,12 @@ pub struct ErrorInfo {
     pub domain: ::prost::alloc::string::String,
     /// Additional structured details about this error.
     ///
-    /// Keys should match /\[a-zA-Z0-9-_\]/ and be limited to 64 characters in
+    /// Keys must match a regular expression of `\[a-z][a-zA-Z0-9-_\]+` but should
+    /// ideally be lowerCamelCase. Also, they must be limited to 64 characters in
     /// length. When identifying the current value of an exceeded limit, the units
     /// should be contained in the key, not the value.  For example, rather than
-    /// {"instanceLimit": "100/request"}, should be returned as,
-    /// {"instanceLimitPerRequest": "100"}, if the client exceeds the number of
+    /// `{"instanceLimit": "100/request"}`, should be returned as,
+    /// `{"instanceLimitPerRequest": "100"}`, if the client exceeds the number of
     /// instances that can be created in a single (batch) request.
     #[prost(map="string, string", tag="3")]
     pub metadata: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
@@ -440,6 +441,18 @@ pub mod bad_request {
         /// A description of why the request element is bad.
         #[prost(string, tag="2")]
         pub description: ::prost::alloc::string::String,
+        /// The reason of the field-level error. This is a constant value that
+        /// identifies the proximate cause of the field-level error. It should
+        /// uniquely identify the type of the FieldViolation within the scope of the
+        /// google.rpc.ErrorInfo.domain. This should be at most 63
+        /// characters and match a regular expression of `\[A-Z][A-Z0-9_]+[A-Z0-9\]`,
+        /// which represents UPPER_SNAKE_CASE.
+        #[prost(string, tag="3")]
+        pub reason: ::prost::alloc::string::String,
+        /// Provides a localized error message for field-level errors that is safe to
+        /// return to the API consumer.
+        #[prost(message, optional, tag="4")]
+        pub localized_message: ::core::option::Option<super::LocalizedMessage>,
     }
 }
 /// Contains metadata about the request that clients can attach when filing a bug

--- a/micro-rdk/src/gen/pb.rs
+++ b/micro-rdk/src/gen/pb.rs
@@ -10,6 +10,8 @@ pub struct CppFeatures {
     pub legacy_closed_enum: ::core::option::Option<bool>,
     #[prost(enumeration="cpp_features::StringType", optional, tag="2")]
     pub string_type: ::core::option::Option<i32>,
+    #[prost(bool, optional, tag="3")]
+    pub enum_name_uses_string_view: ::core::option::Option<bool>,
 }
 /// Nested message and enum types in `CppFeatures`.
 pub mod cpp_features {
@@ -41,6 +43,54 @@ pub mod cpp_features {
                 "VIEW" => Some(Self::View),
                 "CORD" => Some(Self::Cord),
                 "STRING" => Some(Self::String),
+                _ => None,
+            }
+        }
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GoFeatures {
+    /// Whether or not to generate the deprecated UnmarshalJSON method for enums.
+    #[prost(bool, optional, tag="1")]
+    pub legacy_unmarshal_json_enum: ::core::option::Option<bool>,
+    /// One of OPEN, HYBRID or OPAQUE.
+    #[prost(enumeration="go_features::ApiLevel", optional, tag="2")]
+    pub api_level: ::core::option::Option<i32>,
+}
+/// Nested message and enum types in `GoFeatures`.
+pub mod go_features {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum ApiLevel {
+        /// API_LEVEL_UNSPECIFIED results in selecting the OPEN API,
+        /// but needs to be a separate value to distinguish between
+        /// an explicitly set api level or a missing api level.
+        Unspecified = 0,
+        ApiOpen = 1,
+        ApiHybrid = 2,
+        ApiOpaque = 3,
+    }
+    impl ApiLevel {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                ApiLevel::Unspecified => "API_LEVEL_UNSPECIFIED",
+                ApiLevel::ApiOpen => "API_OPEN",
+                ApiLevel::ApiHybrid => "API_HYBRID",
+                ApiLevel::ApiOpaque => "API_OPAQUE",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "API_LEVEL_UNSPECIFIED" => Some(Self::Unspecified),
+                "API_OPEN" => Some(Self::ApiOpen),
+                "API_HYBRID" => Some(Self::ApiHybrid),
+                "API_OPAQUE" => Some(Self::ApiOpaque),
                 _ => None,
             }
         }

--- a/micro-rdk/src/gen/proto.stream.v1.rs
+++ b/micro-rdk/src/gen/proto.stream.v1.rs
@@ -35,4 +35,41 @@ pub struct RemoveStreamRequest {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveStreamResponse {
 }
+/// Resolution details the width and height of a stream.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Resolution {
+    #[prost(int32, tag="1")]
+    pub width: i32,
+    #[prost(int32, tag="2")]
+    pub height: i32,
+}
+/// GetStreamOptionsRequest requests the options for a particular stream.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetStreamOptionsRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+}
+/// GetStreamOptionsResponse details the options for a particular stream.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetStreamOptionsResponse {
+    #[prost(message, repeated, tag="1")]
+    pub resolutions: ::prost::alloc::vec::Vec<Resolution>,
+}
+/// SetStreamOptionsRequest sets the options for a particular stream.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetStreamOptionsRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub resolution: ::core::option::Option<Resolution>,
+}
+/// SetStreamOptionsResponse is returned after a successful SetStreamOptionsRequest.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetStreamOptionsResponse {
+}
 // @@protoc_insertion_point(module)

--- a/micro-rdk/src/gen/viam.app.agent.v1.rs
+++ b/micro-rdk/src/gen/viam.app.agent.v1.rs
@@ -10,26 +10,46 @@ pub struct DeviceAgentConfigRequest {
     #[prost(message, optional, tag="2")]
     pub host_info: ::core::option::Option<HostInfo>,
     /// current subsystems and versions
+    /// DEPRECATED in favor of version_info
     #[prost(map="string, string", tag="3")]
     pub subsystem_versions: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    /// Currently installed versions for agent and viam-server
+    #[prost(message, optional, tag="4")]
+    pub version_info: ::core::option::Option<VersionInfo>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceAgentConfigResponse {
     /// subsystems to be installed/configured/updated
     /// note: previously installed subsystems will be removed from the system if removed from this list
+    /// DEPRECATED in favor of indidivual update_info and settings fields
     #[prost(map="string, message", tag="1")]
     pub subsystem_configs: ::std::collections::HashMap<::prost::alloc::string::String, DeviceSubsystemConfig>,
     /// how often this request should be repeated
     #[prost(message, optional, tag="2")]
     pub check_interval: ::core::option::Option<super::super::super::super::google::protobuf::Duration>,
+    /// update info for agent and viam-server, parsed/processed in App
+    #[prost(message, optional, tag="3")]
+    pub agent_update_info: ::core::option::Option<UpdateInfo>,
+    #[prost(message, optional, tag="4")]
+    pub viam_server_update_info: ::core::option::Option<UpdateInfo>,
+    /// various settings that are passed directly to device Agent
+    #[prost(message, optional, tag="5")]
+    pub advanced_settings: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+    #[prost(message, optional, tag="6")]
+    pub network_configuration: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+    #[prost(message, optional, tag="7")]
+    pub additional_networks: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+    #[prost(message, optional, tag="8")]
+    pub system_configuration: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
+/// DEPRECATED as of January 2025
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeviceSubsystemConfig {
     /// data needed to download/validate the subsystem
     #[prost(message, optional, tag="1")]
-    pub update_info: ::core::option::Option<SubsystemUpdateInfo>,
+    pub update_info: ::core::option::Option<UpdateInfo>,
     /// if this subsystem is disabled and should not be started by the agent
     #[prost(bool, tag="2")]
     pub disable: bool,
@@ -39,6 +59,22 @@ pub struct DeviceSubsystemConfig {
     /// arbitrary config sections
     #[prost(message, optional, tag="4")]
     pub attributes: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct VersionInfo {
+    /// the version of agent currently running and making the request
+    #[prost(string, tag="1")]
+    pub agent_running: ::prost::alloc::string::String,
+    /// the version of agent installed (will run after restart if different)
+    #[prost(string, tag="2")]
+    pub agent_installed: ::prost::alloc::string::String,
+    /// the version of viam-server currently running
+    #[prost(string, tag="3")]
+    pub viam_server_running: ::prost::alloc::string::String,
+    /// the version of viam-server installed (will run after restart if different)
+    #[prost(string, tag="4")]
+    pub viam_server_installed: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -56,7 +92,7 @@ pub struct HostInfo {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SubsystemUpdateInfo {
+pub struct UpdateInfo {
     /// unpacked filename as it is expected on disk (regardless of url)
     #[prost(string, tag="1")]
     pub filename: ::prost::alloc::string::String,

--- a/micro-rdk/src/gen/viam.app.build.v1.rs
+++ b/micro-rdk/src/gen/viam.app.build.v1.rs
@@ -18,6 +18,12 @@ pub struct StartBuildRequest {
     /// must be valid semver2.0 string (ex: 1.2.3-rc0)
     #[prost(string, tag="5")]
     pub module_version: ::prost::alloc::string::String,
+    /// checkout token. provide this for private repos
+    #[prost(string, optional, tag="6")]
+    pub token: ::core::option::Option<::prost::alloc::string::String>,
+    /// optional working directory. defaults to repo root.
+    #[prost(string, optional, tag="7")]
+    pub workdir: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/micro-rdk/src/gen/viam.app.data.v1.rs
+++ b/micro-rdk/src/gen/viam.app.data.v1.rs
@@ -158,8 +158,8 @@ pub struct TabularDataBySqlRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TabularDataBySqlResponse {
-    #[prost(message, repeated, tag="1")]
-    pub data: ::prost::alloc::vec::Vec<super::super::super::super::google::protobuf::Struct>,
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub raw_data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
 }
 /// TabularDataByMQLRequest requests tabular data using an MQL query.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -172,13 +172,86 @@ pub struct TabularDataByMqlRequest {
     /// namespace, which holds the Viam organization's tabular data.
     #[prost(bytes="vec", repeated, tag="3")]
     pub mql_binary: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+    #[prost(bool, optional, tag="4")]
+    pub use_recent_data: ::core::option::Option<bool>,
 }
 /// TabularDataByMQLResponse provides unified tabular data and metadata, queried with MQL.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TabularDataByMqlResponse {
-    #[prost(message, repeated, tag="1")]
-    pub data: ::prost::alloc::vec::Vec<super::super::super::super::google::protobuf::Struct>,
+    #[prost(bytes="vec", repeated, tag="2")]
+    pub raw_data: ::prost::alloc::vec::Vec<::prost::alloc::vec::Vec<u8>>,
+}
+/// ExportTabularDataRequest requests tabular data from the specified data source.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExportTabularDataRequest {
+    #[prost(string, tag="1")]
+    pub part_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub resource_name: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub resource_subtype: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub method_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="5")]
+    pub interval: ::core::option::Option<CaptureInterval>,
+}
+/// ExportTabularDataResponse provides unified tabular data and metadata for a single data point from the specified data source.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExportTabularDataResponse {
+    #[prost(string, tag="1")]
+    pub part_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub resource_name: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub resource_subtype: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub method_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="5")]
+    pub time_captured: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="6")]
+    pub organization_id: ::prost::alloc::string::String,
+    #[prost(string, tag="7")]
+    pub location_id: ::prost::alloc::string::String,
+    #[prost(string, tag="8")]
+    pub robot_name: ::prost::alloc::string::String,
+    #[prost(string, tag="9")]
+    pub robot_id: ::prost::alloc::string::String,
+    #[prost(string, tag="10")]
+    pub part_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="11")]
+    pub method_parameters: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+    #[prost(string, repeated, tag="12")]
+    pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(message, optional, tag="13")]
+    pub payload: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+/// GetLatestTabularDataRequest requests the most recent tabular data captured from the specified data source.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetLatestTabularDataRequest {
+    #[prost(string, tag="1")]
+    pub part_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub resource_name: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub method_name: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub resource_subtype: ::prost::alloc::string::String,
+}
+/// GetLatestTabularDataResponse provides the data, time synced, and time captured of the most recent tabular data captured
+/// from the requested data source, as long as it was synced within the last year.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetLatestTabularDataResponse {
+    #[prost(message, optional, tag="1")]
+    pub time_captured: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
+    #[prost(message, optional, tag="2")]
+    pub time_synced: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
+    #[prost(message, optional, tag="3")]
+    pub payload: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
 }
 /// BinaryData contains data and metadata associated with binary data.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -261,6 +334,19 @@ pub struct BoundingBox {
     pub x_max_normalized: f64,
     #[prost(double, tag="6")]
     pub y_max_normalized: f64,
+    /// confidence is an optional range from 0 - 1
+    #[prost(double, optional, tag="7")]
+    pub confidence: ::core::option::Option<f64>,
+}
+/// Classification represents a confidence score with a label.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Classification {
+    #[prost(string, tag="1")]
+    pub label: ::prost::alloc::string::String,
+    /// confidence is an optional range from 0 - 1
+    #[prost(double, optional, tag="2")]
+    pub confidence: ::core::option::Option<f64>,
 }
 /// Annotations are data annotations used for machine learning.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -268,6 +354,8 @@ pub struct BoundingBox {
 pub struct Annotations {
     #[prost(message, repeated, tag="1")]
     pub bboxes: ::prost::alloc::vec::Vec<BoundingBox>,
+    #[prost(message, repeated, tag="2")]
+    pub classifications: ::prost::alloc::vec::Vec<Classification>,
 }
 /// BinaryMetadata is the metadata associated with binary data.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -440,7 +528,7 @@ pub struct AddBoundingBoxToImageByIdResponse {
     #[prost(string, tag="1")]
     pub bbox_id: ::prost::alloc::string::String,
 }
-/// RemoveBoundingBoxFromImageByIDRequest removes the bounding box with specified bbox ID for the file represented by the binary id.
+/// RemoveBoundingBoxFromImageByIDRequest removes the bounding box with specified bounding box ID for the file represented by the binary ID.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveBoundingBoxFromImageByIdRequest {
@@ -452,6 +540,29 @@ pub struct RemoveBoundingBoxFromImageByIdRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RemoveBoundingBoxFromImageByIdResponse {
+}
+/// UpdateBoundingBoxRequest updates the bounding box with specified bounding box ID for the file represented by the binary ID.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateBoundingBoxRequest {
+    #[prost(message, optional, tag="1")]
+    pub binary_id: ::core::option::Option<BinaryId>,
+    #[prost(string, tag="2")]
+    pub bbox_id: ::prost::alloc::string::String,
+    #[prost(string, optional, tag="3")]
+    pub label: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(double, optional, tag="4")]
+    pub x_min_normalized: ::core::option::Option<f64>,
+    #[prost(double, optional, tag="5")]
+    pub y_min_normalized: ::core::option::Option<f64>,
+    #[prost(double, optional, tag="6")]
+    pub x_max_normalized: ::core::option::Option<f64>,
+    #[prost(double, optional, tag="7")]
+    pub y_max_normalized: ::core::option::Option<f64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateBoundingBoxResponse {
 }
 /// BoundingBoxLabelsByFilterRequest requests all the labels of the bounding boxes from files from a given filter.
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/micro-rdk/src/gen/viam.app.datasync.v1.rs
+++ b/micro-rdk/src/gen/viam.app.datasync.v1.rs
@@ -67,7 +67,8 @@ pub struct StreamingDataCaptureUploadResponse {
     #[prost(string, tag="1")]
     pub file_id: ::prost::alloc::string::String,
 }
-/// SensorMetadata contains the time the sensor data was requested and was received.
+/// SensorMetadata contains the time the sensor data was requested and was
+/// received.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SensorMetadata {
@@ -75,6 +76,10 @@ pub struct SensorMetadata {
     pub time_requested: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
     pub time_received: ::core::option::Option<super::super::super::super::google::protobuf::Timestamp>,
+    #[prost(enumeration="MimeType", tag="3")]
+    pub mime_type: i32,
+    #[prost(message, optional, tag="4")]
+    pub annotations: ::core::option::Option<super::super::data::v1::Annotations>,
 }
 /// SensorData contains the contents and metadata for tabular data.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -162,6 +167,38 @@ pub struct DataCaptureUploadMetadata {
     pub upload_metadata: ::core::option::Option<UploadMetadata>,
     #[prost(message, optional, tag="2")]
     pub sensor_metadata: ::core::option::Option<SensorMetadata>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MimeType {
+    Unspecified = 0,
+    ImageJpeg = 1,
+    ImagePng = 2,
+    ApplicationPcd = 3,
+}
+impl MimeType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            MimeType::Unspecified => "MIME_TYPE_UNSPECIFIED",
+            MimeType::ImageJpeg => "MIME_TYPE_IMAGE_JPEG",
+            MimeType::ImagePng => "MIME_TYPE_IMAGE_PNG",
+            MimeType::ApplicationPcd => "MIME_TYPE_APPLICATION_PCD",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "MIME_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "MIME_TYPE_IMAGE_JPEG" => Some(Self::ImageJpeg),
+            "MIME_TYPE_IMAGE_PNG" => Some(Self::ImagePng),
+            "MIME_TYPE_APPLICATION_PCD" => Some(Self::ApplicationPcd),
+            _ => None,
+        }
+    }
 }
 /// DataType specifies the type of data uploaded.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]

--- a/micro-rdk/src/gen/viam.app.mlinference.v1.rs
+++ b/micro-rdk/src/gen/viam.app.mlinference.v1.rs
@@ -1,0 +1,25 @@
+// @generated
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetInferenceRequest {
+    /// The model framework and model type are inferred from the ML model registry item;
+    /// For valid model types (classification, detections) we will return the formatted
+    /// labels or annotations from the associated inference outputs.
+    #[prost(string, tag="1")]
+    pub registry_item_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub registry_item_version: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub binary_id: ::core::option::Option<super::super::data::v1::BinaryId>,
+    #[prost(string, tag="4")]
+    pub organization_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetInferenceResponse {
+    #[prost(message, optional, tag="1")]
+    pub output_tensors: ::core::option::Option<super::super::super::service::mlmodel::v1::FlatTensors>,
+    #[prost(message, optional, tag="2")]
+    pub annotations: ::core::option::Option<super::super::data::v1::Annotations>,
+}
+// @@protoc_insertion_point(module)

--- a/micro-rdk/src/gen/viam.app.mltraining.v1.rs
+++ b/micro-rdk/src/gen/viam.app.mltraining.v1.rs
@@ -36,6 +36,8 @@ pub struct SubmitCustomTrainingJobRequest {
     pub model_name: ::prost::alloc::string::String,
     #[prost(string, tag="5")]
     pub model_version: ::prost::alloc::string::String,
+    #[prost(map="string, string", tag="7")]
+    pub arguments: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/micro-rdk/src/gen/viam.app.v1.rs
+++ b/micro-rdk/src/gen/viam.app.v1.rs
@@ -197,6 +197,30 @@ pub struct DeleteOrganizationResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetOrganizationMetadataRequest {
+    #[prost(string, tag="1")]
+    pub organization_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetOrganizationMetadataResponse {
+    #[prost(map="string, message", tag="1")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateOrganizationMetadataRequest {
+    #[prost(string, tag="1")]
+    pub organization_id: ::prost::alloc::string::String,
+    #[prost(map="string, message", tag="2")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateOrganizationMetadataResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListOrganizationMembersRequest {
     #[prost(string, tag="1")]
     pub organization_id: ::prost::alloc::string::String,
@@ -286,6 +310,100 @@ pub struct DeleteOrganizationMemberRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteOrganizationMemberResponse {
+}
+// Third Party Org Services
+
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BillingAddress {
+    #[prost(string, tag="1")]
+    pub address_line_1: ::prost::alloc::string::String,
+    #[prost(string, optional, tag="2")]
+    pub address_line_2: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag="3")]
+    pub city: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub state: ::prost::alloc::string::String,
+    #[prost(string, tag="5")]
+    pub zipcode: ::prost::alloc::string::String,
+    #[prost(string, tag="6")]
+    pub country: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnableBillingServiceRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub billing_address: ::core::option::Option<BillingAddress>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnableBillingServiceResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateBillingServiceRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub billing_address: ::core::option::Option<BillingAddress>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateBillingServiceResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBillingServiceConfigRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetBillingServiceConfigResponse {
+    #[prost(message, optional, tag="1")]
+    pub billing_address: ::core::option::Option<BillingAddress>,
+    #[prost(string, tag="2")]
+    pub support_email: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub logo_url: ::prost::alloc::string::String,
+    #[prost(string, tag="4")]
+    pub billing_dashboard_url: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DisableBillingServiceRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DisableBillingServiceResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationSetSupportEmailRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub email: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationSetSupportEmailResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationGetSupportEmailRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationGetSupportEmailResponse {
+    #[prost(string, tag="1")]
+    pub email: ::prost::alloc::string::String,
 }
 // Location
 //
@@ -479,6 +597,30 @@ pub struct DeleteLocationRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteLocationResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetLocationMetadataRequest {
+    #[prost(string, tag="1")]
+    pub location_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetLocationMetadataResponse {
+    #[prost(map="string, message", tag="1")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateLocationMetadataRequest {
+    #[prost(string, tag="1")]
+    pub location_id: ::prost::alloc::string::String,
+    #[prost(map="string, message", tag="2")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateLocationMetadataResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -732,6 +874,30 @@ pub struct DeleteRobotPartRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotPartMetadataRequest {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotPartMetadataResponse {
+    #[prost(map="string, message", tag="1")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateRobotPartMetadataRequest {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(map="string, message", tag="2")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateRobotPartMetadataResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetRobotApiKeysRequest {
     #[prost(string, tag="1")]
     pub robot_id: ::prost::alloc::string::String,
@@ -790,6 +956,8 @@ pub struct Fragment {
     /// latest timestamp when fragment was updated
     #[prost(message, optional, tag="13")]
     pub last_updated: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+    #[prost(string, tag="14")]
+    pub revision: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -802,6 +970,62 @@ pub struct FragmentHistoryEntry {
     pub old: ::core::option::Option<Fragment>,
     #[prost(message, optional, tag="4")]
     pub edited_by: ::core::option::Option<AuthenticatorInfo>,
+    #[prost(string, tag="5")]
+    pub revision: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="6")]
+    pub config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FragmentRevision {
+    #[prost(string, tag="1")]
+    pub revision: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub created_at: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FragmentTag {
+    #[prost(string, tag="1")]
+    pub tag: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub revision: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FragmentError {
+    #[prost(enumeration="FragmentErrorType", tag="1")]
+    pub error_type: i32,
+    #[prost(string, tag="2")]
+    pub fragment_id: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub detail: ::prost::alloc::string::String,
+}
+/// Cached fragment usage statistics
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct FragmentUsage {
+    #[prost(string, tag="1")]
+    pub fragment_id: ::prost::alloc::string::String,
+    #[prost(int32, tag="2")]
+    pub organizations: i32,
+    #[prost(int32, tag="3")]
+    pub machines: i32,
+    #[prost(int32, tag="4")]
+    pub machines_in_current_org: i32,
+    /// revision or tag
+    #[prost(string, optional, tag="5")]
+    pub version: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResolvedFragment {
+    #[prost(string, tag="1")]
+    pub fragment_id: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="2")]
+    pub resolved_config: ::core::option::Option<super::super::super::google::protobuf::Struct>,
+    #[prost(message, optional, tag="3")]
+    pub error: ::core::option::Option<FragmentError>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -818,18 +1042,31 @@ pub struct ListFragmentsRequest {
 pub struct ListFragmentsResponse {
     #[prost(message, repeated, tag="1")]
     pub fragments: ::prost::alloc::vec::Vec<Fragment>,
+    #[prost(message, repeated, tag="2")]
+    pub fragment_usages: ::prost::alloc::vec::Vec<FragmentUsage>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetFragmentRequest {
     #[prost(string, tag="1")]
     pub id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub current_organization_id: ::prost::alloc::string::String,
+    /// revision or tag
+    #[prost(string, optional, tag="3")]
+    pub version: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetFragmentResponse {
     #[prost(message, optional, tag="1")]
     pub fragment: ::core::option::Option<Fragment>,
+    #[prost(message, optional, tag="2")]
+    pub fragment_usage: ::core::option::Option<FragmentUsage>,
+    #[prost(message, repeated, tag="3")]
+    pub revisions: ::prost::alloc::vec::Vec<FragmentRevision>,
+    #[prost(message, repeated, tag="4")]
+    pub tags: ::prost::alloc::vec::Vec<FragmentTag>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -899,6 +1136,48 @@ pub struct GetFragmentHistoryResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetFragmentUsageRequest {
+    #[prost(string, tag="1")]
+    pub fragment_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetFragmentUsageResponse {
+    #[prost(message, repeated, tag="1")]
+    pub version_usages: ::prost::alloc::vec::Vec<FragmentUsage>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetFragmentTagRequest {
+    #[prost(string, tag="1")]
+    pub fragment_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub tag: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub revision: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetFragmentTagResponse {
+    #[prost(message, repeated, tag="1")]
+    pub tags: ::prost::alloc::vec::Vec<FragmentTag>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteFragmentTagRequest {
+    #[prost(string, tag="1")]
+    pub fragment_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub tag: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteFragmentTagResponse {
+    #[prost(message, repeated, tag="1")]
+    pub tags: ::prost::alloc::vec::Vec<FragmentTag>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListRobotsRequest {
     #[prost(string, tag="1")]
     pub location_id: ::prost::alloc::string::String,
@@ -920,6 +1199,8 @@ pub struct ListMachineFragmentsRequest {
 pub struct ListMachineFragmentsResponse {
     #[prost(message, repeated, tag="1")]
     pub fragments: ::prost::alloc::vec::Vec<Fragment>,
+    #[prost(message, repeated, tag="2")]
+    pub resolved_fragments: ::prost::alloc::vec::Vec<ResolvedFragment>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -966,6 +1247,30 @@ pub struct DeleteRobotRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DeleteRobotResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotMetadataRequest {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRobotMetadataResponse {
+    #[prost(map="string, message", tag="1")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateRobotMetadataRequest {
+    #[prost(string, tag="1")]
+    pub id: ::prost::alloc::string::String,
+    #[prost(map="string, message", tag="2")]
+    pub data: ::std::collections::HashMap<::prost::alloc::string::String, super::super::super::google::protobuf::Any>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateRobotMetadataResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1115,6 +1420,9 @@ pub struct ModuleVersion {
     /// The entrypoint for this version of the module
     #[prost(string, tag="4")]
     pub entrypoint: ::prost::alloc::string::String,
+    /// The path to a setup script that is run before a newly downloaded module starts.
+    #[prost(string, optional, tag="5")]
+    pub first_run: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1129,6 +1437,9 @@ pub struct ModuleMetadata {
     /// The executable to run to start the module program
     #[prost(string, tag="3")]
     pub entrypoint: ::prost::alloc::string::String,
+    /// The path to a setup script that is run before a newly downloaded module starts.
+    #[prost(string, optional, tag="4")]
+    pub first_run: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1233,6 +1544,8 @@ pub mod registry_item {
 pub struct GetRegistryItemRequest {
     #[prost(string, tag="1")]
     pub item_id: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag="2")]
+    pub include_markdown_documentation: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1270,6 +1583,21 @@ pub struct UpdateRegistryItemRequest {
     pub visibility: i32,
     #[prost(string, optional, tag="5")]
     pub url: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(oneof="update_registry_item_request::Metadata", tags="6, 7, 8")]
+    pub metadata: ::core::option::Option<update_registry_item_request::Metadata>,
+}
+/// Nested message and enum types in `UpdateRegistryItemRequest`.
+pub mod update_registry_item_request {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Metadata {
+        #[prost(message, tag="6")]
+        ModuleUpdateMetadata(super::UpdateModuleMetadata),
+        #[prost(message, tag="7")]
+        MlModelUpdateMetadata(super::UpdateMlModelMetadata),
+        #[prost(message, tag="8")]
+        MlTrainingUpdateMetadata(super::UpdateMlTrainingMetadata),
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1296,6 +1624,8 @@ pub struct ListRegistryItemsRequest {
     /// One or more public namespaces to return results for.
     #[prost(string, repeated, tag="8")]
     pub public_namespaces: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(bool, optional, tag="9")]
+    pub include_markdown_documentation: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1368,6 +1698,9 @@ pub struct UpdateModuleRequest {
     /// The executable to run to start the module program
     #[prost(string, tag="6")]
     pub entrypoint: ::prost::alloc::string::String,
+    /// The path to a setup script that is run before a newly downloaded module starts.
+    #[prost(string, optional, tag="7")]
+    pub first_run: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1378,6 +1711,34 @@ pub struct UpdateModuleResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateModuleMetadata {
+    /// A list of models that are available in the module
+    #[prost(message, repeated, tag="1")]
+    pub models: ::prost::alloc::vec::Vec<Model>,
+    /// The executable to run to start the module program
+    #[prost(string, tag="2")]
+    pub entrypoint: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateMlModelMetadata {
+    #[prost(enumeration="super::mltraining::v1::ModelType", tag="1")]
+    pub model_type: i32,
+    #[prost(enumeration="super::mltraining::v1::ModelFramework", tag="2")]
+    pub model_framework: i32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateMlTrainingMetadata {
+    #[prost(enumeration="super::mltraining::v1::ModelType", tag="1")]
+    pub model_type: i32,
+    #[prost(enumeration="super::mltraining::v1::ModelFramework", tag="2")]
+    pub model_framework: i32,
+    #[prost(bool, tag="3")]
+    pub draft: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Model {
     /// The colon-delimited-triplet of the api implemented by the model
     #[prost(string, tag="1")]
@@ -1385,6 +1746,12 @@ pub struct Model {
     /// The colon-delimited-triplet of the model
     #[prost(string, tag="2")]
     pub model: ::prost::alloc::string::String,
+    /// The markdown content describing the usage of the model
+    #[prost(string, optional, tag="3")]
+    pub markdown_documentation: ::core::option::Option<::prost::alloc::string::String>,
+    /// A short description of the model that explains its purpose
+    #[prost(string, optional, tag="4")]
+    pub description: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1398,6 +1765,11 @@ pub struct ModuleFileInfo {
     /// The platform that the file is built to run on
     #[prost(string, tag="3")]
     pub platform: ::prost::alloc::string::String,
+    /// Platform tag constraints. When a robot requests its config, it uploads a platform and a list of
+    /// platform tags. The platform is checked against `platform` above, and the tags are checked against
+    /// this list.
+    #[prost(string, repeated, tag="5")]
+    pub platform_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1431,6 +1803,8 @@ pub struct GetModuleRequest {
     /// The id of the module (formatted as prefix:name where prefix is the module owner's orgid or namespace)
     #[prost(string, tag="1")]
     pub module_id: ::prost::alloc::string::String,
+    #[prost(bool, optional, tag="2")]
+    pub include_markdown_documentation: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1480,6 +1854,9 @@ pub struct Module {
     /// This is empty if no public namespace is set
     #[prost(string, tag="12")]
     pub public_namespace: ::prost::alloc::string::String,
+    /// The path to a setup script that is run before a newly downloaded module starts.
+    #[prost(string, optional, tag="13")]
+    pub first_run: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1496,6 +1873,9 @@ pub struct VersionHistory {
     /// The entrypoint for this version of the module
     #[prost(string, tag="4")]
     pub entrypoint: ::prost::alloc::string::String,
+    /// The path to a setup script that is run before a newly downloaded module starts.
+    #[prost(string, optional, tag="5")]
+    pub first_run: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1513,6 +1893,8 @@ pub struct ListModulesRequest {
     /// The id of the organization to return private modules for.
     #[prost(string, optional, tag="1")]
     pub organization_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(bool, optional, tag="2")]
+    pub include_markdown_documentation: ::core::option::Option<bool>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1546,12 +1928,34 @@ pub struct OrgDetails {
     pub org_id: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub org_name: ::prost::alloc::string::String,
+    #[prost(string, optional, tag="3")]
+    pub org_cid: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="4")]
+    pub public_namespace: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListOrganizationsByUserResponse {
     #[prost(message, repeated, tag="1")]
     pub orgs: ::prost::alloc::vec::Vec<OrgDetails>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SearchOrganizationsRequest {
+    #[prost(string, optional, tag="1")]
+    pub org_id: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="2")]
+    pub org_name: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="3")]
+    pub cid: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag="4")]
+    pub public_namespace: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SearchOrganizationsResponse {
+    #[prost(message, repeated, tag="1")]
+    pub organizations: ::prost::alloc::vec::Vec<OrgDetails>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -1657,6 +2061,144 @@ pub struct CreateKeyFromExistingKeyAuthorizationsResponse {
     #[prost(string, tag="2")]
     pub key: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationSetLogoRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(bytes="vec", tag="2")]
+    pub logo: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationSetLogoResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationGetLogoRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OrganizationGetLogoResponse {
+    #[prost(string, tag="1")]
+    pub url: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnableAuthServiceRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct EnableAuthServiceResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DisableAuthServiceRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DisableAuthServiceResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOAuthAppRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub oauth_config: ::core::option::Option<OAuthConfig>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CreateOAuthAppResponse {
+    #[prost(string, tag="1")]
+    pub client_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_secret: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadOAuthAppRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ReadOAuthAppResponse {
+    #[prost(string, tag="1")]
+    pub client_name: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_secret: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="3")]
+    pub oauth_config: ::core::option::Option<OAuthConfig>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateOAuthAppRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_id: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub client_name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="4")]
+    pub oauth_config: ::core::option::Option<OAuthConfig>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UpdateOAuthAppResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteOAuthAppRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub client_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeleteOAuthAppResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListOAuthAppsRequest {
+    #[prost(string, tag="1")]
+    pub org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListOAuthAppsResponse {
+    #[prost(string, repeated, tag="1")]
+    pub client_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OAuthConfig {
+    #[prost(enumeration="ClientAuthentication", tag="1")]
+    pub client_authentication: i32,
+    #[prost(enumeration="Pkce", tag="2")]
+    pub pkce: i32,
+    #[prost(enumeration="UrlValidation", tag="3")]
+    pub url_validation: i32,
+    #[prost(string, repeated, tag="4")]
+    pub origin_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, repeated, tag="5")]
+    pub redirect_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, tag="6")]
+    pub logout_uri: ::prost::alloc::string::String,
+    #[prost(enumeration="EnabledGrant", repeated, tag="7")]
+    pub enabled_grants: ::prost::alloc::vec::Vec<i32>,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum AuthenticationType {
@@ -1726,6 +2268,41 @@ impl FragmentVisibility {
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
+pub enum FragmentErrorType {
+    Unspecified = 0,
+    NoAccess = 1,
+    NestingLimitExceeded = 2,
+    ChildIdInvalid = 3,
+    CycleDetected = 4,
+}
+impl FragmentErrorType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            FragmentErrorType::Unspecified => "FRAGMENT_ERROR_TYPE_UNSPECIFIED",
+            FragmentErrorType::NoAccess => "FRAGMENT_ERROR_TYPE_NO_ACCESS",
+            FragmentErrorType::NestingLimitExceeded => "FRAGMENT_ERROR_TYPE_NESTING_LIMIT_EXCEEDED",
+            FragmentErrorType::ChildIdInvalid => "FRAGMENT_ERROR_TYPE_CHILD_ID_INVALID",
+            FragmentErrorType::CycleDetected => "FRAGMENT_ERROR_TYPE_CYCLE_DETECTED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "FRAGMENT_ERROR_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "FRAGMENT_ERROR_TYPE_NO_ACCESS" => Some(Self::NoAccess),
+            "FRAGMENT_ERROR_TYPE_NESTING_LIMIT_EXCEEDED" => Some(Self::NestingLimitExceeded),
+            "FRAGMENT_ERROR_TYPE_CHILD_ID_INVALID" => Some(Self::ChildIdInvalid),
+            "FRAGMENT_ERROR_TYPE_CYCLE_DETECTED" => Some(Self::CycleDetected),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
 pub enum RegistryItemStatus {
     Unspecified = 0,
     Published = 1,
@@ -1757,10 +2334,12 @@ impl RegistryItemStatus {
 #[repr(i32)]
 pub enum Visibility {
     Unspecified = 0,
-    /// Private modules are visible only within your org
+    /// Private registry items are visible only within the owning org
     Private = 1,
-    /// Public modules are visible to everyone
+    /// Public registry items are visible to everyone
     Public = 2,
+    /// Public Unlisted registry items are usable in everyone's robot but are hidden from the registry page as if they are private
+    PublicUnlisted = 3,
 }
 impl Visibility {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -1772,6 +2351,7 @@ impl Visibility {
             Visibility::Unspecified => "VISIBILITY_UNSPECIFIED",
             Visibility::Private => "VISIBILITY_PRIVATE",
             Visibility::Public => "VISIBILITY_PUBLIC",
+            Visibility::PublicUnlisted => "VISIBILITY_PUBLIC_UNLISTED",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -1780,6 +2360,138 @@ impl Visibility {
             "VISIBILITY_UNSPECIFIED" => Some(Self::Unspecified),
             "VISIBILITY_PRIVATE" => Some(Self::Private),
             "VISIBILITY_PUBLIC" => Some(Self::Public),
+            "VISIBILITY_PUBLIC_UNLISTED" => Some(Self::PublicUnlisted),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ClientAuthentication {
+    Unspecified = 0,
+    Required = 1,
+    NotRequired = 2,
+    NotRequiredWhenUsingPkce = 3,
+}
+impl ClientAuthentication {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            ClientAuthentication::Unspecified => "CLIENT_AUTHENTICATION_UNSPECIFIED",
+            ClientAuthentication::Required => "CLIENT_AUTHENTICATION_REQUIRED",
+            ClientAuthentication::NotRequired => "CLIENT_AUTHENTICATION_NOT_REQUIRED",
+            ClientAuthentication::NotRequiredWhenUsingPkce => "CLIENT_AUTHENTICATION_NOT_REQUIRED_WHEN_USING_PKCE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CLIENT_AUTHENTICATION_UNSPECIFIED" => Some(Self::Unspecified),
+            "CLIENT_AUTHENTICATION_REQUIRED" => Some(Self::Required),
+            "CLIENT_AUTHENTICATION_NOT_REQUIRED" => Some(Self::NotRequired),
+            "CLIENT_AUTHENTICATION_NOT_REQUIRED_WHEN_USING_PKCE" => Some(Self::NotRequiredWhenUsingPkce),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Pkce {
+    Unspecified = 0,
+    Required = 1,
+    NotRequired = 2,
+    NotRequiredWhenUsingClientAuthentication = 3,
+}
+impl Pkce {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Pkce::Unspecified => "PKCE_UNSPECIFIED",
+            Pkce::Required => "PKCE_REQUIRED",
+            Pkce::NotRequired => "PKCE_NOT_REQUIRED",
+            Pkce::NotRequiredWhenUsingClientAuthentication => "PKCE_NOT_REQUIRED_WHEN_USING_CLIENT_AUTHENTICATION",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "PKCE_UNSPECIFIED" => Some(Self::Unspecified),
+            "PKCE_REQUIRED" => Some(Self::Required),
+            "PKCE_NOT_REQUIRED" => Some(Self::NotRequired),
+            "PKCE_NOT_REQUIRED_WHEN_USING_CLIENT_AUTHENTICATION" => Some(Self::NotRequiredWhenUsingClientAuthentication),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum UrlValidation {
+    Unspecified = 0,
+    ExactMatch = 1,
+    AllowWildcards = 2,
+}
+impl UrlValidation {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            UrlValidation::Unspecified => "URL_VALIDATION_UNSPECIFIED",
+            UrlValidation::ExactMatch => "URL_VALIDATION_EXACT_MATCH",
+            UrlValidation::AllowWildcards => "URL_VALIDATION_ALLOW_WILDCARDS",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "URL_VALIDATION_UNSPECIFIED" => Some(Self::Unspecified),
+            "URL_VALIDATION_EXACT_MATCH" => Some(Self::ExactMatch),
+            "URL_VALIDATION_ALLOW_WILDCARDS" => Some(Self::AllowWildcards),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum EnabledGrant {
+    Unspecified = 0,
+    AuthorizationCode = 1,
+    Implicit = 2,
+    Password = 3,
+    RefreshToken = 4,
+    DeviceCode = 5,
+}
+impl EnabledGrant {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            EnabledGrant::Unspecified => "ENABLED_GRANT_UNSPECIFIED",
+            EnabledGrant::AuthorizationCode => "ENABLED_GRANT_AUTHORIZATION_CODE",
+            EnabledGrant::Implicit => "ENABLED_GRANT_IMPLICIT",
+            EnabledGrant::Password => "ENABLED_GRANT_PASSWORD",
+            EnabledGrant::RefreshToken => "ENABLED_GRANT_REFRESH_TOKEN",
+            EnabledGrant::DeviceCode => "ENABLED_GRANT_DEVICE_CODE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "ENABLED_GRANT_UNSPECIFIED" => Some(Self::Unspecified),
+            "ENABLED_GRANT_AUTHORIZATION_CODE" => Some(Self::AuthorizationCode),
+            "ENABLED_GRANT_IMPLICIT" => Some(Self::Implicit),
+            "ENABLED_GRANT_PASSWORD" => Some(Self::Password),
+            "ENABLED_GRANT_REFRESH_TOKEN" => Some(Self::RefreshToken),
+            "ENABLED_GRANT_DEVICE_CODE" => Some(Self::DeviceCode),
             _ => None,
         }
     }
@@ -1802,42 +2514,6 @@ pub struct InvoiceSummary {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct BillableResourceEvent {
-    #[prost(string, tag="1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(string, tag="2")]
-    pub r#type: ::prost::alloc::string::String,
-    #[prost(double, tag="3")]
-    pub usage_quantity: f64,
-    #[prost(string, tag="4")]
-    pub usage_quantity_unit: ::prost::alloc::string::String,
-    #[prost(string, tag="5")]
-    pub usage_cost: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="6")]
-    pub occurred_at: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
-    #[prost(string, tag="7")]
-    pub user_name: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Invoice {
-    #[prost(string, tag="1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="2")]
-    pub invoice_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
-    #[prost(double, tag="3")]
-    pub invoice_amount: f64,
-    #[prost(string, tag="4")]
-    pub status: ::prost::alloc::string::String,
-    #[prost(message, optional, tag="5")]
-    pub due_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
-    #[prost(message, repeated, tag="6")]
-    pub items: ::prost::alloc::vec::Vec<BillableResourceEvent>,
-    #[prost(string, tag="7")]
-    pub emailed_to: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentMethodCard {
     #[prost(string, tag="1")]
     pub brand: ::prost::alloc::string::String,
@@ -1852,31 +2528,77 @@ pub struct GetCurrentMonthUsageRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UsageCost {
+    #[prost(enumeration="UsageCostType", tag="1")]
+    pub resource_type: i32,
+    #[prost(double, tag="2")]
+    pub cost: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResourceUsageCostsBySource {
+    #[prost(enumeration="SourceType", tag="1")]
+    pub source_type: i32,
+    #[prost(message, optional, tag="2")]
+    pub resource_usage_costs: ::core::option::Option<ResourceUsageCosts>,
+    #[prost(string, tag="3")]
+    pub tier_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ResourceUsageCosts {
+    #[prost(message, repeated, tag="1")]
+    pub usage_costs: ::prost::alloc::vec::Vec<UsageCost>,
+    #[prost(double, tag="2")]
+    pub discount: f64,
+    #[prost(double, tag="3")]
+    pub total_with_discount: f64,
+    #[prost(double, tag="4")]
+    pub total_without_discount: f64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetCurrentMonthUsageResponse {
     #[prost(message, optional, tag="1")]
     pub start_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
     #[prost(message, optional, tag="2")]
     pub end_date: ::core::option::Option<super::super::super::google::protobuf::Timestamp>,
+    #[prost(message, repeated, tag="14")]
+    pub resource_usage_costs_by_source: ::prost::alloc::vec::Vec<ResourceUsageCostsBySource>,
+    #[prost(double, tag="15")]
+    pub subtotal: f64,
+    /// all fields below are deprecated
+    #[deprecated]
     #[prost(double, tag="3")]
     pub cloud_storage_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="4")]
     pub data_upload_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="5")]
     pub data_egres_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="6")]
     pub remote_control_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="7")]
     pub standard_compute_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="8")]
     pub discount_amount: f64,
+    #[deprecated]
     #[prost(double, tag="9")]
     pub total_usage_with_discount: f64,
+    #[deprecated]
     #[prost(double, tag="10")]
     pub total_usage_without_discount: f64,
+    #[deprecated]
     #[prost(double, tag="11")]
     pub per_machine_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="12")]
     pub binary_data_cloud_storage_usage_cost: f64,
+    #[deprecated]
     #[prost(double, tag="13")]
     pub other_cloud_storage_usage_cost: f64,
 }
@@ -1930,6 +2652,18 @@ pub struct GetInvoicePdfResponse {
     #[prost(bytes="vec", tag="1")]
     pub chunk: ::prost::alloc::vec::Vec<u8>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SendPaymentRequiredEmailRequest {
+    #[prost(string, tag="1")]
+    pub customer_org_id: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub billing_owner_org_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SendPaymentRequiredEmailResponse {
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PaymentMethodType {
@@ -1952,6 +2686,127 @@ impl PaymentMethodType {
         match value {
             "PAYMENT_METHOD_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
             "PAYMENT_METHOD_TYPE_CARD" => Some(Self::Card),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum UsageCostType {
+    Unspecified = 0,
+    DataUpload = 1,
+    DataEgress = 2,
+    RemoteControl = 3,
+    StandardCompute = 4,
+    CloudStorage = 5,
+    BinaryDataCloudStorage = 6,
+    OtherCloudStorage = 7,
+    PerMachine = 8,
+    TriggerNotification = 9,
+    TabularDataCloudStorage = 10,
+    ConfigHistoryCloudStorage = 11,
+    LogsCloudStorage = 12,
+    TrainingLogsCloudStorage = 13,
+    PackagesCloudStorage = 14,
+    BinaryDataUpload = 15,
+    TabularDataUpload = 16,
+    LogsUpload = 17,
+    BinaryDataEgress = 18,
+    TabularDataEgress = 19,
+    LogsEgress = 20,
+    TrainingLogsEgress = 21,
+    TabularDataDatabaseCloudStorage = 22,
+    TabularDataDatabaseCompute = 23,
+}
+impl UsageCostType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            UsageCostType::Unspecified => "USAGE_COST_TYPE_UNSPECIFIED",
+            UsageCostType::DataUpload => "USAGE_COST_TYPE_DATA_UPLOAD",
+            UsageCostType::DataEgress => "USAGE_COST_TYPE_DATA_EGRESS",
+            UsageCostType::RemoteControl => "USAGE_COST_TYPE_REMOTE_CONTROL",
+            UsageCostType::StandardCompute => "USAGE_COST_TYPE_STANDARD_COMPUTE",
+            UsageCostType::CloudStorage => "USAGE_COST_TYPE_CLOUD_STORAGE",
+            UsageCostType::BinaryDataCloudStorage => "USAGE_COST_TYPE_BINARY_DATA_CLOUD_STORAGE",
+            UsageCostType::OtherCloudStorage => "USAGE_COST_TYPE_OTHER_CLOUD_STORAGE",
+            UsageCostType::PerMachine => "USAGE_COST_TYPE_PER_MACHINE",
+            UsageCostType::TriggerNotification => "USAGE_COST_TYPE_TRIGGER_NOTIFICATION",
+            UsageCostType::TabularDataCloudStorage => "USAGE_COST_TYPE_TABULAR_DATA_CLOUD_STORAGE",
+            UsageCostType::ConfigHistoryCloudStorage => "USAGE_COST_TYPE_CONFIG_HISTORY_CLOUD_STORAGE",
+            UsageCostType::LogsCloudStorage => "USAGE_COST_TYPE_LOGS_CLOUD_STORAGE",
+            UsageCostType::TrainingLogsCloudStorage => "USAGE_COST_TYPE_TRAINING_LOGS_CLOUD_STORAGE",
+            UsageCostType::PackagesCloudStorage => "USAGE_COST_TYPE_PACKAGES_CLOUD_STORAGE",
+            UsageCostType::BinaryDataUpload => "USAGE_COST_TYPE_BINARY_DATA_UPLOAD",
+            UsageCostType::TabularDataUpload => "USAGE_COST_TYPE_TABULAR_DATA_UPLOAD",
+            UsageCostType::LogsUpload => "USAGE_COST_TYPE_LOGS_UPLOAD",
+            UsageCostType::BinaryDataEgress => "USAGE_COST_TYPE_BINARY_DATA_EGRESS",
+            UsageCostType::TabularDataEgress => "USAGE_COST_TYPE_TABULAR_DATA_EGRESS",
+            UsageCostType::LogsEgress => "USAGE_COST_TYPE_LOGS_EGRESS",
+            UsageCostType::TrainingLogsEgress => "USAGE_COST_TYPE_TRAINING_LOGS_EGRESS",
+            UsageCostType::TabularDataDatabaseCloudStorage => "USAGE_COST_TYPE_TABULAR_DATA_DATABASE_CLOUD_STORAGE",
+            UsageCostType::TabularDataDatabaseCompute => "USAGE_COST_TYPE_TABULAR_DATA_DATABASE_COMPUTE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "USAGE_COST_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "USAGE_COST_TYPE_DATA_UPLOAD" => Some(Self::DataUpload),
+            "USAGE_COST_TYPE_DATA_EGRESS" => Some(Self::DataEgress),
+            "USAGE_COST_TYPE_REMOTE_CONTROL" => Some(Self::RemoteControl),
+            "USAGE_COST_TYPE_STANDARD_COMPUTE" => Some(Self::StandardCompute),
+            "USAGE_COST_TYPE_CLOUD_STORAGE" => Some(Self::CloudStorage),
+            "USAGE_COST_TYPE_BINARY_DATA_CLOUD_STORAGE" => Some(Self::BinaryDataCloudStorage),
+            "USAGE_COST_TYPE_OTHER_CLOUD_STORAGE" => Some(Self::OtherCloudStorage),
+            "USAGE_COST_TYPE_PER_MACHINE" => Some(Self::PerMachine),
+            "USAGE_COST_TYPE_TRIGGER_NOTIFICATION" => Some(Self::TriggerNotification),
+            "USAGE_COST_TYPE_TABULAR_DATA_CLOUD_STORAGE" => Some(Self::TabularDataCloudStorage),
+            "USAGE_COST_TYPE_CONFIG_HISTORY_CLOUD_STORAGE" => Some(Self::ConfigHistoryCloudStorage),
+            "USAGE_COST_TYPE_LOGS_CLOUD_STORAGE" => Some(Self::LogsCloudStorage),
+            "USAGE_COST_TYPE_TRAINING_LOGS_CLOUD_STORAGE" => Some(Self::TrainingLogsCloudStorage),
+            "USAGE_COST_TYPE_PACKAGES_CLOUD_STORAGE" => Some(Self::PackagesCloudStorage),
+            "USAGE_COST_TYPE_BINARY_DATA_UPLOAD" => Some(Self::BinaryDataUpload),
+            "USAGE_COST_TYPE_TABULAR_DATA_UPLOAD" => Some(Self::TabularDataUpload),
+            "USAGE_COST_TYPE_LOGS_UPLOAD" => Some(Self::LogsUpload),
+            "USAGE_COST_TYPE_BINARY_DATA_EGRESS" => Some(Self::BinaryDataEgress),
+            "USAGE_COST_TYPE_TABULAR_DATA_EGRESS" => Some(Self::TabularDataEgress),
+            "USAGE_COST_TYPE_LOGS_EGRESS" => Some(Self::LogsEgress),
+            "USAGE_COST_TYPE_TRAINING_LOGS_EGRESS" => Some(Self::TrainingLogsEgress),
+            "USAGE_COST_TYPE_TABULAR_DATA_DATABASE_CLOUD_STORAGE" => Some(Self::TabularDataDatabaseCloudStorage),
+            "USAGE_COST_TYPE_TABULAR_DATA_DATABASE_COMPUTE" => Some(Self::TabularDataDatabaseCompute),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SourceType {
+    Unspecified = 0,
+    Org = 1,
+    Fragment = 2,
+}
+impl SourceType {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SourceType::Unspecified => "SOURCE_TYPE_UNSPECIFIED",
+            SourceType::Org => "SOURCE_TYPE_ORG",
+            SourceType::Fragment => "SOURCE_TYPE_FRAGMENT",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SOURCE_TYPE_UNSPECIFIED" => Some(Self::Unspecified),
+            "SOURCE_TYPE_ORG" => Some(Self::Org),
+            "SOURCE_TYPE_FRAGMENT" => Some(Self::Fragment),
             _ => None,
         }
     }
@@ -2083,6 +2938,12 @@ pub struct RobotConfig {
     /// Attributes a particular revision to the config.
     #[prost(string, tag="15")]
     pub revision: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="16")]
+    pub maintenance: ::core::option::Option<MaintenanceConfig>,
+    /// Disables the robot's log deduplication (identical, noisy logs will still
+    /// be output individually instead of aggregated.)
+    #[prost(bool, tag="17")]
+    pub disable_log_deduplication: bool,
 }
 /// LogPatternConfig allows you to specify a 2-tuple consisting
 /// of a logger name and its corresponding log level.
@@ -2202,6 +3063,8 @@ pub struct ProcessConfig {
     /// additional environment variables passed to the process
     #[prost(map="string, string", tag="9")]
     pub env: ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
+    #[prost(string, tag="10")]
+    pub username: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2489,6 +3352,9 @@ pub struct AgentInfo {
     /// The platform the RDK is running on. For example linux/amd64
     #[prost(string, optional, tag="6")]
     pub platform: ::core::option::Option<::prost::alloc::string::String>,
+    /// Optional tags to further constrain which artifact is returned for modules.
+    #[prost(string, repeated, tag="7")]
+    pub platform_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -2579,6 +3445,9 @@ pub struct ModuleConfig {
     /// info about the validity of the module
     #[prost(message, optional, tag="7")]
     pub status: ::core::option::Option<AppValidationStatus>,
+    /// timeout for first_run script
+    #[prost(message, optional, tag="8")]
+    pub first_run_timeout: ::core::option::Option<super::super::super::google::protobuf::Duration>,
 }
 /// PackageConfig is the configration for deployed Packages.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -2599,6 +3468,14 @@ pub struct PackageConfig {
     /// info about the validity of the package
     #[prost(message, optional, tag="5")]
     pub status: ::core::option::Option<AppValidationStatus>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MaintenanceConfig {
+    #[prost(message, optional, tag="1")]
+    pub sensor_name: ::core::option::Option<super::super::common::v1::ResourceName>,
+    #[prost(string, tag="2")]
+    pub maintenance_allowed_key: ::prost::alloc::string::String,
 }
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]

--- a/micro-rdk/src/gen/viam.common.v1.rs
+++ b/micro-rdk/src/gen/viam.common.v1.rs
@@ -11,6 +11,10 @@ pub struct ResourceName {
     pub subtype: ::prost::alloc::string::String,
     #[prost(string, tag="4")]
     pub name: ::prost::alloc::string::String,
+    #[prost(string, repeated, tag="5")]
+    pub remote_path: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, tag="6")]
+    pub local_name: ::prost::alloc::string::String,
 }
 /// Pose is a combination of location and orientation.
 /// Location is expressed as distance which is represented by x , y, z coordinates. Orientation is expressed as an orientation vector which

--- a/micro-rdk/src/gen/viam.component.arm.v1.rs
+++ b/micro-rdk/src/gen/viam.component.arm.v1.rs
@@ -21,8 +21,7 @@ pub struct GetEndPositionResponse {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct JointPositions {
     /// A list of joint positions. Rotations values are in degrees, translational values in mm.
-    /// The numbers are ordered spatially from the base toward the end effector
-    /// This is used in GetJointPositionsResponse and MoveToJointPositionsRequest
+    /// There should be 1 entry in the list per joint DOF, ordered spatially from the base toward the end effector of the arm
     #[prost(double, repeated, tag="1")]
     pub values: ::prost::alloc::vec::Vec<f64>,
 }
@@ -83,6 +82,26 @@ pub struct MoveToJointPositionsResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MoveThroughJointPositionsRequest {
+    /// Name of an arm
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// A list of joint positions which will be moved to in the order they are specified
+    #[prost(message, repeated, tag="2")]
+    pub positions: ::prost::alloc::vec::Vec<JointPositions>,
+    /// optional specifications to be obeyed during the motion
+    #[prost(message, optional, tag="3")]
+    pub options: ::core::option::Option<MoveOptions>,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MoveThroughJointPositionsResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StopRequest {
     /// Name of an arm
     #[prost(string, tag="1")]
@@ -116,5 +135,15 @@ pub struct IsMovingRequest {
 pub struct IsMovingResponse {
     #[prost(bool, tag="1")]
     pub is_moving: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct MoveOptions {
+    /// Maximum allowable velocity of an arm joint, in degrees per second
+    #[prost(double, optional, tag="1")]
+    pub max_vel_degs_per_sec: ::core::option::Option<f64>,
+    /// Maximum allowable acceleration of an arm joint, in degrees per second squared
+    #[prost(double, optional, tag="2")]
+    pub max_acc_degs_per_sec2: ::core::option::Option<f64>,
 }
 // @@protoc_insertion_point(module)

--- a/micro-rdk/src/gen/viam.component.button.v1.rs
+++ b/micro-rdk/src/gen/viam.component.button.v1.rs
@@ -1,0 +1,14 @@
+// @generated
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PushRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct PushResponse {
+}
+// @@protoc_insertion_point(module)

--- a/micro-rdk/src/gen/viam.component.camera.v1.rs
+++ b/micro-rdk/src/gen/viam.component.camera.v1.rs
@@ -114,6 +114,9 @@ pub struct GetPropertiesResponse {
     /// Supported MIME types by the camera
     #[prost(string, repeated, tag="4")]
     pub mime_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// Optional camera frame rate for image capture timing
+    #[prost(float, optional, tag="5")]
+    pub frame_rate: ::core::option::Option<f32>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/micro-rdk/src/gen/viam.component.switch.v1.rs
+++ b/micro-rdk/src/gen/viam.component.switch.v1.rs
@@ -1,0 +1,44 @@
+// @generated
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPositionRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(uint32, tag="2")]
+    pub position: u32,
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SetPositionResponse {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPositionRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetPositionResponse {
+    #[prost(uint32, tag="1")]
+    pub position: u32,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetNumberOfPositionsRequest {
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetNumberOfPositionsResponse {
+    #[prost(uint32, tag="1")]
+    pub number_of_positions: u32,
+}
+// @@protoc_insertion_point(module)

--- a/micro-rdk/src/gen/viam.robot.v1.rs
+++ b/micro-rdk/src/gen/viam.robot.v1.rs
@@ -1,8 +1,22 @@
 // @generated
-/// this is an experimental API message
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TunnelRequest {
+    #[prost(uint32, tag="1")]
+    pub destination_port: u32,
+    #[prost(bytes="vec", tag="2")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TunnelResponse {
+    #[prost(bytes="vec", tag="1")]
+    pub data: ::prost::alloc::vec::Vec<u8>,
+}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FrameSystemConfig {
+    /// this is an experimental API message
     #[prost(message, optional, tag="1")]
     pub frame: ::core::option::Option<super::super::common::v1::Transform>,
     #[prost(message, optional, tag="2")]
@@ -167,6 +181,7 @@ pub struct GetSessionsResponse {
     pub sessions: ::prost::alloc::vec::Vec<Session>,
 }
 // Discovery
+// Discovery is deprecated
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -175,6 +190,8 @@ pub struct DiscoveryQuery {
     pub subtype: ::prost::alloc::string::String,
     #[prost(string, tag="2")]
     pub model: ::prost::alloc::string::String,
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::google::protobuf::Struct>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -183,6 +200,28 @@ pub struct Discovery {
     pub query: ::core::option::Option<DiscoveryQuery>,
     #[prost(message, optional, tag="2")]
     pub results: ::core::option::Option<super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ModuleModel {
+    #[prost(string, tag="1")]
+    pub module_name: ::prost::alloc::string::String,
+    #[prost(string, tag="2")]
+    pub model: ::prost::alloc::string::String,
+    #[prost(string, tag="3")]
+    pub api: ::prost::alloc::string::String,
+    #[prost(bool, tag="4")]
+    pub from_local_module: bool,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetModelsFromModulesRequest {
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetModelsFromModulesResponse {
+    #[prost(message, repeated, tag="1")]
+    pub models: ::prost::alloc::vec::Vec<ModuleModel>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -348,6 +387,43 @@ pub struct GetMachineStatusResponse {
     pub resources: ::prost::alloc::vec::Vec<ResourceStatus>,
     #[prost(message, optional, tag="2")]
     pub config: ::core::option::Option<ConfigStatus>,
+    #[prost(enumeration="get_machine_status_response::State", tag="3")]
+    pub state: i32,
+}
+/// Nested message and enum types in `GetMachineStatusResponse`.
+pub mod get_machine_status_response {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum State {
+        Unspecified = 0,
+        /// the machine is reachable but still in the process of configuring initial
+        /// modules and resources.
+        Initializing = 1,
+        /// the machine has finished initializing.
+        Running = 2,
+    }
+    impl State {
+        /// String value of the enum field names used in the ProtoBuf definition.
+        ///
+        /// The values are not transformed in any way and thus are considered stable
+        /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+        pub fn as_str_name(&self) -> &'static str {
+            match self {
+                State::Unspecified => "STATE_UNSPECIFIED",
+                State::Initializing => "STATE_INITIALIZING",
+                State::Running => "STATE_RUNNING",
+            }
+        }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "STATE_UNSPECIFIED" => Some(Self::Unspecified),
+                "STATE_INITIALIZING" => Some(Self::Initializing),
+                "STATE_RUNNING" => Some(Self::Running),
+                _ => None,
+            }
+        }
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -368,6 +444,9 @@ pub struct ResourceStatus {
     /// resource is ready and non-null if the resource unhealthy.
     #[prost(string, tag="5")]
     pub error: ::prost::alloc::string::String,
+    /// infomation about resource orgID, locationID and partID
+    #[prost(message, optional, tag="6")]
+    pub cloud_metadata: ::core::option::Option<GetCloudMetadataResponse>,
 }
 /// Nested message and enum types in `ResourceStatus`.
 pub mod resource_status {

--- a/micro-rdk/src/gen/viam.service.discovery.v1.rs
+++ b/micro-rdk/src/gen/viam.service.discovery.v1.rs
@@ -1,0 +1,19 @@
+// @generated
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverResourcesRequest {
+    /// name of the discover service
+    #[prost(string, tag="1")]
+    pub name: ::prost::alloc::string::String,
+    /// Additional arguments to the method
+    #[prost(message, optional, tag="99")]
+    pub extra: ::core::option::Option<super::super::super::super::google::protobuf::Struct>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscoverResourcesResponse {
+    /// list of ComponentConfigs that describe the components found by a discover service.
+    #[prost(message, repeated, tag="1")]
+    pub discoveries: ::prost::alloc::vec::Vec<super::super::super::app::v1::ComponentConfig>,
+}
+// @@protoc_insertion_point(module)

--- a/micro-rdk/src/lib.rs
+++ b/micro-rdk/src/lib.rs
@@ -90,6 +90,14 @@ pub mod proto {
                 include!("gen/viam.app.mltraining.v1.rs");
             }
         }
+
+        // responsible to proto dependency, same issue as above
+        #[cfg(feature = "data")]
+        pub mod data {
+            pub mod v1 {
+                include!("gen/viam.app.data.v1.rs");
+            }
+        }
     }
 
     pub mod rpc {


### PR DESCRIPTION
Viam AgentConfig apis were updated recently that adds new convenience wrappers (`[get/set/has]NetworkConfiguration`) for downstream work (multiple wifi support). It's not a blocker, but a nice to have since I'm already doing work with the agent config and we haven't updated protos recently.

~*DO NOT MERGE*:  changes in commit 25d3d29efc494e60c0a2fea483f877b49e3c9d27 (changes in micro-rdk) use dummy variables, this is just for verifying changes to compile properly. If we want the new protos but want to dive deep into getting the individual fields to be what they should right now, we can add tickets to put correct values.~

Values updated. 
- `local_name` refers to the name that a host sees a resource as (ex. the module's binary's name)
- `remote_path` refers to an array of remote machine names needed to be traveresd to get to where the module is ran (ex. `[remote1:remote2]` if the resource was two remotes deep/away)
- `mime_type` was added for camera metadata, not useful for us until we add cameras to the data collector
- `annotations` was also added for cameras, additional bounding box info 