### PR TITLE
[RSDK-8748] data capture motor position

### DIFF
--- a/micro-rdk/src/common/motor.rs
+++ b/micro-rdk/src/common/motor.rs
@@ -286,6 +286,9 @@ where
 #[cfg(feature = "builtin-components")]
 impl Motor for FakeMotor {
     fn get_position(&mut self) -> Result<i32, MotorError> {
+        if self.is_moving()? {
+            self.pos += self.power;
+        }
         Ok(self.pos as i32)
     }
     fn set_power(&mut self, pct: f64) -> Result<(), MotorError> {

--- a/micro-rdk/src/common/motor.rs
+++ b/micro-rdk/src/common/motor.rs
@@ -287,7 +287,7 @@ where
 impl Motor for FakeMotor {
     fn get_position(&mut self) -> Result<i32, MotorError> {
         if self.is_moving()? {
-            self.pos += self.power;
+            self.pos = (self.pos + 1.0) % 360.0;
         }
         Ok(self.pos as i32)
     }


### PR DESCRIPTION
tested using a fake motor with the `Position` data capture method on app.viam

To view a change in position on `FakeMotor`, set the power > 0.0 in the test/control section.

This PR does not include the `IsPowered` data capture method as we have not implemented the api yet. [ticket](https://viam.atlassian.net/browse/RSDK-10834?atlOrigin=eyJpIjoiMWVmYWVkMDRjMGMyNGExMzg1ZDEzOGZmMWEyN2JiYmQiLCJwIjoiaiJ9)