### PR TITLE
[RSDK-9841] Use COMPONENT_VERSION in FFI component with ESP-IDF 5

### DIFF
--- a/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
+++ b/micro-rdk-ffi/micrordklib-idf-component/CMakeLists.txt
@@ -1,15 +1,14 @@
 idf_component_register(INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}")
 idf_build_set_property(INCLUDE_DIRECTORIES "${CMAKE_CURRENT_BINARY_DIR}/assets" APPEND)
 
-set(LIBMICRORDK_VERSION v0.4.1-rc10)
-set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${LIBMICRORDK_VERSION}/micro-rdk-lib.zip)
+set(LIBMICRORDK_URL https://github.com/viamrobotics/micro-rdk/releases/download/${COMPONENT_VERSION}/micro-rdk-lib.zip)
 set(LIBMICRORDK_PATH ${CMAKE_BINARY_DIR}/import/micro-rdk-lib.zip)
 
 if((NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/libmicrordk.a") OR(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h" AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/micrordk.h"))
   file(DOWNLOAD ${LIBMICRORDK_URL} ${LIBMICRORDK_PATH} STATUS LIBMICRORDK_DOWNLOAD_STATUS)
   list(GET LIBMICRORDK_DOWNLOAD_STATUS 0 LIBMICRORDK_DOWNLOAD_STATUS_NO)
   if(LIBMICRORDK_DOWNLOAD_STATUS_NO)
-    message( FATAL_ERROR "Cannot download Micro-RDK ${LIBMICRORDK_VERSION} check if the version is valid" )
+    message(FATAL_ERROR "Cannot download Micro-RDK ${COMPONENT_VERSION} check if the version in idf_component.yml is valid")
   else()
     add_prebuilt_library(micro_rdk_ffi
       "${CMAKE_CURRENT_BINARY_DIR}/assets/libmicrordk.a"


### PR DESCRIPTION
We tried to do this here https://github.com/viamrobotics/micro-rdk/commit/0ccc9fc29133b1baa5b96651d98226f39240ee2d#diff-ed1421c19afa77da895d13381af64b9e0d604a7deda389355470f832609962d7L4 but we couldn't yet because `COMPONENT_VERSION` doesn't exist before ESP-IDF 5.

This just gets rid of one more touchpoint for updating versions during release.

I don't plan to merge this until we have a working ESP-IDF 5 compile so I can test it out, but I had it in my tree waiting, so it seemed worth getting it up for review.