### PR TITLE
Reset GPIO pin in when configuring I2C

### DIFF
--- a/micro-rdk/src/esp32/i2c.rs
+++ b/micro-rdk/src/esp32/i2c.rs
@@ -81,7 +81,9 @@ impl Esp32I2C<'_> {
     pub fn new_from_config(conf: &Esp32I2cConfig) -> Result<Self, I2CErrors> {
         let name = conf.name.to_string();
         let timeout_ns = conf.timeout_ns;
+        unsafe { esp_idf_svc::sys::gpio_reset_pin(conf.data_pin) };
         let sda = unsafe { AnyIOPin::new(conf.data_pin) };
+        unsafe { esp_idf_svc::sys::gpio_reset_pin(conf.clock_pin) };
         let scl = unsafe { AnyIOPin::new(conf.clock_pin) };
         let driver_conf = I2cConfig::from(conf);
 


### PR DESCRIPTION
This a fix to reset the state of GPIO pin back to reset after waking up from sleep. Since the chip doesn't reset it's GPIO pin when waking up from sleep the pin may be configured in a way that make them unusable for I2C.
This shouldn't affect normal reset (power on, brown out etc..)