### PR TITLE
[CONSULT-1023] - implement rest of missed NMEA field types

### DIFF
--- a/micro-rdk-nmea-macros/src/attributes.rs
+++ b/micro-rdk-nmea-macros/src/attributes.rs
@@ -49,6 +49,8 @@ pub(crate) struct MacroAttributes {
     pub(crate) pgn: Option<u32>,
     pub(crate) is_polymorphic: bool,
     pub(crate) lookup_field: Option<Ident>,
+    pub(crate) is_mmsi: bool,
+    pub(crate) encoding_is_variable: bool,
 }
 
 // Attempt to deduce the bit size from the data type
@@ -60,6 +62,7 @@ fn get_bits(field_ty: &Type) -> Result<usize, TokenStream> {
         Type::Path(type_path) if type_path.path.is_ident("i16") => 16,
         Type::Path(type_path) if type_path.path.is_ident("u32") => 32,
         Type::Path(type_path) if type_path.path.is_ident("i32") => 32,
+        Type::Path(type_path) if type_path.path.is_ident("f32") => 32,
         Type::Path(type_path) if type_path.path.is_ident("u64") => 64,
         Type::Path(type_path) if type_path.path.is_ident("i64") => 64,
         Type::Array(type_array) => {
@@ -98,6 +101,8 @@ impl MacroAttributes {
             pgn: None,
             is_polymorphic: false,
             lookup_field: None,
+            is_mmsi: false,
+            encoding_is_variable: false,
         };
 
         for attr in field.attrs.iter() {
@@ -319,6 +324,8 @@ impl MacroAttributes {
                     }
                     "fieldset" => macro_attrs.is_fieldset = true,
                     "polymorphic" => macro_attrs.is_polymorphic = true,
+                    "mmsi" => macro_attrs.is_mmsi = true,
+                    "variable_encoding" => macro_attrs.encoding_is_variable = true,
                     _ => {}
                 };
             }

--- a/micro-rdk-nmea-macros/src/lib.rs
+++ b/micro-rdk-nmea-macros/src/lib.rs
@@ -23,7 +23,9 @@ use proc_macro::TokenStream;
         unit,
         pgn,
         polymorphic,
-        lookup_field
+        lookup_field,
+        mmsi,
+        variable_encoding
     )
 )]
 pub fn pgn_message_derive(item: TokenStream) -> TokenStream {
@@ -52,7 +54,9 @@ pub fn pgn_message_derive(item: TokenStream) -> TokenStream {
         length_field,
         unit,
         polymorphic,
-        lookup_field
+        lookup_field,
+        mmsi,
+        variable_encoding
     )
 )]
 pub fn fieldset_derive(item: TokenStream) -> TokenStream {

--- a/micro-rdk-nmea-macros/src/utils.rs
+++ b/micro-rdk-nmea-macros/src/utils.rs
@@ -105,3 +105,10 @@ pub(crate) fn is_supported_integer_type(field_type: &Type) -> bool {
         _ => false,
     }
 }
+
+pub(crate) fn is_string_type(field_type: &Type) -> bool {
+    match field_type {
+        Type::Path(type_path) => type_path.path.is_ident("String"),
+        _ => false,
+    }
+}

