### PR TITLE
Update transient ICE log errors to warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 .vscode
 .envrc
 /build
+/.micro-rdk-docker-caches/

--- a/micro-rdk/src/common/webrtc/ice.rs
+++ b/micro-rdk/src/common/webrtc/ice.rs
@@ -343,7 +343,7 @@ impl ICEAgent {
                     let decoded = match decoder.decode_from_bytes(&buf[..len]).unwrap() {
                         Ok(e) => e,
                         Err(e) => {
-                            log::error!("dropping stun msg {:?}", e);
+                            log::warn!("dropping stun msg {:?}", e);
                             buf.clear();
                             continue;
                         }
@@ -362,17 +362,17 @@ impl ICEAgent {
                         MessageClass::SuccessResponse => {
                             if let Err(e) = self.process_stun_response(Instant::now(), decoded) {
                                 // could be caused by multiple response for one request
-                                log::error!("unable to properly process stun response {:?}", e);
+                                log::warn!("unable to properly process stun response {:?}", e);
                             }
                         }
 
                         MessageClass::ErrorResponse => {
                             //TODO(RSDK-3064)
-                            log::error!("received a stun error");
+                            log::warn!("received a stun error");
                         }
                         MessageClass::Indication => {
                             //TODO(RSDK-3064)
-                            log::error!("received a stun indication")
+                            log::warn!("received a stun indication")
                         }
                     }
                 }


### PR DESCRIPTION
There are lots of transient ICE log errors which give a false impression of instability. I frequently see "unable to properly process stun response IceStunEncodingError". Other changes in this PR are flybys.