### PR TITLE
[RSDK-10281] Fix deprecation warnings in project template

### DIFF
--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -82,12 +82,14 @@ mod esp32 {
         // it will try to load statically compiled values.
 
         if !storage.has_default_network() {
+            log::warn!("no default network settings found in storage");
+
             // check if any were statically compiled
             if SSID.is_some() && PASS.is_some() {
-                log::info!("storing static values from build time wifi configuration to storage");
+                log::info!("storing static values from build time network settings to storage as default");
                 storage
                     .store_default_network(SSID.unwrap(), PASS.unwrap())
-                    .expect("Failed to store WiFi credentials to NVS");
+                    .expect("failed to store network settings to storage");
             }
         }
 

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -86,7 +86,9 @@ mod esp32 {
 
             // check if any were statically compiled
             if SSID.is_some() && PASS.is_some() {
-                log::info!("storing static values from build time network settings to storage as default");
+                log::info!(
+                    "storing static values from build time network settings to storage as default"
+                );
                 storage
                     .store_default_network(SSID.unwrap(), PASS.unwrap())
                     .expect("failed to store network settings to storage");

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -9,9 +9,7 @@ use std::rc::Rc;
 use micro_rdk::{
     common::{
         conn::{server::WebRtcConfiguration, viam::ViamServerBuilder},
-        credentials_storage::{
-            RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage,
-        },
+        credentials_storage::{RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage},
         exec::Executor,
         log::initialize_logger,
         provisioning::server::ProvisioningInfo,
@@ -74,12 +72,11 @@ fn main() {
 
         // check if any were statically compiled
         if SSID.is_some() && PASS.is_some() {
-            log::info!("storing static values from build time network settings to storage as default");
+            log::info!(
+                "storing static values from build time network settings to storage as default"
+            );
             storage
-                .store_default_network(
-                    SSID.unwrap(),
-                    PASS.unwrap(),
-                )
+                .store_default_network(SSID.unwrap(), PASS.unwrap())
                 .expect("failed to store network settings to storage");
         }
     }

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -10,7 +10,7 @@ use micro_rdk::{
     common::{
         conn::{server::WebRtcConfiguration, viam::ViamServerBuilder},
         credentials_storage::{
-            RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage, WifiCredentials,
+            RobotConfigurationStorage, RobotCredentials, WifiCredentialStorage,
         },
         exec::Executor,
         log::initialize_logger,
@@ -69,18 +69,18 @@ fn main() {
     // At runtime, if the program does not detect credentials or configs in storage,
     // it will try to load statically compiled values.
 
-    if !storage.has_wifi_credentials() {
-        log::warn!("no wifi credentials were found in storage");
+    if !storage.has_default_network() {
+        log::warn!("no default network settings found in storage");
 
         // check if any were statically compiled
         if SSID.is_some() && PASS.is_some() {
-            log::info!("storing static values from build time wifi configuration to storage");
+            log::info!("storing static values from build time network settings to storage as default");
             storage
-                .store_wifi_credentials(&WifiCredentials::new(
-                    SSID.unwrap().to_string(),
-                    PASS.unwrap().to_string(),
-                ))
-                .expect("failed to store WiFi credentials to storage");
+                .store_default_network(
+                    SSID.unwrap(),
+                    PASS.unwrap(),
+                )
+                .expect("failed to store network settings to storage");
         }
     }
 


### PR DESCRIPTION
Also, cleanup logging terminology and harmonize between viam-micro-server and template projects.