### PR TITLE
use flash size argument for OTA targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ build-esp32-ota:
 		--target=xtensa-esp32-espidf \
 		-Zbuild-std=std,panic_abort \
 		--release \
+		--flash-size=8mb \
 		target/xtensa-esp32-espidf/release/micro-rdk-server-esp32-ota.bin
 
 build-esp32c6-ota:
@@ -121,6 +122,7 @@ build-esp32c6-ota:
 		--target=riscv32imac-esp-espidf \
 		-Zbuild-std=std,panic_abort \
 		--release \
+		--flash-size=8mb \
 		target/riscv32imac-esp-espidf/release/micro-rdk-server-esp32-ota.bin
 
 build-qemu-bin:

--- a/templates/project/Makefile
+++ b/templates/project/Makefile
@@ -51,6 +51,7 @@ build-esp32-ota:
 		--target=xtensa-esp32-espidf \
 		-Zbuild-std=std,panic_abort \
 		--release \
+		--flash-size=${FLASHSIZE} \
 		target/xtensa-esp32-espidf/release/{{project-name}}-ota.bin
 
 flash-esp32-bin:


### PR DESCRIPTION
Future versions of `cargo-espflash` (I'm running a build from HEAD that has fixes needed to flash an esp36c6) demand this flag, or error out with:

```
Partition table:   micro-rdk-server/esp32/partitions.csv
Error: espflash::partition_table::does_not_fit

  × The partition table does not fit into the flash (4MB)
  help: Make sure you set the correct flash size with the `--flash-size`
        option

make: *** [build-esp32-ota] Error 1
```

Add this flag now so things don't break when we upgrade `cargo-espflash` to a version that introduces this requirement.