### PR TITLE
Fix broken rendering of step 3

### DIFF
--- a/micro-rdk-installer/README.md
+++ b/micro-rdk-installer/README.md
@@ -16,8 +16,8 @@ Only necessary as an alternative to the previous Download step
 
 1. `git clone https://github.com/viamrobotics/micro-rdk.git`
 2. cd micro-rdk/micro-rdk-installer
-2.`cargo build`
-3. Executable (`micro-rdk-installer`) will be under target/debug
+3. `cargo build`
+4. Executable (`micro-rdk-installer`) will be under target/debug
 
 ## Usage
 


### PR DESCRIPTION
Fixes a minor issue where step 3 displays as a second step 2 on the same line as the first step 2.

Not a huge deal, but I figured I'd toss a fix your way since it made me a confuse briefly when reading the README.