### PR TITLE
[RSDK-9594] Don't produce a core on planned shutdowns

### DIFF
--- a/micro-rdk-ffi/src/ffi/runtime.rs
+++ b/micro-rdk-ffi/src/ffi/runtime.rs
@@ -267,6 +267,12 @@ pub unsafe extern "C" fn viam_server_start(ctx: *mut viam_server_context) -> via
         .unwrap();
     }
 
+    log::info!("viam_server_start called");
+    #[cfg(target_os = "espidf")]
+    log::info!("esp restarted due to esp_reset_reason_t{{{}}}", unsafe {
+        micro_rdk::esp32::esp_idf_svc::sys::esp_reset_reason()
+    });
+
     let network = {
         #[cfg(not(target_os = "espidf"))]
         {

--- a/micro-rdk-server/esp32/main.rs
+++ b/micro-rdk-server/esp32/main.rs
@@ -48,6 +48,9 @@ mod esp32 {
         initialize_logger::<EspLogger>();
 
         log::info!("micro-rdk-server started (esp32)");
+        log::info!("esp restarted due to esp_reset_reason_t{{{}}}", unsafe {
+            esp_idf_svc::sys::esp_reset_reason()
+        });
 
         esp_idf_svc::sys::esp!(unsafe {
             esp_idf_svc::sys::esp_vfs_eventfd_register(

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -315,11 +315,10 @@ where
     }
 
     pub fn with_default_tasks(&mut self) -> &mut Self {
-        let restart_monitor = Box::new(RestartMonitor::new(|| std::process::exit(0)));
+        let restart_monitor = Box::new(RestartMonitor::new(|| crate::common::runtime::terminate()));
         let log_upload = Box::new(LogUploadTask);
         self.with_app_client_task(restart_monitor)
-            .with_app_client_task(log_upload);
-        self
+            .with_app_client_task(log_upload)
     }
 }
 impl<Storage> ViamServerBuilder<Storage, WantsNetwork>
@@ -607,7 +606,7 @@ where
             self.storage.clone(),
             #[cfg(feature = "ota")]
             self.executor.clone(),
-            || std::process::exit(0),
+            || crate::common::runtime::terminate(),
         ));
         self.app_client_tasks.push(config_monitor_task);
 

--- a/micro-rdk/src/common/grpc.rs
+++ b/micro-rdk/src/common/grpc.rs
@@ -1394,12 +1394,7 @@ impl<'a> GrpcServerInner<'a> {
 
     // robot_shutdown will not return anything because will restart
     fn robot_shutdown(&mut self, _: &[u8]) -> ! {
-        #[cfg(feature = "native")]
-        std::process::exit(0);
-        #[cfg(feature = "esp32")]
-        unsafe {
-            crate::esp32::esp_idf_svc::sys::esp_restart();
-        }
+        crate::common::runtime::terminate()
     }
 
     fn robot_get_cloud_metadata(&mut self) -> Result<Bytes, ServerError> {

--- a/micro-rdk/src/common/mod.rs
+++ b/micro-rdk/src/common/mod.rs
@@ -64,6 +64,7 @@ pub mod power_sensor;
 pub mod registry;
 pub mod restart_monitor;
 pub mod robot;
+pub mod runtime;
 pub mod sensor;
 pub mod servo;
 pub mod status;

--- a/micro-rdk/src/common/runtime.rs
+++ b/micro-rdk/src/common/runtime.rs
@@ -1,0 +1,8 @@
+pub(crate) fn terminate() -> ! {
+    #[cfg(feature = "native")]
+    std::process::exit(0);
+    #[cfg(feature = "esp32")]
+    unsafe {
+        crate::esp32::esp_idf_svc::sys::esp_restart();
+    }
+}

--- a/templates/project/src/main.rs
+++ b/templates/project/src/main.rs
@@ -46,6 +46,9 @@ fn main() {
     initialize_logger::<EspLogger>();
 
     log::info!("{} started (esp32)", env!("CARGO_PKG_NAME"));
+    log::info!("esp restarted due to esp_reset_reason_t{{{}}}", unsafe {
+        esp_idf_svc::sys::esp_reset_reason()
+    });
 
     esp_idf_svc::sys::esp!(unsafe {
         esp_idf_svc::sys::esp_vfs_eventfd_register(&esp_idf_svc::sys::esp_vfs_eventfd_config_t {


### PR DESCRIPTION
Also, log the restart reason on startup after we have initialized our logging buffers so it can be seen in the log viewer on app.viam.com