### PR TITLE
ESP32 Makefile template enhancements

### DIFF
--- a/templates/project/Makefile
+++ b/templates/project/Makefile
@@ -1,14 +1,45 @@
 .PHONY: build
 
+# Older ESP32 devices might only have 4mb of flash and slower
+FLASHSIZE:=8mb
+BAUDRATE:=460800
+
+clean:
+	cargo clean
+
 build:
 	cargo build --release
 
 upload:
-	cargo espflash flash --erase-parts nvs --monitor --partition-table partitions.csv --baud 460800 -f 80mhz --release $(ESPFLASH_FLASH_ARGS)
+	cargo espflash flash \
+		--erase-parts nvs \
+		--monitor \
+		--partition-table partitions.csv \
+		--baud ${BAUDRATE} \
+		--flash-freq 80mhz \
+		--release $(ESPFLASH_FLASH_ARGS)
 
+monitor:
+	espflash monitor --baud ${BAUDRATE}
+
+info:
+	cargo espflash board-info --baud ${BAUDRATE}
+
+erase:
+	cargo espflash erase-flash --baud ${BAUDRATE}
+
+list-partitions:
+	cargo espflash partition-table partitions.csv
 
 build-esp32-bin:
-	cargo espflash save-image --merge --chip esp32 target/xtensa-esp32-espidf/release/{{project-name}}.bin --partition-table partitions.csv -s 8mb  --release
+	cargo espflash save-image \
+		--merge \
+		--chip esp32 \
+		--partition-table partitions.csv \
+		--target xtensa-esp32-espidf \
+		--flash-size ${FLASHSIZE} \
+		--release \
+		target/xtensa-esp32-espidf/release/{{project-name}}.bin
 
 build-esp32-ota:
 	cargo +esp espflash save-image \
@@ -16,12 +47,18 @@ build-esp32-ota:
 		--chip=esp32 \
 		--partition-table=partitions.csv \
 		--target=xtensa-esp32-espidf \
-		-Zbuild-std=std,panic_abort --release \
+		-Zbuild-std=std,panic_abort \
+		--release \
 		target/xtensa-esp32-espidf/project-ota.bin
 
 flash-esp32-bin:
 ifneq (,$(wildcard target/xtensa-esp32-espidf/release/{{project-name}}))
-	espflash flash --erase-parts nvs --partition-table partitions.csv  target/xtensa-esp32-espidf/release/{{project-name}} --baud 460800 -s 8mb && sleep 2 && espflash monitor
+	espflash flash \
+		--erase-parts nvs \
+		--partition-table partitions.csv \
+		--flash-size ${FLASHSIZE} \
+		--baud ${BAUDRATE} \
+		target/xtensa-esp32-espidf/release/{{project-name}} && sleep 2 && espflash monitor --baud ${BAUDRATE}
 else
 	$(error target/xtensa-esp32-espidf/release/{{project-name}} not found, run build-esp32-bin first)
 endif


### PR DESCRIPTION
I have an older esp32-cam MCU board revision that only has 4mb of Flash and I had to reduce the baudrate from 460800 to 115200.  I was able to get the Rust based Viam Micro-RDK working on my ESP32-CAM and connected to the Viam Dashboard.

Along the journey, I improved the readability and customized the Makefile a bit.   I thought these enhancements might make the template easier to understand.

I removed the OTA partitions from my partitions.csv to fit in 4mb  but that's not worthy of a PR.