### PR TITLE
[CONSULT-1023] support custom PGN formats used for proprietary messages

### DIFF
--- a/micro-rdk-nmea/src/messages/message.rs
+++ b/micro-rdk-nmea/src/messages/message.rs
@@ -6,7 +6,10 @@ use micro_rdk::{
     google::protobuf::{value::Kind, Value},
 };
 
-use crate::parse_helpers::{errors::NmeaParseError, parsers::DataCursor};
+use crate::parse_helpers::{
+    errors::NmeaParseError,
+    parsers::{DataCursor, FieldSet},
+};
 
 pub trait Message: Sized + Clone {
     const PGN: u32;
@@ -49,4 +52,12 @@ impl UnparsedNmeaMessageBody {
     pub fn pgn(&self) -> u32 {
         self.pgn
     }
+}
+
+pub trait PolymorphicPgnParent<T> {
+    fn read_match_value(&self) -> T;
+}
+
+pub trait MessageVariant<T>: FieldSet {
+    const MATCH_VALUE: T;
 }

--- a/micro-rdk-nmea/src/messages/pgns.rs
+++ b/micro-rdk-nmea/src/messages/pgns.rs
@@ -1,3 +1,4 @@
+#![allow(unused_macros)]
 use std::collections::HashMap;
 use std::marker::PhantomData;
 
@@ -7,16 +8,14 @@ use micro_rdk::{
 };
 use micro_rdk_nmea_macros::{FieldsetDerive, PgnMessageDerive};
 
-use super::message::{Message, MessageVariant, PolymorphicPgnParent, UnparsedNmeaMessageBody};
+use super::message::{Message, UnparsedNmeaMessageBody};
 use crate::parse_helpers::{
     enums::{
-        DirectionReference, Gns, GnsIntegrity, GnsMethod, IndustryCode, ManufacturerCode,
-        RangeResidualMode, SatelliteStatus, SimnetDisplayGroup, TemperatureSource, WaterReference,
+        DirectionReference, Gns, GnsIntegrity, GnsMethod, RangeResidualMode, SatelliteStatus,
+        TemperatureSource, WaterReference,
     },
     errors::NmeaParseError,
-    parsers::{
-        DataCursor, FieldSet, NmeaMessageMetadata, PolymorphicDataType, SimnetKey, SimnetKeyValue,
-    },
+    parsers::{DataCursor, FieldSet, NmeaMessageMetadata},
 };
 
 #[derive(PgnMessageDerive, Clone, Debug)]

--- a/micro-rdk-nmea/src/messages/pgns.rs
+++ b/micro-rdk-nmea/src/messages/pgns.rs
@@ -279,86 +279,6 @@ pub struct Attitude {
     roll: i16,
 }
 
-#[derive(FieldsetDerive, Clone, Debug)]
-pub struct SimnetParameterSet {
-    #[lookup]
-    #[bits = 11]
-    manufacturer_code: ManufacturerCode,
-
-    #[lookup]
-    #[bits = 3]
-    #[offset = 2]
-    industry_code: IndustryCode,
-
-    address: u8,
-
-    b: u8,
-
-    #[lookup]
-    #[bits = 8]
-    display_group: SimnetDisplayGroup,
-
-    d: u16,
-
-    #[lookup]
-    #[bits = 16]
-    key: SimnetKey,
-
-    #[polymorphic]
-    #[offset = 16]
-    #[lookup_field = "key"]
-    value: SimnetKeyValue,
-}
-
-#[derive(FieldsetDerive, Clone, Debug)]
-pub struct SimnetParameterSetCopy {
-    #[lookup]
-    #[bits = 11]
-    manufacturer_code: ManufacturerCode,
-
-    #[lookup]
-    #[bits = 3]
-    #[offset = 2]
-    industry_code: IndustryCode,
-
-    address: u8,
-
-    b: u8,
-
-    #[lookup]
-    #[bits = 8]
-    display_group: SimnetDisplayGroup,
-
-    d: u16,
-
-    #[lookup]
-    #[bits = 16]
-    key: SimnetKey,
-
-    #[polymorphic]
-    #[offset = 16]
-    #[lookup_field = "key"]
-    value: SimnetKeyValue,
-}
-
-#[derive(PartialEq)]
-pub struct Pgn130846MatchValue {
-    manufacturer_code: ManufacturerCode,
-    industry_code: IndustryCode,
-}
-
-#[derive(FieldsetDerive, Clone, Debug)]
-pub struct Pgn130846Parent {
-    #[lookup]
-    #[bits = 11]
-    manufacturer_code: ManufacturerCode,
-
-    #[lookup]
-    #[bits = 3]
-    #[offset = 2]
-    industry_code: IndustryCode,
-}
-
 macro_rules! impl_match {
     ( $matchtype:ident, $parent:ty, ($($prop:ident),*), $(($variant:ty, $(($prop2:ident, $val:expr)),*)),* ) => {
         impl PolymorphicPgnParent<$matchtype> for $parent {
@@ -378,22 +298,6 @@ macro_rules! impl_match {
         )*
     };
 }
-
-impl_match!(
-    Pgn130846MatchValue,
-    Pgn130846Parent,
-    (manufacturer_code, industry_code),
-    (
-        SimnetParameterSet,
-        (manufacturer_code, ManufacturerCode::Simrad),
-        (industry_code, IndustryCode::Marine)
-    ),
-    (
-        SimnetParameterSetCopy,
-        (manufacturer_code, ManufacturerCode::Simrad),
-        (industry_code, IndustryCode::Industrial)
-    )
-);
 
 macro_rules! define_proprietary_pgn {
     ( $pgn:expr, $messagelabel:ident, $parent:ident, $variantlabel:ident, $matchval:ty, $($varianttylabel:ident, $variantty:ty),* ) => {
@@ -439,18 +343,6 @@ macro_rules! define_proprietary_pgn {
         }
     };
 }
-
-define_proprietary_pgn!(
-    130846,
-    Pgn130846Message,
-    Pgn130846Parent,
-    Pgn130846Variant,
-    Pgn130846MatchValue,
-    A,
-    SimnetParameterSet,
-    B,
-    SimnetParameterSetCopy
-);
 
 macro_rules! define_pgns {
     ( $($pgndef:ident),* ) => {
@@ -499,8 +391,7 @@ define_pgns!(
     VesselHeading,
     Attitude,
     Speed,
-    DistanceLog,
-    Pgn130846Message
+    DistanceLog
 );
 
 pub struct NmeaMessage {

--- a/micro-rdk-nmea/src/parse_helpers/enums.rs
+++ b/micro-rdk-nmea/src/parse_helpers/enums.rs
@@ -8,7 +8,7 @@ pub trait NmeaEnumeratedField: Sized + From<u32> + ToString {}
 /// written in Go does not fail on unrecognized lookups.
 macro_rules! define_nmea_enum {
     ( $name:ident, $(($value:expr, $var:ident, $label:expr)),*, $default:ident) => {
-        #[derive(Copy, Clone, Debug)]
+        #[derive(Copy, Clone, Debug, PartialEq)]
         pub enum $name {
             $($var),*,
             $default

--- a/micro-rdk-nmea/src/parse_helpers/errors.rs
+++ b/micro-rdk-nmea/src/parse_helpers/errors.rs
@@ -24,4 +24,6 @@ pub enum NmeaParseError {
     UnsupportedPgn(u32),
     #[error("unknown lookup value for polymorphic field")]
     UnknownPolymorphicLookupValue,
+    #[error("unsupported match value encountered")]
+    UnsupportedMatchValue,
 }


### PR DESCRIPTION
Manufacturers with specialized NMEA messages have to share a range of PGNs for defining their formats. As a result, there are different message formats with the same PGN that match on the value of a certain set of fields in the data past the appearance of the PGN. This PR treats all of the variants as a single PGN message enum with each variant being a struct that implements the Fieldset trait.