### PR TITLE
Replace defunct buildjet runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
 
   # github-actions does not have a runner that supports arm64 linux and cross-compilation does not seem to work for the ring crate
   build-installer-arm64-linux:
-    runs-on: [buildjet-8vcpu-ubuntu-2204-arm]
+    runs-on: [github-linux-arm64-8core]
     # by default github use sh as shell
     defaults:
       run:


### PR DESCRIPTION
The buildjet runners no longer work, breaking these workflows. This maps them to GitHub-hosted runners, matching the fix already made in [viamrobotics/rust-utils#178](https://github.com/viamrobotics/rust-utils/pull/178):

- `buildjet-*-ubuntu-2204-arm` (native arm64 builds) -> `github-linux-arm64-8core`
- `buildjet-*-ubuntu-2204` (x86) -> `ubuntu-large`

These are all native per-arch builds (arm64 container images / `--platform linux/arm64`), so the arm jobs map to the arm GitHub runner. Where present, the now-unused buildjet labels are also dropped from `.github/actionlint.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)