### PR TITLE
fix panic when ESP-IDF fails to allocate new UDP socket

### DIFF
--- a/micro-rdk/src/common/conn/viam.rs
+++ b/micro-rdk/src/common/conn/viam.rs
@@ -1130,7 +1130,7 @@ where
                         conf.cert.clone(),
                         ip,
                         conf.dtls.make()?,
-                    );
+                    )?;
 
                     let (answer, prio) = api.answer(0).await?;
                     let robot = self.robot.clone();

--- a/micro-rdk/src/common/webrtc/api.rs
+++ b/micro-rdk/src/common/webrtc/api.rs
@@ -584,12 +584,12 @@ where
         certificate: Rc<C>,
         local_ip: Ipv4Addr,
         dtls: Box<dyn DtlsConnector>,
-    ) -> Self {
-        let udp = Arc::new(async_io::Async::<UdpSocket>::bind(([0, 0, 0, 0], 0)).unwrap());
+    ) -> Result<Self, WebRtcError> {
+        let udp = Arc::new(async_io::Async::<UdpSocket>::bind(([0, 0, 0, 0], 0))?);
 
         let transport = WebRtcTransport::new(udp);
 
-        Self {
+        Ok(Self {
             executor,
             signaling,
             transport,
@@ -599,7 +599,7 @@ where
             local_ip,
             dtls: Some(dtls),
             ice_agent: AtomicSync::default(),
-        }
+        })
     }
 
     async fn run_ice_until_connected(&mut self, answer: &WebRtcSdp) -> Result<(), WebRtcError> {


### PR DESCRIPTION
When many connections are attempted against micro-rdk ESP-IDF may run out of available file descriptor and will panic in this.
I assume the error is transient so by returning the error we should be able to process the connection later