### PR TITLE
[RSDK-10067] - add release action workflow to project template

### DIFF
--- a/templates/project/.github/workflows/publish.yml
+++ b/templates/project/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-project:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
+    steps:
+    - name : Checkout main branch code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: Build esp32 OTA binary
+      run: |
+        bash -c '. /home/testbot/.bash_profile ; git config --global --add safe.directory "$ESP_ROOT"/esp-idf && make build-esp32-ota'
+        cp target/xtensa-esp32-espidf/project-ota.bin project-ota.bin
+    - name: Upload release Lib
+      uses: actions/upload-artifact@v4
+      with:
+        name: ota-binary
+        path: |
+          project-ota.bin
+
+  publish-release:
+    needs: [build-project]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check release type
+      id: check-tag
+      run: |
+        if echo ${{ github.event.ref }} | grep -Eq '^refs/tags/v.*rc[0-9]{1}$'; then
+              echo "match=true" >> $GITHUB_OUTPUT
+        else
+              echo "match=false" >> $GITHUB_OUTPUT
+        fi
+    - name: Download OTA binary
+      uses: actions/download-artifact@v4
+      with:
+        name: ota-binary
+    - name: Compute checksums
+      run: |
+        sha256sum  project-ota.bin  >> sha256sums.txt
+    - name: Publish release
+      uses: ncipollo/release-action@v1
+      if: github.event_name == 'push'
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: |
+          project-ota.bin
+          sha256sums.txt
+        prerelease: ${{ steps.check-tag.outputs.match }}
+        replacesArtifacts: true
+        allowUpdates: true
+        name: ${{ github.ref_name }}

--- a/templates/project/Makefile
+++ b/templates/project/Makefile
@@ -10,6 +10,15 @@ upload:
 build-esp32-bin:
 	cargo espflash save-image --merge --chip esp32 target/xtensa-esp32-espidf/release/{{project-name}}.bin --partition-table partitions.csv -s 8mb  --release
 
+build-esp32-ota:
+	cargo +esp espflash save-image \
+		--skip-update-check \
+		--chip=esp32 \
+		--partition-table=partitions.csv \
+		--target=xtensa-esp32-espidf \
+		-Zbuild-std=std,panic_abort --release \
+		target/xtensa-esp32-espidf/project-ota.bin
+
 flash-esp32-bin:
 ifneq (,$(wildcard target/xtensa-esp32-espidf/release/{{project-name}}))
 	espflash flash --erase-parts nvs --partition-table partitions.csv  target/xtensa-esp32-espidf/release/{{project-name}} --baud 460800 -s 8mb && sleep 2 && espflash monitor


### PR DESCRIPTION
This will significantly reduce the friction for those developing firmware using the project template that want to make use of OTA by preparing a compiled binary as a release asset whenever a new version tag is pushed to the project. In theory, the download link to the release asset can be used in the configuration of the OTA service for a machine hosting the firmware.

However, this download link will only work when we have fixed the OTA service to properly handle redirects from the link location of the binary (likely to be addressed by [RSDK-10054](https://viam.atlassian.net/browse/RSDK-10054)).

[RSDK-10054]: https://viam.atlassian.net/browse/RSDK-10054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