### PR TITLE
RSDK-10268 Pin docker image in gh actions

### DIFF
--- a/.canon.yaml
+++ b/.canon.yaml
@@ -1,6 +1,6 @@
 viam-micro-rdk:
-    image_amd64: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
-    image_arm64: ghcr.io/viamrobotics/micro-rdk-dev-env:arm64
+    image_amd64: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
+    image_arm64: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-arm64
     minimum_date: 2023-03-06T00:15:26.271839721-05:00
     update_interval: 168h0m0s
     user: testbot

--- a/.github/workflows/esp32.yml
+++ b/.github/workflows/esp32.yml
@@ -18,7 +18,7 @@ jobs:
     name: "Build, clippy and test for esp32"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
     steps:
     - name : Checkout main branch code
       if: github.event_name != 'pull_request_target'

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -12,7 +12,7 @@ jobs:
     name: Audit 3rd-Party Licenses
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -74,7 +74,7 @@ jobs:
   build-installer-arm64-linux:
     runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
     container:
-      image: ghcr.io/viamrobotics/micro-rdk-dev-env:arm64
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-arm64
     needs: tests
     defaults:
       run:
@@ -106,7 +106,7 @@ jobs:
   build-micro-RDK:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
     needs: tests
     steps:
     - name : Checkout main branch code

--- a/templates/project/.canon.yaml
+++ b/templates/project/.canon.yaml
@@ -1,6 +1,6 @@
 viam-micro-rdk:
-    image_amd64: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
-    image_arm64: ghcr.io/viamrobotics/micro-rdk-dev-env:arm64
+    image_amd64: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
+    image_arm64: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83-0-arm64
     minimum_date: 2023-03-06T00:15:26.271839721-05:00
     update_interval: 168h0m0s
     user: testbot

--- a/templates/project/.github/workflows/publish.yml
+++ b/templates/project/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
   build-project:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/viamrobotics/micro-rdk-dev-env:amd64
+      image: ghcr.io/viamrobotics/micro-rdk-dev-env:1.83.0-amd64
     steps:
     - name : Checkout main branch code
       uses: actions/checkout@v3


### PR DESCRIPTION
This way, I can do another PR to update the docker image as I need and push it without it taking immediate effect, and then make another PR to upgrade to that new docker image along with any associated changes in the action definitions. Right now I can't do that.

Also valuable so we can re-run actions from old commits, and lookup what docker image was used to build a given commit, should we ever need to do that archaeology.

This does mean we will need to (remember to) not overwrite tags when pushing docker images, but at least now we can meaningfully do that. I intend to push the next docker images as `1.83.0-1-a{rm,md}64`