### PR TITLE
fix linting errors, rm ota from native

### DIFF
--- a/micro-rdk-server/Cargo.toml
+++ b/micro-rdk-server/Cargo.toml
@@ -18,7 +18,7 @@ ota = ["micro-rdk/ota"]
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
 env_logger.workspace = true
 local-ip-address.workspace = true
-micro-rdk = { workspace = true, features = ["native"], default-features = true }
+micro-rdk = { workspace = true, features = ["native", "builtin-components", "data", "local-signaling"], default-features = false }
 
 
 [target.'cfg(target_os="espidf")'.dependencies]

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -71,7 +71,7 @@ where
         app_client: &'c AppClient,
     ) -> Pin<Box<dyn Future<Output = Result<Option<Duration>, AppClientError>> + 'c>> {
         Box::pin(async move {
-            #[allow(unused_mut)] // for native
+            #[cfg(feature="esp32")]
             let mut reboot = false;
             let (new_config, _cfg_received_datetime) = app_client
                 .get_app_config(None)
@@ -150,6 +150,7 @@ where
                 }
             }
 
+            #[cfg(feature="esp32")]
             if reboot {
                 log::info!("rebooting from config monitor...");
                 // TODO(RSDK-9464): flush logs to app.viam before restarting

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -150,7 +150,6 @@ where
                 }
             }
 
-            #[cfg(feature="esp32")]
             if reboot {
                 log::info!("rebooting from config monitor...");
                 // TODO(RSDK-9464): flush logs to app.viam before restarting

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -71,6 +71,7 @@ where
         app_client: &'c AppClient,
     ) -> Pin<Box<dyn Future<Output = Result<Option<Duration>, AppClientError>> + 'c>> {
         Box::pin(async move {
+            #[allow(unused_mut)] // for native
             let mut reboot = false;
             let (new_config, _cfg_received_datetime) = app_client
                 .get_app_config(None)

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -150,6 +150,7 @@ where
                 }
             }
 
+            #[cfg(feature="esp32")]
             if reboot {
                 log::info!("rebooting from config monitor...");
                 // TODO(RSDK-9464): flush logs to app.viam before restarting

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -71,7 +71,7 @@ where
         app_client: &'c AppClient,
     ) -> Pin<Box<dyn Future<Output = Result<Option<Duration>, AppClientError>> + 'c>> {
         Box::pin(async move {
-            #[cfg(feature="esp32")]
+            #[allow(unused_mut)]
             let mut reboot = false;
             let (new_config, _cfg_received_datetime) = app_client
                 .get_app_config(None)

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -419,7 +419,7 @@ where
         #[cfg(feature = "esp32")]
         {
             use esp_idf_svc::sys::{esp_task_wdt_config_t, CONFIG_FREERTOS_NUMBER_OF_CORES};
-            let wdt_cfg = esp_task_wdt_config_t {
+            let wdt_cfg = crate::esp32::esp_idf_svc::sys::esp_task_wdt_config_t {
                 timeout_ms: (180 * 10_u32.pow(3)), // 180 seconds in milliseconds
                 trigger_panic: true,
                 idle_core_mask: (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -418,11 +418,10 @@ where
     pub fn run_forever(&mut self) -> ! {
         #[cfg(feature = "esp32")]
         {
-            use esp_idf_svc::sys::{esp_task_wdt_config_t, CONFIG_FREERTOS_NUMBER_OF_CORES};
             let wdt_cfg = crate::esp32::esp_idf_svc::sys::esp_task_wdt_config_t {
                 timeout_ms: (180 * 10_u32.pow(3)), // 180 seconds in milliseconds
                 trigger_panic: true,
-                idle_core_mask: (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
+                idle_core_mask: (1 << esp_idf_svc::sys::CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
             };
 
             // set the TWDT to expire after 3 minutes

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -418,10 +418,11 @@ where
     pub fn run_forever(&mut self) -> ! {
         #[cfg(feature = "esp32")]
         {
-            let wdt_cfg = crate::esp32::esp_idf_svc::sys::esp_task_wdt_config_t {
+            use esp_idf_svc::sys::{esp_task_wdt_config_t, CONFIG_FREERTOS_NUMBER_OF_CORES};
+            let wdt_cfg = esp_task_wdt_config_t {
                 timeout_ms: (180 * 10_u32.pow(3)), // 180 seconds in milliseconds
                 trigger_panic: true,
-                idle_core_mask: (1 << esp_idf_svc::sys::CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
+                idle_core_mask: (1 << CONFIG_FREERTOS_NUMBER_OF_CORES) - 1,
             };
 
             // set the TWDT to expire after 3 minutes


### PR DESCRIPTION
these are just small changes to 
~1. address an unused import warning~ 
2. rm ota from native compilation (only useful for specific testing)
3. silence an unused variable warning in native