### PR TITLE
add simple test for digital interrupt pins, better error

### DIFF
--- a/micro-rdk/src/common/board.rs
+++ b/micro-rdk/src/common/board.rs
@@ -235,7 +235,9 @@ impl Board for FakeBoard {
         _callback: Option<unsafe extern "C" fn(_: *mut core::ffi::c_void)>,
         _arg: Option<*mut core::ffi::c_void>,
     ) -> Result<(), BoardError> {
-        Err(BoardError::OtherBoardError("method not supported".into()))
+        Err(BoardError::BoardMethodNotSupported(
+            "add_digital_interrupt_callback".into(),
+        ))
     }
 
     fn get_pwm_duty(&self, pin: i32) -> f64 {

--- a/micro-rdk/src/common/robot.rs
+++ b/micro-rdk/src/common/robot.rs
@@ -741,6 +741,23 @@ mod tests {
                         ]),
                     ),
                     (
+                        "digital_interrupts".to_owned(),
+                        Kind::VecValue(vec![
+                            Kind::StructValue(HashMap::from([(
+                                "pin".to_owned(),
+                                Kind::StringValue("13".to_owned()),
+                            )])),
+                            Kind::StructValue(HashMap::from([(
+                                "pin".to_owned(),
+                                Kind::StringValue("14".to_owned()),
+                            )])),
+                            Kind::StructValue(HashMap::from([(
+                                "pin".to_owned(),
+                                Kind::StringValue("15".to_owned()),
+                            )])),
+                        ]),
+                    ),
+                    (
                         "analogs".to_owned(),
                         Kind::StructValue(HashMap::from([(
                             "1".to_owned(),
@@ -1075,6 +1092,48 @@ mod tests {
             .unwrap()
             .get_position(EncoderPositionType::DEGREES);
         assert!(pos_deg.is_err());
+    }
+
+    #[test_log::test]
+    fn test_digital_interrupt_pins_only() {
+        let robot_config: Vec<Option<DynamicComponentConfig>> =
+            vec![Some(DynamicComponentConfig {
+                name: ResourceName::new_builtin("board".to_owned(), "board".to_owned()),
+                model: Model::new_builtin("fake".to_owned()),
+                data_collector_configs: vec![],
+                attributes: Some(HashMap::from([(
+                    "digital_interrupts".to_owned(),
+                    Kind::VecValue(vec![
+                        Kind::StructValue(HashMap::from([(
+                            "pin".to_owned(),
+                            Kind::StringValue("13".to_owned()),
+                        )])),
+                        Kind::StructValue(HashMap::from([(
+                            "pin".to_owned(),
+                            Kind::StringValue("14".to_owned()),
+                        )])),
+                        Kind::StructValue(HashMap::from([(
+                            "pin".to_owned(),
+                            Kind::StringValue("15".to_owned()),
+                        )])),
+                    ]),
+                )])),
+            })];
+
+        let mut robot = LocalRobot::default();
+
+        let ret = robot.process_components(robot_config, &mut Box::default());
+        ret.unwrap();
+
+        let board = robot.get_board_by_name("board".to_string());
+
+        assert!(board.is_some());
+
+        assert!(board.as_ref().unwrap().get_gpio_level(13).is_ok());
+
+        assert!(board.as_ref().unwrap().get_gpio_level(14).is_ok());
+
+        assert!(board.as_ref().unwrap().get_gpio_level(15).is_ok());
     }
 
     #[test_log::test]


### PR DESCRIPTION
- add digital interrupt configs to robot test
- test that, in the absence of a pins array, digital interrupt pins are still configured as regular gpio pins
- fix an error return type