--- a/micro-rdk-nmea/src/parse_helpers/errors.rs
+++ b/micro-rdk-nmea/src/parse_helpers/errors.rs
@@ -1,9 +1,13 @@
+use std::string::{FromUtf16Error, FromUtf8Error};
+
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum NumberFieldError {
     #[error("field bit size {0} too large for max size {0}")]
     ImproperBitSize(usize, usize),
+    #[error("Only 32 bits allowed as size for floats")]
+    SizeNotAllowedforF32,
     #[error("{0} field not present in message")]
     FieldNotPresent(String),
     #[error("{0} field was error value")]
@@ -26,4 +30,10 @@ pub enum NmeaParseError {
     UnknownPolymorphicLookupValue,
     #[error("unsupported match value encountered")]
     UnsupportedMatchValue,
+    #[error(transparent)]
+    FromUtf8Error(#[from] FromUtf8Error),
+    #[error(transparent)]
+    FromUtf16Error(#[from] FromUtf16Error),
+    #[error("unexpected encoding byte {0} encountered when parsing string")]
+    UnexpectedEncoding(u8),
 }

--- a/micro-rdk-nmea/src/parse_helpers/parsers.rs
+++ b/micro-rdk-nmea/src/parse_helpers/parsers.rs
@@ -499,7 +499,7 @@ mod tests {
 
     use super::{
         ArrayField, FieldSet, FieldSetList, LookupField, NumberField, NumberFieldWithScale,
-        PolymorphicDataTypeReader, VariableLengthStringField
+        PolymorphicDataTypeReader, VariableLengthStringField,
     };
 
     pub const MESSAGE_DATA_OFFSET: usize = 32;

--- a/micro-rdk-nmea/src/parse_helpers/parsers.rs
+++ b/micro-rdk-nmea/src/parse_helpers/parsers.rs
@@ -59,7 +59,7 @@ pub trait FieldReader {
 
 /// A field reader for parsing a basic number type. A reader with bit_size n will read its value
 /// as the first n bits of `size_of::<T>()` bytes with the remaining bits as zeroes (the resulting bytes
-/// will be parsed as Little-Endian). See invocation of the generate_number_field_readers macro below
+/// will be parsed as Little-Endian). See invocation of the generate_integer_field_readers macro below
 /// for the currently supported number types.
 pub struct NumberField<T> {
     bit_size: usize,
@@ -107,7 +107,7 @@ where
     }
 }
 
-macro_rules! generate_number_field_readers {
+macro_rules! generate_integer_field_readers {
     ($($t:ty),*) => {
         $(
             impl FieldReader for NumberField<$t> {
@@ -142,7 +142,87 @@ macro_rules! generate_number_field_readers {
     };
 }
 
-generate_number_field_readers!(u8, i8, u16, i16, u32, i32, u64, i64);
+generate_integer_field_readers!(u8, i8, u16, i16, u32, i32, u64, i64);
+
+impl FieldReader for NumberField<f32> {
+    type FieldType = f32;
+
+    fn read_from_cursor(&self, cursor: &mut DataCursor) -> Result<Self::FieldType, NmeaParseError> {
+        if self.bit_size != 32 {
+            return Err(NumberFieldError::SizeNotAllowedforF32.into());
+        }
+        let data = cursor.read(self.bit_size)?;
+        Ok(f32::from_le_bytes(data[..].try_into()?))
+    }
+}
+
+pub struct FixedSizeStringField {
+    bit_size: usize,
+}
+
+impl FixedSizeStringField {
+    pub fn new(bit_size: usize) -> Self {
+        Self { bit_size }
+    }
+}
+
+fn trim_string_bytes(string_data: &mut Vec<u8>) {
+    let last_index = string_data
+        .iter()
+        .position(|byte| {
+            if (*byte == 0xFF) || (*byte == 0) {
+                return true;
+            }
+            let char_at = *byte as char;
+            (char_at == '@') || (char_at == ' ')
+        })
+        .unwrap_or(string_data.len());
+    let _ = string_data.split_off(last_index);
+}
+
+impl FieldReader for FixedSizeStringField {
+    type FieldType = String;
+    fn read_from_cursor(&self, cursor: &mut DataCursor) -> Result<Self::FieldType, NmeaParseError> {
+        let mut string_data = cursor.read(self.bit_size)?;
+        trim_string_bytes(&mut string_data);
+        Ok(String::from_utf8(string_data)?)
+    }
+}
+
+pub struct VariableLengthStringField;
+
+impl FieldReader for VariableLengthStringField {
+    type FieldType = String;
+    fn read_from_cursor(&self, cursor: &mut DataCursor) -> Result<Self::FieldType, NmeaParseError> {
+        let length = cursor.read(8)?[0];
+        let mut string_data = cursor.read((length * 8) as usize)?;
+        trim_string_bytes(&mut string_data);
+        Ok(String::from_utf8(string_data)?)
+    }
+}
+
+pub struct VariableLengthAndEncodingStringField;
+
+impl FieldReader for VariableLengthAndEncodingStringField {
+    type FieldType = String;
+    fn read_from_cursor(&self, cursor: &mut DataCursor) -> Result<Self::FieldType, NmeaParseError> {
+        let length = cursor.read(8)?[0];
+        let encoding = cursor.read(8)?[0];
+        let mut string_data = cursor.read((length * 8) as usize)?;
+        trim_string_bytes(&mut string_data);
+        Ok(match encoding {
+            0 => {
+                let utf16_vec: Vec<u16> = string_data
+                    .chunks_exact(2)
+                    .map(|a| u16::from_ne_bytes([a[0], a[1]]))
+                    .collect();
+                String::from_utf16(utf16_vec.as_slice())?
+            }
+            1 => String::from_utf8(string_data)?,
+            x => return Err(NmeaParseError::UnexpectedEncoding(x)),
+        })
+    }
+}
 
 /// A field reader for parsing data into a field type that implements the `Lookup` trait.
 /// The `bit_size` property is used to parse a raw number value first with a methodology similar to the one
@@ -419,7 +499,7 @@ mod tests {
 
     use super::{
         ArrayField, FieldSet, FieldSetList, LookupField, NumberField, NumberFieldWithScale,
-        PolymorphicDataTypeReader,
+        PolymorphicDataTypeReader, VariableLengthStringField
     };
 
     pub const MESSAGE_DATA_OFFSET: usize = 32;
@@ -638,5 +718,23 @@ mod tests {
             res.unwrap(),
             TestSeedPolymorphism::NumberTypeB(180.0)
         ))
+    }
+
+    #[test]
+    fn string_field_test() {
+        let test_str_bytes = b"ffreghorsgeuilf@ @  ".to_vec();
+        let result_str = "ffreghorsgeuilf".to_string();
+
+        let mut bytes_to_read: Vec<u8> = vec![test_str_bytes.len() as u8];
+        bytes_to_read.extend(test_str_bytes);
+        bytes_to_read.extend(b"other garbage afterwards".to_vec());
+        let mut cursor = DataCursor::new(bytes_to_read);
+
+        let reader = VariableLengthStringField {};
+        let res = reader.read_from_cursor(&mut cursor);
+
+        assert!(res.is_ok());
+        let res = res.unwrap();
+        assert_eq!(res, result_str);
     }
 }


### PR DESCRIPTION
We were missing support for MMSI, String, and 32-bit float data types in the NMEA parsing macro. This fixes that. 