### PR TITLE
[RSDK-2437] use send_system_event for default impl Board set_power_mode

### DIFF
--- a/micro-rdk/src/common/board.rs
+++ b/micro-rdk/src/common/board.rs
@@ -90,11 +90,9 @@ pub trait Board: DoCommand {
             ));
         }
 
-        Ok(async_io::block_on(
-            crate::common::system::send_system_event(
-                crate::common::system::SystemEvent::DeepSleep(duration),
-                false,
-            ),
+        Ok(crate::common::system::try_send_system_event(
+            crate::common::system::SystemEvent::DeepSleep(duration),
+            false,
         )?)
     }
 

--- a/micro-rdk/src/common/board.rs
+++ b/micro-rdk/src/common/board.rs
@@ -39,6 +39,8 @@ pub enum BoardError {
     #[error(transparent)]
     BoardI2CError(#[from] I2CErrors),
     #[error(transparent)]
+    SystemError(#[from] super::system::SystemEventError),
+    #[error(transparent)]
     #[cfg(feature = "esp32")]
     EspError(#[from] EspError),
     #[error("construction error test")]
@@ -72,7 +74,29 @@ pub trait Board: DoCommand {
         &self,
         mode: component::board::v1::PowerMode,
         duration: Option<Duration>,
-    ) -> Result<(), BoardError>;
+    ) -> Result<(), BoardError> {
+        info!(
+            "Received request to set power mode to {} for {} milliseconds",
+            mode.as_str_name(),
+            match duration {
+                Some(dur) => dur.as_millis().to_string(),
+                None => "<forever>".to_string(),
+            }
+        );
+
+        if mode != component::board::v1::PowerMode::OfflineDeep {
+            return Err(BoardError::BoardUnsupportedArgument(
+                "only support OfflineDeep mode",
+            ));
+        }
+
+        Ok(async_io::block_on(
+            crate::common::system::send_system_event(
+                crate::common::system::SystemEvent::DeepSleep(duration),
+                false,
+            ),
+        )?)
+    }
 
     /// Get a wrapped [I2CHandle] by name.
     fn get_i2c_by_name(&self, name: String) -> Result<I2cHandleType, BoardError>;
@@ -203,22 +227,6 @@ impl Board for FakeBoard {
             Some(reader) => Ok(reader.clone()),
             None => Err(BoardError::AnalogReaderNotFound(name)),
         }
-    }
-
-    fn set_power_mode(
-        &self,
-        mode: component::board::v1::PowerMode,
-        duration: Option<Duration>,
-    ) -> Result<(), BoardError> {
-        info!(
-            "set power mode to {} for {} milliseconds",
-            mode.as_str_name(),
-            match duration {
-                Some(dur) => dur.as_millis().to_string(),
-                None => "<forever>".to_string(),
-            }
-        );
-        Ok(())
     }
 
     fn get_i2c_by_name(&self, name: String) -> Result<I2cHandleType, BoardError> {

--- a/micro-rdk/src/common/system.rs
+++ b/micro-rdk/src/common/system.rs
@@ -78,7 +78,6 @@ pub(crate) async fn send_system_event(
     event: SystemEvent,
     force: bool,
 ) -> Result<(), SystemEventError> {
-    log::info!("received call to {}", event);
     let mut current_event = SHUTDOWN_EVENT.lock().await;
     if current_event.is_none() || force {
         let _ = current_event.insert(event);
@@ -96,7 +95,6 @@ pub(crate) fn try_send_system_event(
     event: SystemEvent,
     force: bool,
 ) -> Result<(), SystemEventError> {
-    log::info!("received call to {}", event);
     let mut current_event = SHUTDOWN_EVENT
         .try_lock()
         .ok_or(SystemEventError::SystemEventFailedTryLock)?;

--- a/micro-rdk/src/esp32/board.rs
+++ b/micro-rdk/src/esp32/board.rs
@@ -3,15 +3,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use crate::{
-    common::{
-        analog::{AnalogReader, AnalogReaderType},
-        board::{Board, BoardError, BoardType},
-        config::ConfigType,
-        digital_interrupt::DigitalInterruptConfig,
-        i2c::I2cHandleType,
-        registry::ComponentRegistry,
-    },
+use crate::common::{
+    analog::{AnalogReader, AnalogReaderType},
+    board::{Board, BoardError, BoardType},
+    config::ConfigType,
+    digital_interrupt::DigitalInterruptConfig,
+    i2c::I2cHandleType,
+    registry::ComponentRegistry,
 };
 
 #[cfg(esp32)]


### PR DESCRIPTION
This changes uses the new system capabilities to initiate a deepsleep request.

This was initially started for testing the [support of other wakeup sources](https://viam.atlassian.net/browse/RSDK-10572?atlOrigin=eyJpIjoiZmFlYzJlM2MzNGIyNDQxMzliYTM1ZTQzMWFhYzI1ODAiLCJwIjoiaiJ9), however, the `set_power_mode` apis in both the Python SDK and Go SDK don't forward `extra` arguments ([ticket](https://viam.atlassian.net/browse/RSDK-10891?atlOrigin=eyJpIjoiN2VjYmZmMjg2N2U1NGVlY2E3MTE3OTM1NDYzZDM2NGEiLCJwIjoiaiJ9)). This would have been used for setting things such as `ulp_wakeup_enabled` or `interrupt_pin` for GPIO-based wakeups

This was tested using both the Python and Go SDK.

```sh
# go sdk output
2025-06-04T22:40:17.896Z	DEBUG	client.networking.mdns.webrtc.client	utils@v0.1.143/logger.go:158	finished client unary call	{"grpc.code":"OK","grpc.time_ms":305.026,"span.kind":"client","system":"grpc","grpc.service":"viam.component.board.v1.BoardService","grpc.method":"SetPowerMode"}
2025-06-04T22:40:17.896Z	INFO	client.networking.mdns.webrtc.client	rpc/wrtc_base_channel.go:86	connection state changed	{"conn_id":"PeerConnection-1749076814973864857","conn_state":"closed"}
```