### PR TITLE
[RSDK-10692] use revision to check config change

### DIFF
--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -17,7 +17,7 @@ use crate::common::{exec::Executor, ota};
 
 pub struct ConfigMonitor<'a, Storage> {
     /// revision of running `RobotConfig`
-    revision: String,
+    config_revision: String,
     storage: Storage,
     #[cfg(feature = "ota")]
     executor: Executor,
@@ -37,7 +37,7 @@ where
         restart_hook: impl Fn() + 'a,
     ) -> Self {
         Self {
-            revision: curr_config.revision.to_string(),
+            config_revision: curr_config.revision.to_string(),
             storage,
             #[cfg(feature = "ota")]
             executor,
@@ -109,7 +109,7 @@ where
                     }
                 }
 
-                if config.revision != self.revision {
+                if config.revision != self.config_revision {
                     if let Err(e) = self.storage.reset_robot_configuration() {
                         log::warn!(
                             "failed to reset machine config after new config detected: {}",

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -16,7 +16,8 @@ use std::{fmt::Debug, pin::Pin, time::Duration};
 use crate::common::{exec::Executor, ota};
 
 pub struct ConfigMonitor<'a, Storage> {
-    curr_config: Box<RobotConfig>, //config for robot gotten from last robot startup, aka inputted from entry
+    /// revision of running `RobotConfig`
+    revision: String,
     storage: Storage,
     #[cfg(feature = "ota")]
     executor: Executor,
@@ -30,13 +31,13 @@ where
     ServerError: From<<Storage as RobotConfigurationStorage>::Error>,
 {
     pub fn new(
-        curr_config: Box<RobotConfig>,
+        curr_config: &RobotConfig,
         storage: Storage,
         #[cfg(feature = "ota")] executor: Executor,
         restart_hook: impl Fn() + 'a,
     ) -> Self {
         Self {
-            curr_config,
+            revision: curr_config.revision.to_string(),
             storage,
             #[cfg(feature = "ota")]
             executor,
@@ -108,7 +109,7 @@ where
                     }
                 }
 
-                if config.revision != self.curr_config.revision {
+                if config.revision != self.revision {
                     if let Err(e) = self.storage.reset_robot_configuration() {
                         log::warn!(
                             "failed to reset machine config after new config detected: {}",

--- a/micro-rdk/src/common/config_monitor.rs
+++ b/micro-rdk/src/common/config_monitor.rs
@@ -108,7 +108,7 @@ where
                     }
                 }
 
-                if *config != *self.curr_config {
+                if config.revision != self.curr_config.revision {
                     if let Err(e) = self.storage.reset_robot_configuration() {
                         log::warn!(
                             "failed to reset machine config after new config detected: {}",

--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -610,7 +610,7 @@ where
         }
 
         let config_monitor_task = Box::new(ConfigMonitor::new(
-            config.clone(),
+            &config,
             self.storage.clone(),
             #[cfg(feature = "ota")]
             self.executor.clone(),


### PR DESCRIPTION
Tested using a config that has a `modules` attribute, prevents reboot.

Example logging of the revision
```sh
I (45445) micro_rdk::common::config_monitor: mperez-
prev_revision: 1747332178801
next_revision: 1747332219939
```